### PR TITLE
Fixes calculation of clustering coefficient on graph (Issue #625)

### DIFF
--- a/StatisticsPlugin/src/org/gephi/statistics/plugin/ClusteringCoefficient.java
+++ b/StatisticsPlugin/src/org/gephi/statistics/plugin/ClusteringCoefficient.java
@@ -458,8 +458,10 @@ public class ClusteringCoefficient implements Statistics, LongTask {
         //Results and average
         avgClusteringCoeff = 0;
         totalTriangles = 0;
+        int numNodesDegreeGreaterThanOne = 0;
         for (int v = 0; v < N; v++) {
             if (network[v].length() > 1) {
+                numNodesDegreeGreaterThanOne++;
                 double cc = triangles[v];
                 totalTriangles += triangles[v];
                 cc /= (network[v].length() * (network[v].length() - 1));
@@ -477,7 +479,7 @@ public class ClusteringCoefficient implements Statistics, LongTask {
             }
         }
         totalTriangles /= 3;
-        avgClusteringCoeff /= N;
+        avgClusteringCoeff /= numNodesDegreeGreaterThanOne;
 
         hgraph.readUnlock();
     }
@@ -523,8 +525,6 @@ public class ClusteringCoefficient implements Statistics, LongTask {
     }
     }
     nodeCC /= 2.0;
-    
-    
     
     if (neighborhood > 1) {
     float cc = nodeCC / (.5f * neighborhood * (neighborhood - 1));


### PR DESCRIPTION
This is an at least partial fix for Issue #625.  That is, I have amended the calculation of clustering coefficient on undirected graphs to produce results which match Latapy's implementation (which I refer to in Issue #625).  The question I raise in Issue #625 as to whether Latapy himself implements the clustering coefficient correctly remains unresolved.
