### PR TITLE
Speed up CSV import by 90%

### DIFF
--- a/modules/AttributesAPI/src/main/java/org/gephi/data/attributes/api/AttributeModel.java
+++ b/modules/AttributesAPI/src/main/java/org/gephi/data/attributes/api/AttributeModel.java
@@ -42,6 +42,7 @@ Portions Copyrighted 2011 Gephi Consortium.
 package org.gephi.data.attributes.api;
 
 import org.gephi.project.api.Workspace;
+import org.gephi.graph.api.MassAttributeUpdate;
 
 /**
  * Represents the data model, like a standard database would do. As a database,
@@ -155,4 +156,14 @@ public interface AttributeModel {
      * @return the workspace that owns this Attribute model or null if it is independent from a Workspace
      */
     public Workspace getWorkspace();
+
+    /**
+     * Start a mass update against this table. The mass update object will be
+     * configured to dispatch events against this table when it reaches
+     * a threshold level, or when its <code>close</code> method is called.
+     *
+     * @return  A new mass update object bound to this table.
+     */
+    public MassAttributeUpdate startMassUpdate();
+
 }

--- a/modules/AttributesAPI/src/main/java/org/gephi/data/attributes/api/AttributeRowFactory.java
+++ b/modules/AttributesAPI/src/main/java/org/gephi/data/attributes/api/AttributeRowFactory.java
@@ -44,6 +44,7 @@ package org.gephi.data.attributes.api;
 import org.gephi.graph.api.EdgeData;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.NodeData;
 
 /**
@@ -61,6 +62,15 @@ public interface AttributeRowFactory {
      * @see     AttributeModel#getNodeTable()
      */
     public AttributeRow newNodeRow(NodeData nodeData);
+
+    /**
+     * Returns a new row for the <b>node</b> table, using an optional mass update buffer.
+     *
+     * @param massUpdate mass update buffer object
+     * @return  a newly created row for the node table
+     * @see     AttributeModel#getNodeTable()
+     */
+    public AttributeRow newNodeRow(NodeData nodeData, MassAttributeUpdate massUpdate);
 
     /**
      * Returns a new row for the <b>edge</b> table.

--- a/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/AbstractAttributeModel.java
+++ b/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/AbstractAttributeModel.java
@@ -52,6 +52,7 @@ import org.gephi.data.attributes.api.AttributeValueFactory;
 import org.gephi.data.attributes.event.AbstractEvent;
 import org.gephi.data.attributes.event.AttributeEventManager;
 import org.gephi.data.properties.PropertiesColumn;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.project.api.Workspace;
 import org.openide.util.NbBundle;
 
@@ -192,4 +193,9 @@ public abstract class AbstractAttributeModel implements AttributeModel {
     public Workspace getWorkspace(){
         return this.workspace;
     }
+
+    public MassAttributeUpdate startMassUpdate() {
+	return new MassAttributeUpdateImpl(eventManager);
+    }
+
 }

--- a/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/AttributeFactoryImpl.java
+++ b/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/AttributeFactoryImpl.java
@@ -50,6 +50,7 @@ import org.gephi.data.attributes.api.AttributeValue;
 import org.gephi.data.attributes.api.AttributeValueFactory;
 import org.gephi.graph.api.EdgeData;
 import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.NodeData;
 
 /**
@@ -91,6 +92,10 @@ public class AttributeFactoryImpl implements AttributeValueFactory, AttributeRow
 
     public AttributeRowImpl newNodeRow(NodeData nodeData) {
         return new AttributeRowImpl(model.getNodeTable(), nodeData);
+    }
+
+    public AttributeRowImpl newNodeRow(NodeData nodeData, MassAttributeUpdate massUpdate) {
+        return new AttributeRowImpl(model.getNodeTable(), nodeData, massUpdate);
     }
 
     public AttributeRowImpl newEdgeRow(EdgeData edgeData) {

--- a/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/MassAttributeUpdateImpl.java
+++ b/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/MassAttributeUpdateImpl.java
@@ -1,0 +1,36 @@
+
+package org.gephi.data.attributes;
+
+import java.util.ArrayList;
+import org.gephi.graph.api.MassAttributeUpdate;
+import org.gephi.data.attributes.event.AbstractEvent;
+import org.gephi.data.attributes.event.AttributeEventManager;
+
+public class MassAttributeUpdateImpl implements MassAttributeUpdate {
+
+    private AttributeEventManager sink;
+    private ArrayList<AbstractEvent> events;
+    private static final int SIZE_LIMIT = 1000000;
+
+    public MassAttributeUpdateImpl(AttributeEventManager s) {
+	sink = s;
+	events = new ArrayList<AbstractEvent>();
+    }
+
+    public void queueEvent(AbstractEvent ev) {
+	events.add(ev);
+	if(events.size() == MassAttributeUpdateImpl.SIZE_LIMIT)
+	    flush();
+    }
+
+    public void flush() {
+	sink.fireEvents(events);
+	events = new ArrayList<AbstractEvent>();
+    }
+
+    public void close() {
+	if(events.size() > 0)
+	    sink.fireEvents(events);
+    }
+
+}

--- a/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/event/AttributeEventManager.java
+++ b/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/event/AttributeEventManager.java
@@ -65,7 +65,7 @@ public class AttributeEventManager implements Runnable {
     private final AbstractAttributeModel model;
     private final List<AttributeListener> listeners;
     private final AtomicReference<Thread> thread = new AtomicReference<Thread>();
-    private final LinkedBlockingQueue<AbstractEvent> eventQueue;
+    private final LinkedBlockingQueue<ArrayList<AbstractEvent>> eventQueue;
     private final Object lock = new Object();
     private final LinkedList<Integer> rateList = new LinkedList<Integer>();
     private double avgRate = 1.0;
@@ -74,7 +74,7 @@ public class AttributeEventManager implements Runnable {
 
     public AttributeEventManager(AbstractAttributeModel model) {
         this.model = model;
-        this.eventQueue = new LinkedBlockingQueue<AbstractEvent>();
+        this.eventQueue = new LinkedBlockingQueue<ArrayList<AbstractEvent>>();
         this.listeners = Collections.synchronizedList(new ArrayList<AttributeListener>());
     }
 
@@ -97,29 +97,38 @@ public class AttributeEventManager implements Runnable {
             List<Object> eventCompressObjects = null;
 
             AbstractEvent precEvt = null;
-            AbstractEvent evt = null;
-            while ((evt = eventQueue.peek()) != null) {
-                if (precEvt != null) {
-                    if ((evt instanceof ValueEvent || evt instanceof ColumnEvent) && precEvt.getEventType().equals(evt.getEventType()) && precEvt.getAttributeTable() == evt.getAttributeTable()) {     //Same type
-                        if (eventCompress == null) {
-                            eventCompress = new ArrayList<Object>();
-                            eventCompress.add(precEvt.getData());
-                        }
-                        if (evt instanceof ValueEvent) {
-                            if (eventCompressObjects == null) {
-                                eventCompressObjects = new ArrayList<Object>();
-                                eventCompressObjects.add(((ValueEvent) precEvt).getObject());
-                            }
-                            eventCompressObjects.add(((ValueEvent) evt).getObject());
-                        }
+            ArrayList<AbstractEvent> evts = null;
+	    // Loop counter persists even when we break out of the inner 'for' loop
+	    // so that we resume correctly after breaking.
+	    int evtsIndex = 0;
 
-                        eventCompress.add(evt.getData());
-                    } else {
-                        break;
-                    }
-                }
+	    outereventloop:
+            while ((evts = eventQueue.peek()) != null) {
+		for(; evtsIndex < evts.size(); ++evtsIndex) {
+		    AbstractEvent evt = evts.get(evtsIndex);
+		    if (precEvt != null) {
+			if ((evt instanceof ValueEvent || evt instanceof ColumnEvent) && precEvt.getEventType().equals(evt.getEventType()) && precEvt.getAttributeTable() == evt.getAttributeTable()) {     //Same type
+			    if (eventCompress == null) {
+				eventCompress = new ArrayList<Object>();
+				eventCompress.add(precEvt.getData());
+			    }
+			    if (evt instanceof ValueEvent) {
+				if (eventCompressObjects == null) {
+				    eventCompressObjects = new ArrayList<Object>();
+				    eventCompressObjects.add(((ValueEvent) precEvt).getObject());
+				}
+				eventCompressObjects.add(((ValueEvent) evt).getObject());
+			    }
+
+			    eventCompress.add(evt.getData());
+			} else {
+			    break outereventloop;
+			}
+		    }
+		    precEvt = evt;
+		}
+		evtsIndex = 0;
                 eventQueue.poll();
-                precEvt = evt;
             }
 
             if (precEvt != null) {
@@ -184,11 +193,17 @@ public class AttributeEventManager implements Runnable {
         this.stop = stop;
     }
 
-    public void fireEvent(AbstractEvent event) {
-        eventQueue.add(event);
+    public void fireEvents(ArrayList<AbstractEvent> events) {
+        eventQueue.add(events);
         synchronized (lock) {
             lock.notifyAll();
         }
+    }
+
+    public void fireEvent(AbstractEvent event) {
+	ArrayList<AbstractEvent> events = new ArrayList<AbstractEvent>(1);
+	events.add(event);
+	fireEvents(events);
     }
 
     public void start() {

--- a/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/event/AttributeEventManager.java
+++ b/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/event/AttributeEventManager.java
@@ -103,7 +103,7 @@ public class AttributeEventManager implements Runnable {
 	    int evtsIndex = 0;
 
 	    outereventloop:
-            while ((evts = eventQueue.peek()) != null) {
+            while (evts != null || (evts = eventQueue.poll()) != null) {
 		for(; evtsIndex < evts.size(); ++evtsIndex) {
 		    AbstractEvent evt = evts.get(evtsIndex);
 		    if (precEvt != null) {
@@ -128,14 +128,16 @@ public class AttributeEventManager implements Runnable {
 		    precEvt = evt;
 		}
 		evtsIndex = 0;
-                eventQueue.poll();
+		evts = null;
             }
 
             if (precEvt != null) {
                 AttributeEvent event = createEvent(precEvt, eventCompress, eventCompressObjects);
-                for (AttributeListener l : listeners.toArray(new AttributeListener[0])) {
-                    l.attributesChanged(event);
-                }
+		synchronized(listeners) {
+		    for (AttributeListener l : listeners) {
+			l.attributesChanged(event);
+		    }
+		}
             }
             rate++;
 

--- a/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/model/IndexedAttributeModel.java
+++ b/modules/AttributesImpl/src/main/java/org/gephi/data/attributes/model/IndexedAttributeModel.java
@@ -66,7 +66,8 @@ public class IndexedAttributeModel extends AbstractAttributeModel {
 
     @Override
     public Object getManagedValue(Object obj, AttributeType attributeType) {
-        return dataIndex.pushData(obj);
+        //return dataIndex.pushData(obj);
+	return obj;
     }
 
     @Override

--- a/modules/DHNSGraph/src/main/java/org/gephi/graph/dhns/core/GraphFactoryImpl.java
+++ b/modules/DHNSGraph/src/main/java/org/gephi/graph/dhns/core/GraphFactoryImpl.java
@@ -47,6 +47,7 @@ import org.gephi.graph.api.Attributes;
 import org.gephi.graph.api.EdgeData;
 import org.gephi.graph.api.GraphFactory;
 import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.Node;
 import org.gephi.graph.api.NodeData;
 import org.gephi.graph.api.TextData;
@@ -79,10 +80,14 @@ public class GraphFactoryImpl implements GraphFactory {
     }
 
     public AttributeRow newNodeAttributes(NodeData nodeData) {
+	return newNodeAttributes(nodeData, null);
+    }
+
+    private AttributeRow newNodeAttributes(NodeData nodeData, MassAttributeUpdate massUpdate) {
         if (attributesFactory == null) {
             return null;
         }
-        return attributesFactory.newNodeRow(nodeData);
+        return attributesFactory.newNodeRow(nodeData, massUpdate);
     }
 
     public AttributeRow newEdgeAttributes(EdgeData edgeData) {
@@ -107,27 +112,39 @@ public class GraphFactoryImpl implements GraphFactory {
     }
 
     public AbstractNode newNode() {
-        return newNode(null, 0);
+        return newNode(null, 0, null);
+    }
+
+    public AbstractNode newNode(MassAttributeUpdate massUpdate) {
+	return newNode(null, 0, massUpdate);
     }
 
     public AbstractNode newNode(int viewId) {
-        return newNode(null, viewId);
+        return newNode(null, viewId, null);
     }
 
-    public AbstractNode newNode(String id, int viewId) {
+    private AbstractNode newNode(String id, int viewId, MassAttributeUpdate massUpdate) {
         AbstractNode node = new AbstractNode(idGen.newNodeId(), viewId, 0, 0, 0, null);  //with wiew = 0
-        node.getNodeData().setAttributes(newNodeAttributes(node.getNodeData()));
+        node.getNodeData().setAttributes(newNodeAttributes(node.getNodeData(), massUpdate));
         node.getNodeData().setTextData(newTextData());
         if (id != null) {
-            node.getNodeData().setId(id);
+            node.getNodeData().setId(id, massUpdate);
         } else {
-            node.getNodeData().setId("" + node.getId());
+            node.getNodeData().setId("" + node.getId(), massUpdate);
         }
         return node;
     }
 
+    public AbstractNode newNode(String id, int viewId) {
+	return newNode(id, viewId, null);
+    }
+
     public AbstractNode newNode(String id) {
-        return newNode(id, 0);
+        return newNode(id, 0, null);
+    }
+
+    public AbstractNode newNode(String id, MassAttributeUpdate massUpdate) {
+	return newNode(id, 0, massUpdate);
     }
 
     public AbstractEdge newEdge(Node source, Node target) {

--- a/modules/DHNSGraph/src/main/java/org/gephi/graph/dhns/node/NodeDataImpl.java
+++ b/modules/DHNSGraph/src/main/java/org/gephi/graph/dhns/node/NodeDataImpl.java
@@ -49,6 +49,7 @@ import org.gephi.graph.api.NodeData;
 import org.gephi.graph.api.GroupData;
 import org.gephi.graph.api.Model;
 import org.gephi.graph.api.TextData;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.dhns.utils.avl.ViewNodeTree;
 
 /**
@@ -203,12 +204,16 @@ public class NodeDataImpl implements NodeData, GroupData {
         this.b = b;
     }
 
-    public void setLabel(String label) {
+    public void setLabel(String label, MassAttributeUpdate massUpdate) {
         if (attributes != null) {
-            attributes.setValue(PropertiesColumn.NODE_LABEL.getIndex(), label);
+	    attributes.setValue(PropertiesColumn.NODE_LABEL.getIndex(), label, massUpdate);
         } else {
             this.label = label;
         }
+    }
+
+    public void setLabel(String Label) {
+	setLabel(label, null);
     }
 
     public float alpha() {
@@ -242,13 +247,17 @@ public class NodeDataImpl implements NodeData, GroupData {
         return (String) attributes.getValue(PropertiesColumn.NODE_ID.getIndex());
     }
 
-    public String setId(String id) {
+    public String setId(String id, MassAttributeUpdate massUpdate) {
         if (attributes == null) {
             return null;
         }
         String oldId = (String) attributes.getValue(PropertiesColumn.NODE_ID.getIndex());
-        attributes.setValue(PropertiesColumn.NODE_ID.getIndex(), id);
+        attributes.setValue(PropertiesColumn.NODE_ID.getIndex(), id, massUpdate);
         return oldId;
+    }
+
+    public String setId(String id) {
+	return setId(id, null);
     }
 
     public boolean isFixed() {

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/DataLaboratoryHelper.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/DataLaboratoryHelper.java
@@ -307,7 +307,14 @@ public class DataLaboratoryHelper {
 
             @Override
             public void run() {
-                m.execute();
+		this.setDefaultUncaughtExceptionHandler(
+							new Thread.UncaughtExceptionHandler() {
+							    @Override public void uncaughtException(Thread t, Throwable e) {
+								System.err.println(t.getName()+": "+e);
+								e.printStackTrace(System.err);
+							    }
+							});
+		m.execute();
             }
         }.start();
     }

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/GraphElementsController.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/GraphElementsController.java
@@ -44,6 +44,7 @@ package org.gephi.datalab.api;
 import org.gephi.datalab.spi.rows.merge.AttributeRowsMergeStrategy;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.Node;
 
 /**
@@ -62,12 +63,13 @@ public interface GraphElementsController {
     Node createNode(String label);
 
     /**
-     * Creates a node with default id and the given label in the given graph (which must match the graph managed by this controller).
+     * Creates a node with default id and the given label in the given graph (which must match the graph managed by this controller)
+     * and with an optional MassAttributeUpdate to batch events.
      * @param label Label for the node
      * @param graph Graph to insert the node into
      * @return The new created node
      */
-    Node createNode(String label, Graph graph);
+    Node createNode(String label, Graph graph, MassAttributeUpdate massUpdate);
 
     /**
      * <p>Creates a node with the given id and label.</p>
@@ -79,14 +81,15 @@ public interface GraphElementsController {
     Node createNode(String label, String id);
 
     /**
-     * <p>Creates a node with the given id and label, in the given graph (which must match the graph managed by this controller)</p>
+     * <p>Creates a node with the given id and label, in the given graph (which must match the graph managed by this controller)
+     * and with an optional MassAttributeUpdate to batch events.</p>
      * <p>If a node with that id already exists, no node will be created</p>
      * @param label Label for the node
      * @param id Id for the node
      * @param graph Graph to insert the node into
      * @return The new created node or null if a node with the given id already exists
      */
-    Node createNode(String label, String id, Graph graph);
+    Node createNode(String label, String id, Graph graph, MassAttributeUpdate massUpdate);
 
     /**
      * <p>Duplicates a node if it is in the graph, and returns the new node.</p>

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/GraphElementsController.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/GraphElementsController.java
@@ -43,6 +43,7 @@ package org.gephi.datalab.api;
 
 import org.gephi.datalab.spi.rows.merge.AttributeRowsMergeStrategy;
 import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.Node;
 
 /**
@@ -61,6 +62,14 @@ public interface GraphElementsController {
     Node createNode(String label);
 
     /**
+     * Creates a node with default id and the given label in the given graph (which must match the graph managed by this controller).
+     * @param label Label for the node
+     * @param graph Graph to insert the node into
+     * @return The new created node
+     */
+    Node createNode(String label, Graph graph);
+
+    /**
      * <p>Creates a node with the given id and label.</p>
      * <p>If a node with that id already exists, no node will be created</p>
      * @param label Label for the node
@@ -68,6 +77,16 @@ public interface GraphElementsController {
      * @return The new created node or null if a node with the given id already exists
      */
     Node createNode(String label, String id);
+
+    /**
+     * <p>Creates a node with the given id and label, in the given graph (which must match the graph managed by this controller)</p>
+     * <p>If a node with that id already exists, no node will be created</p>
+     * @param label Label for the node
+     * @param id Id for the node
+     * @param graph Graph to insert the node into
+     * @return The new created node or null if a node with the given id already exists
+     */
+    Node createNode(String label, String id, Graph graph);
 
     /**
      * <p>Duplicates a node if it is in the graph, and returns the new node.</p>

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/GraphElementsController.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/GraphElementsController.java
@@ -44,6 +44,7 @@ package org.gephi.datalab.api;
 import org.gephi.datalab.spi.rows.merge.AttributeRowsMergeStrategy;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphModel;
 import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.Node;
 
@@ -66,10 +67,11 @@ public interface GraphElementsController {
      * Creates a node with default id and the given label in the given graph (which must match the graph managed by this controller)
      * and with an optional MassAttributeUpdate to batch events.
      * @param label Label for the node
+     * @param graphModel Graph model corresponding to <code>graph</code>
      * @param graph Graph to insert the node into
      * @return The new created node
      */
-    Node createNode(String label, Graph graph, MassAttributeUpdate massUpdate);
+    Node createNode(String label, GraphModel graphModel, Graph graph, MassAttributeUpdate massUpdate);
 
     /**
      * <p>Creates a node with the given id and label.</p>
@@ -86,10 +88,11 @@ public interface GraphElementsController {
      * <p>If a node with that id already exists, no node will be created</p>
      * @param label Label for the node
      * @param id Id for the node
+     * @param graphModel Graph model corresponding to <code>graph</code>
      * @param graph Graph to insert the node into
      * @return The new created node or null if a node with the given id already exists
      */
-    Node createNode(String label, String id, Graph graph, MassAttributeUpdate massUpdate);
+    Node createNode(String label, String id, GraphModel graphModel, Graph graph, MassAttributeUpdate massUpdate);
 
     /**
      * <p>Duplicates a node if it is in the graph, and returns the new node.</p>

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/datatables/DataTablesController.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/datatables/DataTablesController.java
@@ -82,4 +82,7 @@ public interface DataTablesController extends DataTablesCommonInterface {
      * @return True if listener found, false otherwise
      */
     boolean prepareDataTables();
+
+    void setRefreshSuspended(boolean suspended);
+
 }

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/datatables/DataTablesEventListener.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/datatables/DataTablesEventListener.java
@@ -48,5 +48,7 @@ package org.gephi.datalab.api.datatables;
  * @author Eduardo Ramos <eduramiba@gmail.com>
  */
 public interface DataTablesEventListener extends DataTablesCommonInterface {
+
+    public void setRefreshSuspended(boolean suspended);
     
 }

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/AttributeColumnsControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/AttributeColumnsControllerImpl.java
@@ -79,6 +79,7 @@ import org.gephi.graph.api.Attributes;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.GraphModel;
 import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.Node;
 import org.gephi.utils.StatisticsUtils;
@@ -589,7 +590,10 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
 
             //Create nodes:
             GraphElementsController gec = Lookup.getDefault().lookup(GraphElementsController.class);
-            Graph graph = Lookup.getDefault().lookup(GraphController.class).getModel().getGraph();
+	    // Both getModel and getGraph are expensive operations, so fetch them once here
+	    // and pass down to createNode et al.
+	    GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getModel();
+            Graph graph = graphModel.getGraph();
             String id = null;
             Node node;
             Attributes nodeAttributes;
@@ -602,21 +606,21 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
                 if (idColumn != null) {
                     id = reader.get(idColumn);
                     if (id == null || id.isEmpty()) {
-                        node = gec.createNode(null, graph, massUpdate);//id null or empty, assign one
+                        node = gec.createNode(null, graphModel, graph, massUpdate);//id null or empty, assign one
                     } else {
                         graph.readLock();
                         node = graph.getNode(id);
                         graph.readUnlock();
                         if (node != null) {//Node with that id already in graph
                             if (assignNewNodeIds) {
-                                node = gec.createNode(null, graph, massUpdate);
+                                node = gec.createNode(null, graphModel, graph, massUpdate);
                             }
                         } else {
-                            node = gec.createNode(null, id, graph, massUpdate);//New id in the graph
+                            node = gec.createNode(null, id, graphModel, graph, massUpdate);//New id in the graph
                         }
                     }
                 } else {
-                    node = gec.createNode(null, graph, massUpdate);
+                    node = gec.createNode(null, graphModel, graph, massUpdate);
                 }
                 //Assign attributes to the current node:
                 nodeAttributes = node.getNodeData().getAttributes();

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/AttributeColumnsControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/AttributeColumnsControllerImpl.java
@@ -593,21 +593,21 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
                 if (idColumn != null) {
                     id = reader.get(idColumn);
                     if (id == null || id.isEmpty()) {
-                        node = gec.createNode(null);//id null or empty, assign one
+                        node = gec.createNode(null, graph);//id null or empty, assign one
                     } else {
                         graph.readLock();
                         node = graph.getNode(id);
                         graph.readUnlock();
                         if (node != null) {//Node with that id already in graph
                             if (assignNewNodeIds) {
-                                node = gec.createNode(null);
+                                node = gec.createNode(null, graph);
                             }
                         } else {
-                            node = gec.createNode(null, id);//New id in the graph
+                            node = gec.createNode(null, id, graph);//New id in the graph
                         }
                     }
                 } else {
-                    node = gec.createNode(null);
+                    node = gec.createNode(null, graph);
                 }
                 //Assign attributes to the current node:
                 nodeAttributes = node.getNodeData().getAttributes();

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/AttributeColumnsControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/AttributeColumnsControllerImpl.java
@@ -57,6 +57,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.gephi.data.attributes.api.AttributeColumn;
 import org.gephi.data.attributes.api.AttributeController;
+import org.gephi.data.attributes.api.AttributeModel;
 import org.gephi.data.attributes.api.AttributeOrigin;
 import org.gephi.data.attributes.api.AttributeRow;
 import org.gephi.data.attributes.api.AttributeTable;
@@ -78,6 +79,7 @@ import org.gephi.graph.api.Attributes;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.Node;
 import org.gephi.utils.StatisticsUtils;
 import org.openide.util.Exceptions;
@@ -93,7 +95,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = AttributeColumnsController.class)
 public class AttributeColumnsControllerImpl implements AttributeColumnsController {
 
-    public boolean setAttributeValue(Object value, Attributes row, AttributeColumn column) {
+    public boolean setAttributeValue(Object value, Attributes row, AttributeColumn column, MassAttributeUpdate massUpdate) {
         AttributeType targetType = column.getType();
         if (value != null && !value.getClass().equals(targetType.getType())) {
             try {
@@ -106,9 +108,13 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
         if (value == null && !canClearColumnData(column)) {
             return false;//Do not set a null value when the column can't have a null value.
         } else {
-            row.setValue(column.getIndex(), value);
+	    row.setValue(column.getIndex(), value, massUpdate);
             return true;
         }
+    }
+
+    public boolean setAttributeValue(Object value, Attributes row, AttributeColumn column) {
+	return setAttributeValue(value, row, column, null);
     }
 
     public AttributeColumn addAttributeColumn(AttributeTable table, String title, AttributeType type) {
@@ -554,9 +560,11 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
         }
 
         CsvReader reader = null;
+	MassAttributeUpdate massUpdate = null;
         try {
             //Prepare attribute columns for the column names, creating the not already existing columns:
-            AttributeTable nodesTable = Lookup.getDefault().lookup(AttributeController.class).getModel().getNodeTable();
+	    AttributeModel attModel = Lookup.getDefault().lookup(AttributeController.class).getModel();
+            AttributeTable nodesTable = attModel.getNodeTable();
             String idColumn = null;
             ArrayList<AttributeColumn> columnsList = new ArrayList<AttributeColumn>();
             HashMap<AttributeColumn, String> columnHeaders = new HashMap<AttributeColumn, String>();//Necessary because of column name case insensitivity, to map columns to its corresponding csv header.
@@ -585,6 +593,7 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
             String id = null;
             Node node;
             Attributes nodeAttributes;
+	    massUpdate = attModel.startMassUpdate();
             reader = new CsvReader(new FileInputStream(file), separator, charset);
             reader.setTrimWhitespace(false);
             reader.readHeaders();
@@ -593,26 +602,26 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
                 if (idColumn != null) {
                     id = reader.get(idColumn);
                     if (id == null || id.isEmpty()) {
-                        node = gec.createNode(null, graph);//id null or empty, assign one
+                        node = gec.createNode(null, graph, massUpdate);//id null or empty, assign one
                     } else {
                         graph.readLock();
                         node = graph.getNode(id);
                         graph.readUnlock();
                         if (node != null) {//Node with that id already in graph
                             if (assignNewNodeIds) {
-                                node = gec.createNode(null, graph);
+                                node = gec.createNode(null, graph, massUpdate);
                             }
                         } else {
-                            node = gec.createNode(null, id, graph);//New id in the graph
+                            node = gec.createNode(null, id, graph, massUpdate);//New id in the graph
                         }
                     }
                 } else {
-                    node = gec.createNode(null, graph);
+                    node = gec.createNode(null, graph, massUpdate);
                 }
                 //Assign attributes to the current node:
                 nodeAttributes = node.getNodeData().getAttributes();
                 for (AttributeColumn column : columnsList) {
-                    setAttributeValue(reader.get(columnHeaders.get(column)), nodeAttributes, column);
+                    setAttributeValue(reader.get(columnHeaders.get(column)), nodeAttributes, column, massUpdate);
                 }
             }
         } catch (FileNotFoundException ex) {
@@ -621,6 +630,8 @@ public class AttributeColumnsControllerImpl implements AttributeColumnsControlle
             Exceptions.printStackTrace(ex);
         } finally {
             reader.close();
+	    if(massUpdate != null)
+		massUpdate.close();
         }
     }
 

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/DataTablesControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/DataTablesControllerImpl.java
@@ -216,4 +216,11 @@ public class DataTablesControllerImpl implements DataTablesController {
         }
         return isDataTablesReady();
     }
+
+    public void setRefreshSuspended(boolean suspended) {
+	if(listener != null) {
+	    listener.setRefreshSuspended(suspended);
+	}
+    }
+
 }

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/GraphElementsControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/GraphElementsControllerImpl.java
@@ -79,14 +79,17 @@ public class GraphElementsControllerImpl implements GraphElementsController {
     private static final float DEFAULT_NODE_SIZE = 10f;
     private static final float DEFAULT_EDGE_WEIGHT = 1f;
 
-    public Node createNode(String label) {
+    public Node createNode(String label, Graph graph) {
         Node newNode = buildNode(label);
-        getGraph().addNode(newNode);
+        graph.addNode(newNode);
         return newNode;
     }
 
-    public Node createNode(String label, String id) {
-        Graph graph = getGraph();
+    public Node createNode(String label) {
+	return createNode(label, getGraph());
+    }
+
+    public Node createNode(String label, String id, Graph graph) {
         if (graph.getNode(id) == null) {
             Node newNode = buildNode(label, id);
             graph.addNode(newNode);
@@ -94,6 +97,10 @@ public class GraphElementsControllerImpl implements GraphElementsController {
         } else {
             return null;
         }
+    }
+
+    public Node createNode(String label, String id) {
+	return createNode(label, id, getGraph());
     }
 
     public Node duplicateNode(Node node) {

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/GraphElementsControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/GraphElementsControllerImpl.java
@@ -58,6 +58,7 @@ import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphController;
 import org.gephi.graph.api.HierarchicalGraph;
+import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.Node;
 import org.gephi.graph.api.NodeData;
 import org.gephi.graph.api.UndirectedGraph;
@@ -79,19 +80,19 @@ public class GraphElementsControllerImpl implements GraphElementsController {
     private static final float DEFAULT_NODE_SIZE = 10f;
     private static final float DEFAULT_EDGE_WEIGHT = 1f;
 
-    public Node createNode(String label, Graph graph) {
-        Node newNode = buildNode(label);
+    public Node createNode(String label, Graph graph, MassAttributeUpdate massUpdate) {
+        Node newNode = buildNode(label, massUpdate);
         graph.addNode(newNode);
         return newNode;
     }
 
     public Node createNode(String label) {
-	return createNode(label, getGraph());
+	return createNode(label, getGraph(), null);
     }
 
-    public Node createNode(String label, String id, Graph graph) {
+    public Node createNode(String label, String id, Graph graph, MassAttributeUpdate massUpdate) {
         if (graph.getNode(id) == null) {
-            Node newNode = buildNode(label, id);
+            Node newNode = buildNode(label, id, massUpdate);
             graph.addNode(newNode);
             return newNode;
         } else {
@@ -100,7 +101,7 @@ public class GraphElementsControllerImpl implements GraphElementsController {
     }
 
     public Node createNode(String label, String id) {
-	return createNode(label, id, getGraph());
+	return createNode(label, id, getGraph(), null);
     }
 
     public Node duplicateNode(Node node) {
@@ -528,17 +529,17 @@ public class GraphElementsControllerImpl implements GraphElementsController {
         return Lookup.getDefault().lookup(GraphController.class).getModel().getHierarchicalGraph();
     }
 
-    private Node buildNode(String label) {
-        Node newNode = Lookup.getDefault().lookup(GraphController.class).getModel().factory().newNode();
+    private Node buildNode(String label, MassAttributeUpdate massUpdate) {
+        Node newNode = Lookup.getDefault().lookup(GraphController.class).getModel().factory().newNode(massUpdate);
         newNode.getNodeData().setSize(DEFAULT_NODE_SIZE);
-        newNode.getNodeData().setLabel(label);
+        newNode.getNodeData().setLabel(label, massUpdate);
         return newNode;
     }
 
-    private Node buildNode(String label, String id) {
-        Node newNode = Lookup.getDefault().lookup(GraphController.class).getModel().factory().newNode(id);
+    private Node buildNode(String label, String id, MassAttributeUpdate massUpdate) {
+        Node newNode = Lookup.getDefault().lookup(GraphController.class).getModel().factory().newNode(id, massUpdate);
         newNode.getNodeData().setSize(DEFAULT_NODE_SIZE);
-        newNode.getNodeData().setLabel(label);
+        newNode.getNodeData().setLabel(label, massUpdate);
         return newNode;
     }
 
@@ -554,7 +555,7 @@ public class GraphElementsControllerImpl implements GraphElementsController {
 
     private Node copyNodeRecursively(Node node, Node parent, HierarchicalGraph hg) {
         NodeData nodeData = node.getNodeData();
-        Node copy = buildNode(nodeData.getLabel());
+        Node copy = buildNode(nodeData.getLabel(), null);
         NodeData copyData = copy.getNodeData();
 
         //Copy properties (position, size and color):

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/GraphElementsControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/GraphElementsControllerImpl.java
@@ -57,6 +57,7 @@ import org.gephi.graph.api.DirectedGraph;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.GraphModel;
 import org.gephi.graph.api.HierarchicalGraph;
 import org.gephi.graph.api.MassAttributeUpdate;
 import org.gephi.graph.api.Node;
@@ -80,19 +81,21 @@ public class GraphElementsControllerImpl implements GraphElementsController {
     private static final float DEFAULT_NODE_SIZE = 10f;
     private static final float DEFAULT_EDGE_WEIGHT = 1f;
 
-    public Node createNode(String label, Graph graph, MassAttributeUpdate massUpdate) {
-        Node newNode = buildNode(label, massUpdate);
+    public Node createNode(String label, GraphModel graphModel, Graph graph, MassAttributeUpdate massUpdate) {
+        Node newNode = buildNode(label, graphModel, massUpdate);
         graph.addNode(newNode);
         return newNode;
     }
 
     public Node createNode(String label) {
-	return createNode(label, getGraph(), null);
+	GraphModel model = Lookup.getDefault().lookup(GraphController.class).getModel();
+	Graph graph = model.getGraph();
+	return createNode(label, model, graph, null);
     }
 
-    public Node createNode(String label, String id, Graph graph, MassAttributeUpdate massUpdate) {
+    public Node createNode(String label, String id, GraphModel graphModel, Graph graph, MassAttributeUpdate massUpdate) {
         if (graph.getNode(id) == null) {
-            Node newNode = buildNode(label, id, massUpdate);
+            Node newNode = buildNode(label, id, graphModel, massUpdate);
             graph.addNode(newNode);
             return newNode;
         } else {
@@ -101,7 +104,9 @@ public class GraphElementsControllerImpl implements GraphElementsController {
     }
 
     public Node createNode(String label, String id) {
-	return createNode(label, id, getGraph(), null);
+	GraphModel model = Lookup.getDefault().lookup(GraphController.class).getModel();
+	Graph graph = model.getGraph();
+	return createNode(label, id, model, graph, null);
     }
 
     public Node duplicateNode(Node node) {
@@ -529,15 +534,15 @@ public class GraphElementsControllerImpl implements GraphElementsController {
         return Lookup.getDefault().lookup(GraphController.class).getModel().getHierarchicalGraph();
     }
 
-    private Node buildNode(String label, MassAttributeUpdate massUpdate) {
-        Node newNode = Lookup.getDefault().lookup(GraphController.class).getModel().factory().newNode(massUpdate);
+    private Node buildNode(String label, GraphModel model, MassAttributeUpdate massUpdate) {
+        Node newNode = model.factory().newNode(massUpdate);
         newNode.getNodeData().setSize(DEFAULT_NODE_SIZE);
         newNode.getNodeData().setLabel(label, massUpdate);
         return newNode;
     }
 
-    private Node buildNode(String label, String id, MassAttributeUpdate massUpdate) {
-        Node newNode = Lookup.getDefault().lookup(GraphController.class).getModel().factory().newNode(id, massUpdate);
+    private Node buildNode(String label, String id, GraphModel model, MassAttributeUpdate massUpdate) {
+        Node newNode = model.factory().newNode(id, massUpdate);
         newNode.getNodeData().setSize(DEFAULT_NODE_SIZE);
         newNode.getNodeData().setLabel(label, massUpdate);
         return newNode;
@@ -555,7 +560,8 @@ public class GraphElementsControllerImpl implements GraphElementsController {
 
     private Node copyNodeRecursively(Node node, Node parent, HierarchicalGraph hg) {
         NodeData nodeData = node.getNodeData();
-        Node copy = buildNode(nodeData.getLabel(), null);
+	GraphModel model = Lookup.getDefault().lookup(GraphController.class).getModel();
+        Node copy = buildNode(nodeData.getLabel(), model, null);
         NodeData copyData = copy.getNodeData();
 
         //Copy properties (position, size and color):

--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/ImportCSVUIWizardAction.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/ImportCSVUIWizardAction.java
@@ -98,6 +98,9 @@ public final class ImportCSVUIWizardAction extends CallableSystemAction {
             Boolean createNewNodes = (Boolean) wizardDescriptor.getProperty("create-new-nodes");
 
             AttributeColumnsController ac = Lookup.getDefault().lookup(AttributeColumnsController.class);
+	    DataTablesController dtc = Lookup.getDefault().lookup(DataTablesController.class);
+	    dtc.setRefreshSuspended(true);
+
             switch ((Mode) wizardDescriptor.getProperty("mode")) {
                 case NODES_TABLE:
                     ac.importCSVToNodesTable(file, separator, charset, columnNames, columnTypes, assignNewNodeIds);
@@ -106,7 +109,10 @@ public final class ImportCSVUIWizardAction extends CallableSystemAction {
                     ac.importCSVToEdgesTable(file, separator, charset, columnNames, columnTypes, createNewNodes);
                     break;
             }
-            Lookup.getDefault().lookup(DataTablesController.class).refreshCurrentTable();
+
+	    dtc.setRefreshSuspended(false);
+	    dtc.refreshCurrentTable();
+            
         }
         step1.unSetup();
         step2.unSetup();

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
@@ -144,6 +144,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     private int previousEdgeColumnsFilterIndex = 0;
     //Executor
     private RefreshOnceHelperThread refreshOnceHelperThread;
+    private boolean refreshSuspended;
 
     public DataTableTopComponent() {
 
@@ -340,14 +341,16 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     }
 
     public void graphChanged(GraphEvent event) {
-        SwingUtilities.invokeLater(new Runnable() {
+	if(!refreshSuspended) {
+	    SwingUtilities.invokeLater(new Runnable() {
 
-            public void run() {
-                if (isOpened()) {
-                    refreshOnce(false);
-                }
-            }
-        });
+		public void run() {
+		    if (isOpened()) {
+			refreshOnce(false);
+		    }
+		}
+	    });
+	}
     }
 
     /**
@@ -358,6 +361,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
      * refresh all UI including manipulators
      */
     private void refreshOnce(boolean refreshTableOnly) {
+
         if (refreshOnceHelperThread == null || !refreshOnceHelperThread.isAlive() || (refreshOnceHelperThread.refreshTableOnly && !refreshTableOnly)) {
             refreshOnceHelperThread = new RefreshOnceHelperThread(refreshTableOnly);
             refreshOnceHelperThread.start();
@@ -609,14 +613,21 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
             }
         });
     }
+    
+    public void setRefreshSuspended(boolean suspended) {
+	this.refreshSuspended = suspended;
+    }
 
     public void refreshCurrentTable() {
-        SwingUtilities.invokeLater(new Runnable() {
+	if(!refreshSuspended) {
+	    SwingUtilities.invokeLater(new Runnable() {
+		    
+		public void run() {
+		    refreshAllOnce();
+		}
 
-            public void run() {
-                refreshAllOnce();
-            }
-        });
+	    });
+	}
     }
 
     public void setNodeTableSelection(final Node[] nodes) {

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/HackedOutline.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/HackedOutline.java
@@ -1,0 +1,94 @@
+
+package org.gephi.desktop.datalab;
+
+import java.util.Hashtable;
+import java.util.Enumeration;
+import java.awt.Component;
+import javax.swing.JTable;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableModel;
+import org.netbeans.swing.outline.*;
+
+class HackedOutline extends Outline {
+
+    protected TableColumn createColumn(int modelIndex) {
+	return new HackedOutlineColumn(modelIndex);
+    }
+
+    public class HackedOutlineColumn extends OutlineColumn {
+
+	public HackedOutlineColumn(int modelIndex) {
+	    super(modelIndex);
+	}
+       
+	// Copied private method from netbeans...ETable.
+	private int estimatedWidth(Object dataObject, JTable table) {
+	    TableCellRenderer cr = getCellRenderer();
+	    if (cr == null) {
+		Class c = table.getModel().getColumnClass(modelIndex);
+		cr = table.getDefaultRenderer(c);
+	    }
+	    Component c = cr.getTableCellRendererComponent(table, dataObject, false,
+							   false, 0, table.getColumnModel().getColumnIndex(getIdentifier()));
+	    return c.getPreferredSize().width;
+	}
+
+	// Copy of ETable::updatePreferredWidth that avoids extensive calculation for large tables.
+	void updatePreferredWidth(JTable table) {
+
+	    TableModel dataModel = table.getModel();
+	    int rows = dataModel.getRowCount();
+	    if (rows == 0) {
+		return;
+	    }
+	    int sum = 0;
+	    int max = 15;
+
+	    // For long tables, just hope the first block of cells are typical of the table.
+	    if(rows > 10000)
+		rows = 10000;
+
+	    for (int i = 0; i < rows; i++) {
+		Object data = dataModel.getValueAt(i, modelIndex);
+		int estimate = estimatedWidth(data, table);
+		sum += estimate;
+		if (estimate > max) {
+		    max = estimate;
+		}
+	    }
+	    max += 5;
+	    setPreferredWidth(max);
+
+	}
+
+    }
+
+    // Copy more crap to hack around Java visibility
+
+    public void setModel(TableModel dataModel) {
+
+	// Avoid running updatePreferredWidths from within setModel
+	Hashtable backup = defaultRenderersByColumnClass;
+	defaultRenderersByColumnClass = null;
+	super.setModel(dataModel);
+	defaultRenderersByColumnClass = backup;
+
+	// Now use my own hacked update:
+	if(backup != null)
+	    updatePreferredWidths();
+
+    }
+
+    private void updatePreferredWidths() {
+	Enumeration en = getColumnModel().getColumns();
+	while (en.hasMoreElements()) {
+	    Object obj = en.nextElement();
+	    if (obj instanceof HackedOutlineColumn) {
+		HackedOutlineColumn hoc = (HackedOutlineColumn) obj;
+		hoc.updatePreferredWidth(this);
+	    }
+	}
+    }
+    
+}

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/NodeDataTable.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/NodeDataTable.java
@@ -112,7 +112,7 @@ public class NodeDataTable {
         attributeUtils = AttributeUtils.getDefault();
         attributeColumnsController = Lookup.getDefault().lookup(AttributeColumnsController.class);
 
-        outlineTable = new Outline();
+        outlineTable = new HackedOutline();
         outlineTable.setColumnHidingAllowed(false);
 
         quickFilter = new QuickFilter() {
@@ -646,3 +646,6 @@ public class NodeDataTable {
         return nodes;
     }
 }
+
+
+

--- a/modules/GraphAPI/src/main/java/org/gephi/graph/api/Attributes.java
+++ b/modules/GraphAPI/src/main/java/org/gephi/graph/api/Attributes.java
@@ -85,11 +85,29 @@ public interface Attributes {
     public void setValue(String column, Object value);
 
     /**
+     * Sets the value for a specified column. Accepts <code>null</code> values. Uses optional <code>massUpdate</code>
+     * object to batch update events if any are generated.
+     * @param column    the column <b>id</b> or <b>title</b>
+     * @param value     the value that is to be set at the specified column position
+     * @param massUpdate mass update buffer object
+     */
+    public void setValue(String column, Object value, MassAttributeUpdate massUpdate);
+
+    /**
      * Sets the value for a specified column position. Accepts <code>null</code> values.
      * @param index     the column index
      * @param value     the value that is to be set at the specified column position
      */
     public void setValue(int index, Object value);
+
+    /**
+     * Sets the value for a specified column position. Accepts <code>null</code> values. Uses optional <code>massUpdate</code>
+     * object to batch update events if any are generated.
+     * @param index     the column index
+     * @param value     the value that is to be set at the specified column position
+     * @param massUpdate mass update buffer object
+     */
+    public void setValue(int index, Object value, MassAttributeUpdate massUpdate);
 
     /**
      * Resets the content of the row.

--- a/modules/GraphAPI/src/main/java/org/gephi/graph/api/GraphFactory.java
+++ b/modules/GraphAPI/src/main/java/org/gephi/graph/api/GraphFactory.java
@@ -55,12 +55,27 @@ public interface GraphFactory {
     public Node newNode();
 
     /**
+     * Create a new node, with default identifier and using a mass attribute update object to buffer consequent events.
+     * @param massUpdate mass update buffer object
+     * @return          a new node instance
+     */
+    public Node newNode(MassAttributeUpdate massUpdate);
+
+    /**
      * Create a new node with an identifier. If <code>id</code> is <code>null</code>
      * a default identifier is used.
      * @param id        a unique identifier, could be <code>null</code>
      * @return          a new node instance
      */
     public Node newNode(String id);
+
+    /**
+     * Create a new node, with default identifier and using a mass attribute update object to buffer consequent events.
+     * @param id        a unique identifier, could be <code>null</code>
+     * @param massUpdate mass update buffer object
+     * @return          a new node instance
+     */
+    public Node newNode(String id, MassAttributeUpdate massUpdate);
 
     /**
      * Create a new edge. This method don't force the type of edge (directed or

--- a/modules/GraphAPI/src/main/java/org/gephi/graph/api/MassAttributeUpdate.java
+++ b/modules/GraphAPI/src/main/java/org/gephi/graph/api/MassAttributeUpdate.java
@@ -1,0 +1,8 @@
+
+package org.gephi.graph.api;
+
+public interface MassAttributeUpdate {
+
+    public void close();
+
+}

--- a/modules/GraphAPI/src/main/java/org/gephi/graph/api/NodeData.java
+++ b/modules/GraphAPI/src/main/java/org/gephi/graph/api/NodeData.java
@@ -88,6 +88,13 @@ public interface NodeData extends Renderable, Attributable {
     public void setLabel(String label);
 
     /**
+     * Sets this node label, using optional <code>massUpdate</code> for event buffering.
+     * @param label         the label that is to be set as this node label
+     * @param massUpdate    mass-update bufffer object
+     */
+    public void setLabel(String label, MassAttributeUpdate massUpdate);
+
+    /**
      * Returns the string identifier of this node. This identifier can be set
      * by users, in contrario of {@link Node#getId()} which is set by the system.
      * <p>


### PR DESCRIPTION
Hi Gephi devs,

I'd like to present a patchset that drastically reduces the time taken to import CSV data into Gephi for potential inclusion. The motivation: some of my users like to work with large (10M+ records) data sets, but found that importing through the Data Laboratory Nodes table CSV import tool took an hour or more, consisting of 10 minutes reading the data and handling attribute events and the rest of the hour waiting for the GUI thread to clear its backlog of work. This patchset reduces that time by around 90% to around 3 or 4 minutes on my machine, and reduces CPU usage from ~300% to ~120%.

It only covers our particular use case, and there are certainly others (for example, it does not treat the edge table or other methods of data import, such as from a database); however, I have aimed to write principled code that can easily be generalised and extended as required to accelerate other cases. I have written against 0.8.2 since the Data Lab component is currently disabled in head, but the same patches will hopefully be useful there. I have also tried to write such that individual commits can be cherry-picked if you're not happy with the branch as a whole.

Per-patch summary of changes:

3cc05a3: Log uncaught exceptions in the CSV import thread (and other threads).

7dc2d26 and aae4e30: Disable the posting AWT refresh events during import. The receiving thread discarded them anyhow, and it cost a core running at 100% to handle the constant stream of events.

0ab5549: IndexedAttributeModel maintained maps of weak references to *other* weak references to the same object, for no obvious reason. They were time-consuming to create due to synchronisation per op and made GC very slow (I think it doesn't handle weakrefs very well). This is simply stubbed out.

b4a1ee4 and 2ae2987: Every node creation was making several GraphController::getModel calls (which involve synchronization) and GraphModel::getGraph calls (which allocate a wrapper *and* a weak reference). Switch to making these calls once per import, rather than once per row.

f34abfa, a0edc0f and a28f309: Introduce batching in communication between the import thread and the AttributeEventManager. These two threads were wasting a *lot* of time constantly fighting for the event LinkedBlockingQueue and the EventManager's mutex. Reduce the synchronisation frequency by introducing event batching: a MassAttributeUpdate object is created and passed to functions that generate attribute events (of course setValue, but also constructors and initialisation functions). The event queue is modified to carry arrays-of-events rather than events themselves. This may render the event compression mechanism redundant, but I have left it in place for now to simplify the changeset.

72c3ed8: Dramatically reduce the time spent drawing the data table by introducing a hacked variant of Netbeans' Outline table, which spends 10s of minutes calculating a column's preferred width when the table is large. This is a bit of a grim solution, as the relevant function cannot be customised easily; a cleaner solution requires a small patch to netbeans, for which I have filed a bug here: https://netbeans.org/bugzilla/show_bug.cgi?id=249864

Let me know what you think! Always happy to help adapt the changes and get them into a mergeable state.