### PR TITLE
Turn off the verbosity of DefaultProcessor

### DIFF
--- a/modules/ProcessorPlugin/src/main/java/org/gephi/io/processor/plugin/DefaultProcessor.java
+++ b/modules/ProcessorPlugin/src/main/java/org/gephi/io/processor/plugin/DefaultProcessor.java
@@ -139,7 +139,7 @@ public class DefaultProcessor extends AbstractProcessor implements Processor {
 
             flushToEdge(draftEdge, edge);
         }
-        System.out.println("# Nodes loaded: " + nodeCount + "\n# Edges loaded: " + edgeCount);
+
         workspace = null;
     }
 }


### PR DESCRIPTION
It's pretty hard to use Gephi Toolkit in scripting when `DefaultProcessor` writes unnecessary and non-demanded information about the processed data. This commit turns off the verbosity and makes a better experience of the embedded Gephi.