### PR TITLE
Validator of MySQL's "host" field

### DIFF
--- a/ImportPluginUI/src/org/gephi/ui/importer/plugin/EdgeListPanel.java
+++ b/ImportPluginUI/src/org/gephi/ui/importer/plugin/EdgeListPanel.java
@@ -605,7 +605,7 @@ public class EdgeListPanel extends javax.swing.JPanel {
             if (isSqlite(panel)) {
                 return Validators.FILE_MUST_BE_FILE.validate(problems, compName, model);
             } else {
-                return Validators.HOST_NAME_OR_IP_ADDRESS.validate(problems, compName, model);
+                return Validators.REQUIRE_NON_EMPTY_STRING.validate(problems, compName, model);
             }
         }
     }


### PR DESCRIPTION
for the MySQL's "host" field
original validator (HOST_NAME_OR_IP_ADDRESS) does not seem to allow DNS hostnames;
e.g. address of MySQL hosted by Amazon's RDS service: db3.c32l4fl.ap-northeast-1.rds.amazonaws.com 
gives an error: "Too many parts in IP address ..."

Fixed it by using the REQUIRE_NON_EMPTY_STRING validator instead.
