### PR TITLE
Make the GML exporter's Creator tag syntax conformant

### DIFF
--- a/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGML.java
+++ b/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGML.java
@@ -167,7 +167,7 @@ public class ExporterGML implements GraphExporter, CharacterExporter, LongTask {
 
     private void exportData(Graph graph) throws IOException {
         printOpen("graph");
-        printTag("Creator Gephi");
+        printTag("Creator \"Gephi\"");
         if (graph.isDirected() || graph.isMixed()) {
             printTag("directed 1");
         } else if (graph.isUndirected()) {


### PR DESCRIPTION
Every GML file generated by Gephi contains the "Creator" attribute as follows

```
graph
[
  Creator Gephi
  ...
```

However, this does not conform to the GML syntax, since attribute values can be only of type Integer, Real, String and Lists, and Strings need to be quoted. The correct format would therefore be:

```
graph
[
  Creator "Gephi"
  ...
```

The current Gephi form throws off GML readers which adhere to the strict syntax, such as the one in graph-tool.
