### PR TITLE
Import GraphML files correctly (Issue #147)

### DIFF
--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGraphML.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGraphML.java
@@ -96,6 +96,7 @@ public class ImporterGraphML implements FileImporter, LongTask {
     //Architecture
     private Reader reader;
     private ContainerLoader container;
+    private EdgeDraft.EdgeType edgeDefault;
     private boolean cancel;
     private Report report;
     private ProgressTicket progress;
@@ -198,11 +199,18 @@ public class ImporterGraphML implements FileImporter, LongTask {
         }
 
         //Edge Type
+        // Container edge type should NOT be set to default edge type, as this is 
+        // not what it really means. Mixed is the appropriate type, as GraphML supports
+        // mixed edge types. 
+        
+        container.setEdgeDefault(EdgeDefault.MIXED);
+        edgeDefault = EdgeDraft.EdgeType.DIRECTED;
+        
         if (!defaultEdgeType.isEmpty()) {
             if (defaultEdgeType.equalsIgnoreCase("undirected")) {
-                container.setEdgeDefault(EdgeDefault.UNDIRECTED);
+            	edgeDefault = EdgeDraft.EdgeType.UNDIRECTED;
             } else if (defaultEdgeType.equalsIgnoreCase("directed")) {
-                container.setEdgeDefault(EdgeDefault.DIRECTED);
+            	edgeDefault = EdgeDraft.EdgeType.DIRECTED;
             } else {
                 report.logIssue(new Issue(NbBundle.getMessage(ImporterGraphML.class, "importerGraphML_error_defaultedgetype", defaultEdgeType), Issue.Level.SEVERE));
             }
@@ -396,7 +404,10 @@ public class ImporterGraphML implements FileImporter, LongTask {
                 edge.setType(EdgeDraft.EdgeType.UNDIRECTED);
             } else {
                 report.logIssue(new Issue(NbBundle.getMessage(ImporterGraphML.class, "importerGraphML_error_edgetype", directed, edge), Issue.Level.SEVERE));
+                edge.setType(edgeDefault);
             }
+        } else {
+        	edge.setType(edgeDefault);
         }
 
         //Id


### PR DESCRIPTION
Looking at ImportContainerImpl and ImporterGraphML (and other importers), it appears that the problem is a problem of terminology. In GraphML, the 'default' type means that edges should be set to X by default, otherwise to whatever the specific setting is. In the importer, it appears to use the default as the *only* edge type, and forbids all other edge types.

Diving into the processor code, AppendProcessor.java checks the default edge type, and creates a graph according to that edge type, which does not appear to support other edge types. This would reflect the viewpoint of the importer. 

If you change the default edge type in the GraphML importer to MIXED, and set the edge type based on the default edge type, then the bug is fixed. Looking at other file formats, this adjustment should be made to other file formats that also support mixed representations. 