### PR TITLE
Fix issue #699: Reset size defaults to 10.0, not 1.0

### DIFF
--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/component/ActionsToolbar.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/component/ActionsToolbar.java
@@ -70,7 +70,7 @@ public class ActionsToolbar extends JToolBar {
 
     //Settings
     private Color color = new Color(0.6f, 0.6f, 0.6f);
-    private float size = 1f;
+    private float size = 10.0f;
 
     public ActionsToolbar() {
         initDesign();


### PR DESCRIPTION
Changed the value of size in ActionsToolbar from 1.0 to 10.0
