### PR TITLE
Calculate weakly connected components using Disjoint-Set structure

### DIFF
--- a/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/ConnectedComponents.java
+++ b/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/ConnectedComponents.java
@@ -44,10 +44,13 @@ package org.gephi.statistics.plugin;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.gephi.data.attributes.api.AttributeColumn;
 import org.gephi.data.attributes.api.AttributeModel;
 import org.gephi.data.attributes.api.AttributeOrigin;
@@ -106,7 +109,65 @@ public class ConnectedComponents implements Statistics, LongTask {
         }
     }
 
+    // weakly connected components using dijoint set forests
+    // should be more effective on large graphs (actually order of magnitude faster)
     public void weaklyConnected(HierarchicalUndirectedGraph hgraph, AttributeModel attributeModel) {
+
+        hgraph.readLock();
+
+        Progress.start(progress);
+        Progress.switchToIndeterminate(progress);
+        Progress.setDisplayName(progress, "CC: Adding nodes to forest");
+        
+        // add all nodes to dsf, each in its own component
+        DisjointForest<Node> dsf = new DisjointForest<Node>(hgraph.getNodeCount());
+        for (Node n: hgraph.getNodes()){
+            dsf.add(n);
+        }
+        
+        // for each edge connect the components
+        Progress.setDisplayName(progress, "CC: Joining trees");
+        for (Edge e:hgraph.getEdges()) {
+            dsf.union(e.getSource(), e.getTarget());
+        }
+        
+        // assign component ids to all nodes
+        Progress.setDisplayName(progress, "CC: Setting attributes");
+        AttributeTable nodeTable = attributeModel.getNodeTable();
+        AttributeColumn componentCol = nodeTable.getColumn(WEAKLY);
+        if (componentCol == null) {
+            componentCol = nodeTable.addColumn(WEAKLY, "Component ID", AttributeType.INT, AttributeOrigin.COMPUTED, new Integer(0));
+        }
+        HashMap<Integer, Integer> nid2cid = new HashMap<Integer, Integer>();
+        HashMap<Integer, Integer> csizes = new HashMap<Integer, Integer>();
+        int lastcid = 0;
+        for (Node n: hgraph.getNodes()) {
+            Node rep = dsf.find(n);
+            int nid = rep.getId();
+            
+            // map nid to cid
+            if (!nid2cid.containsKey(nid)) {
+                nid2cid.put(nid, lastcid++);
+            }
+            int cid = nid2cid.get(nid);
+            csizes.put(cid, (csizes.containsKey(cid))?csizes.get(cid) + 1:1);
+
+            // set the component id to id of representative node
+            AttributeRow row = (AttributeRow) n.getNodeData().getAttributes();
+            row.setValue(componentCol, cid);
+        }
+
+        hgraph.readUnlock();
+
+        // conunt components
+        componentCount = csizes.size();
+        componentsSize = new int[nid2cid.size()];
+        for (int i = 0; i < nid2cid.size(); i++) {
+            componentsSize[i] = csizes.get(i);
+        }
+    }
+    
+    public void weaklyConnected0(HierarchicalUndirectedGraph hgraph, AttributeModel attributeModel) {
         isCanceled = false;
         componentCount = 0;
         AttributeTable nodeTable = attributeModel.getNodeTable();
@@ -352,4 +413,380 @@ public class ConnectedComponents implements Statistics, LongTask {
     public void setProgressTicket(ProgressTicket progressTicket) {
         progress = progressTicket;
     }
+    
+    /**
+    * A disjoint-union data structure (backed by a HashMap) supporting
+    * find and union operations in (amortized) &alpha;(n) time, where
+    * &alpha;(n) is the very slow-growing inverse of the Ackermann
+    * function. This data structure also supports the standard set
+    * operations with the exception of removal operations, which will
+    * result in an {@link UnsupportedOperationException} being thrown.
+    * @author Nick Watson
+    *
+    * @param <E> The type of elements contained.
+    */
+
+    private class DisjointForest<E> implements Set<E> {
+
+            private class SetNode {
+
+                    E elem;
+                    SetNode parent;
+                    int rank;
+
+                    public SetNode(E e) {
+                            elem = e;
+                            parent = this;
+                            rank = 0;
+                    }
+
+            }
+
+            private HashMap<E, SetNode> map;
+
+            /**
+             * Constructs a new Disjoint Forest. <br />
+             * O(1)
+             */
+            public DisjointForest() {
+                    map = new HashMap<E, SetNode>();
+            }
+
+            /**
+             * Constructs a new Disjoint Forest, with the specified
+             * initial capacity. <br />
+             * O(1)
+             * @param initialCapacity The initial capacity
+             */
+            public DisjointForest(int initialCapacity) {
+                    map = new HashMap<E, SetNode>(initialCapacity);
+            }
+
+            /**
+             * Makes a new disjoint set containing the given element. <br />
+             * O(1)
+             * @param elem The element to add
+             * @return The newly added element (i.e. <code>elem</code>), or
+             * <code>null</code> if <code>elem</code> is already contained
+             * in this set.
+             */
+            public E makeSet(E elem) {
+                    if (map.containsKey(elem)) return null;
+                    map.put(elem, new SetNode(elem));
+                    return elem;
+            }
+
+            private SetNode find(SetNode n) {
+                    if (n == n.parent) return n;
+                    n.parent = find(n.parent); // flatten
+                    return n.parent;
+            }
+
+            /**
+             * Finds the set containing the given element. <br />
+             * O(&alpha;(n))
+             * @param elem The element to find
+             * @return The representative of the set containing the element
+             * @throws IllegalArgumentException If <code>elem</code> is not an
+             * element of this forest.
+             */
+            public E find(E elem) {
+                    SetNode n = map.get(elem);
+                    if (n == null) throw new IllegalArgumentException(
+                            "Non-existent element passed as representative.");
+                    return find(n).elem;
+            }
+
+            private E union(SetNode n1, SetNode n2) {
+                    SetNode r1 = find(n1), r2 = find(n2);
+                    if (r1 == r2) return r1.elem;
+                    if (r1.rank > r2.rank) {
+                            r2.parent = r1;
+                            return r1.elem;
+                    }
+                    r1.parent = r2;
+                    if (r1.rank == r2.rank) r2.rank++;
+                    return r2.elem;
+            }
+
+            /**
+             * Merges two disjoint sets by taking their union. <br />
+             * O(&alpha;(n))
+             * @param repr1 The representative of the first set to merge
+             * @param repr2 The representative of the second set to merge
+             * @return The representative of the union of the two sets
+             * @throws IllegalArgumentException If <code>repr1</code> or
+             * <code>repr2</code> is not an element of this forest.
+             */
+            public E union(E repr1, E repr2) {
+                    SetNode n1 = map.get(repr1), n2 = map.get(repr2);
+                    if (n1 == null) throw new IllegalArgumentException(
+                            "Non-existent element passed as representative 1.");
+                    if (n2 == null) throw new IllegalArgumentException(
+                            "Non-existent element passed as representative 2.");
+                    return union(n1, n2);
+            }
+
+            /**
+             * Gets whether the disjoint forest is empty. <br />
+             * O(1)
+             * @return Whether the disjoint forest is empty
+             */
+            @Override
+            public boolean isEmpty() { return map.isEmpty(); }
+
+            /**
+             * Gets the size of the disjoint forest. <br />
+             * O(1)
+             * @return The size of the disjoint forest
+             */
+            @Override
+            public int size() { return map.size(); }
+
+            /**
+             * Makes a new disjoint set containing the given element. <br />
+             * O(1)
+             * @param elem The element to add
+             * @return True if the element wasn't already contained in this
+             * disjoint forest
+             * @see #makeSet
+             */
+            @Override
+            public boolean add(E elem) {
+                    return makeSet(elem) != null;
+            }
+
+            /**
+             * Adds an element to the given set. <code>add(elem, null)</code>
+             * is equivalent to <code>makeSet(elem)</code>. <br />
+             * O(&alpha;(n))
+             * @param elem The element to add
+             * @param repr The representative of the set to add it to
+             * @return The representative of the set containing the added
+             * element, or <code>null</code> if <code>elem</code> is already
+             * contained in this set.
+             * @throws IllegalArgumentException If <code>repr</code> is not an
+             * element of this forest.
+             */
+            public E add(E elem, E repr) {
+                    if (repr == null) return makeSet(elem);
+                    if (map.containsKey(elem)) return null;
+                    SetNode r = map.get(repr);
+                    if (r == null) throw new IllegalArgumentException(
+                                    "Non-existent element passed as representative.");
+                    SetNode n = new SetNode(elem);
+                    map.put(elem, n);
+                    return union(r, n);
+            }
+
+            /**
+             * Adds all elements in the given collection to this disjoint
+             * forest, putting each one in <i>its own set</i>. <br />
+             * O(n)
+             * @param c The collection to add
+             * @return True if any of the elements were added successfully
+             */
+            @Override
+            public boolean addAll(Collection<? extends E> c) {
+                    boolean changed = false;
+                    for (E e : c) changed |= add(e);
+                    return changed;
+            }
+
+            /**
+             * Adds all elements in the given collection to this disjoint
+             * forest, optionally putting them all in the same set. <br />
+             * O(n)
+             * @param c The collection to add
+             * @param sameSet Whether to put all newly added elements in the
+             * same set
+             * @return True if any of the elements were added successfully
+             */
+            public boolean addAll(Collection<? extends E> c, boolean sameSet) {
+                    if (c.isEmpty()) return false;
+                    if (!sameSet) return addAll(c);
+                    E root = null;
+                    for (E e : c) {
+                            if (root == null) root = makeSet(e);
+                            else add(e, root);
+                    }
+                    return root != null;
+            }
+
+            /**
+             * Removes all elements from this disjoint forest (in place). <br />
+             * O(n)
+             */
+            @Override
+            public void clear() {
+                    map.clear();
+            }
+
+            /**
+             * Gets whether this disjoint forest contains the
+             * given element. <br />
+             * O(1)
+             * @param elem The object to search for
+             * @return Whether the element is present
+             */
+            @Override
+            public boolean contains(Object elem) {
+                    return map.containsKey(elem);
+            }
+
+            /**
+             * Gets whether this disjoint forest contains all
+             * of the elements in the given collection. <br />
+             * O(n)
+             * @param c The collection to check
+             * @return Whether all elements are present
+             */
+            @Override
+            public boolean containsAll(Collection<?> c) {
+                    for (Object o : c) {
+                            if (!map.containsKey(o)) return false;
+                    }
+                    return true;
+            }
+
+            /**
+             * Provides an iterator for this disjoint set. The
+             * iterator provides no guarantee as to the order of
+             * iteration and does not support removals. <br />
+             * O(1)
+             * @return An iterator for this disjoint forest
+             */
+            @Override
+            public Iterator<E> iterator() {
+                    return new Iterator<E>() {
+
+                            Iterator<E> it = map.keySet().iterator();
+
+                            @Override
+                            public boolean hasNext() {
+                                    return it.hasNext();
+                            }
+
+                            @Override
+                            public E next() {
+                                    return it.next();
+                            }
+
+                            @Deprecated
+                            @Override
+                            public void remove() {
+                                    throw new UnsupportedOperationException("Removals not supported");
+                            }			
+                    };
+            }
+
+            /**
+             * Gets the HashMap backing this disjoint forest
+             * @return The backing HashMap
+             */
+            HashMap<E, SetNode> map() { return map; }
+
+            /**
+             * Compares the specified object with this set for equality.
+             * Returns true if the specified object is also a set, and
+             * the two sets have the same size and elements. <br />
+             * O(n)
+             * @param o The object to be compared for equality
+             * @return True if the object is equal
+             */
+            @Override
+            public boolean equals(Object o) {
+                    return map.keySet().equals(o instanceof DisjointForest ?
+                                    ((DisjointForest<?>)o).map().keySet() : o);
+            }
+
+            /**
+             * Returns the hash code value for this set. The hash code of a
+             * set is defined to be the sum of the hash codes of the elements
+             * in the set, where the hash code of a null element is defined to
+             * be zero. <br />
+             * O(n)
+             * @return A hash value for this set
+             */
+            @Override
+            public int hashCode() {
+                    return map.keySet().hashCode();
+            }
+
+            /**
+             * Returns an array containing all of the elements
+             * in this set, in no particular order. <br />
+             * O(n)
+             * @return An array containing the elements in this set
+             */
+            @Override
+            public Object[] toArray() {
+                    return map.keySet().toArray();
+            }
+
+            /**
+             * Returns an array containing all of the elements in this
+             * set, in no particular order; the runtime type of the
+             * returned array is that of the specified array. <br />
+             * O(n)
+             * @return An array of the given type containing the elements
+             * in this set
+             */
+            @Override
+            public <T> T[] toArray(T[] a) {
+                    return map.keySet().toArray(a);
+            }
+
+            /**
+             * Converts this Disjoint Forest to a comma-separated
+             * list of its elements. <br />
+             * O(n)
+             * @return A string representing this disjoint forest
+             */
+            @Override
+            @SuppressWarnings("unchecked")
+            public String toString() {
+                    StringBuffer b = new StringBuffer();		
+                    E[] e = toArray((E[])new Object[0]);
+                    for (int i = 0; i < e.length; i++) {
+                            b.append(e[i].toString());
+                            if (i != e.length-1) b.append(",");
+                    }
+                    return b.toString();
+            }
+
+            /**
+             * Removals are not supported.
+             * @param elem Unused
+             * @throws UnsupportedOperationException Always
+             */
+            @Override
+            @Deprecated
+            public boolean remove(Object elem) {
+                    throw new UnsupportedOperationException("Removals not supported");
+            }
+
+            /**
+             * Removals are not supported.
+             * @param c Unused
+             * @throws UnsupportedOperationException Always
+             */
+            @Override
+            @Deprecated
+            public boolean removeAll(Collection<?> c) {
+                    throw new UnsupportedOperationException("Removals not supported");
+            }
+
+            /**
+             * Removals are not supported.
+             * @param c Unused
+             * @throws UnsupportedOperationException Always
+             */
+            @Override
+            @Deprecated
+            public boolean retainAll(Collection<?> c) {
+                    throw new UnsupportedOperationException("Removals not supported");
+            }
+    }
+
 }


### PR DESCRIPTION
Implemented as a POC while waiting for too long for results from the original CC plugin. Disjoint set (http://en.wikipedia.org/wiki/Disjoint-set_data_structure) is quite effective approach for this purpose. Results are obtained orders of magnitude faster, what matters for large graphs. 

Using Disjoint-set implementation by Nick Watson (http://www.seas.upenn.edu/~nwatson/). There is no mention of licensing terms in the source nor in the webpage. It can be probably negotiated with the author, or the code rewritten from scratch, if necessary.
