### PR TITLE
Fix GML import - try to keep column format double, if the parser detected it as double

### DIFF
--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGML.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGML.java
@@ -306,10 +306,14 @@ public class ImporterGML implements FileImporter, LongTask {
                 AttributeTable edgeClass = container.getAttributeModel().getEdgeTable();
                 AttributeColumn column = edgeClass.getColumn(key);
                 if (column == null) {
-                    column = edgeClass.addColumn(key, AttributeType.STRING);
+                    column = edgeClass.addColumn(key, (value instanceof Double)?AttributeType.DOUBLE:AttributeType.STRING);
                     report.log("Edge attribute " + column.getTitle() + " (" + column.getType() + ")");
                 }
-                edge.addAttributeValue(column, value.toString());
+                if (value instanceof Double || value instanceof String) {
+                    edge.addAttributeValue(column, value);
+                } else {
+                    edge.addAttributeValue(column, value.toString());
+                }
             }
         }
         return ret;

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGML.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGML.java
@@ -243,10 +243,15 @@ public class ImporterGML implements FileImporter, LongTask {
                 AttributeTable nodeClass = container.getAttributeModel().getNodeTable();
                 AttributeColumn column = nodeClass.getColumn(key);
                 if (column == null) {
-                    column = nodeClass.addColumn(key, AttributeType.STRING);
+                    column = nodeClass.addColumn(key, (value instanceof Double)?AttributeType.DOUBLE:AttributeType.STRING);
                     report.log("Node attribute " + column.getTitle() + " (" + column.getType() + ")");
                 }
-                node.addAttributeValue(column, value.toString());
+                if (value instanceof Double || value instanceof String) {
+                    node.addAttributeValue(column, value);
+                } else {
+                    // can this happen?
+                    node.addAttributeValue(column, value.toString());
+                }
             }
         }
         return ret;


### PR DESCRIPTION
``GML`` is quite a convinient format when creating graphs from scripts. I need to pass several numerical attributes together with the nodes and edges, and this patch removes the pain of manually clicking ``copy column`` and changing it's type to ``Double`` for each of the columns.

Not much error checking is done, but in script generated graphs typo errors do not happen very often;)