### PR TITLE
Bug fix for Issue #320

### DIFF
--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterDOT.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterDOT.java
@@ -174,6 +174,9 @@ public class ImporterDOT implements FileImporter, LongTask {
             } else if (streamTokenizer.ttype == '[') {
                 NodeDraft nodeDraft = getOrCreateNode(nodeId);
                 nodeAttributes(streamTokenizer, nodeDraft);
+            } else {
+                getOrCreateNode(nodeId);
+                streamTokenizer.pushBack();
             }
         }
     }


### PR DESCRIPTION
The DOT parser seems to be hand-rolled, and originally it would treat a single node without edge/node information as "noise" and just ignore it. After that, the parsing of the remaining part of the file would be messed up because of the first number on the next line would then be read and discarded, causing troubles for the parser.

This patch make the parser accept a node without node information, and then push back the next token into the inputstream, which would then make the inputstream to be acceptable by the parser, and the single node added to the graph.
