### PR TITLE
Fix label outline in Preview

### DIFF
--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/EdgeLabelRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/EdgeLabelRenderer.java
@@ -220,17 +220,23 @@ public class EdgeLabelRenderer implements Renderer {
         float posX = x - fm.stringWidth(label) / 2f;
         float posY = y + fm.getAscent() / 2f;
 
+        Shape outlineGlyph = null;
+
         if (outlineSize > 0) {
             FontRenderContext frc = graphics.getFontRenderContext();
             GlyphVector gv = font.createGlyphVector(frc, label);
-            Shape glyph = gv.getOutline(posX, posY);
+            outlineGlyph = gv.getOutline(posX, posY);
             graphics.setColor(outlineColor);
             graphics.setStroke(new BasicStroke(outlineSize, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
-            graphics.draw(glyph);
+            graphics.draw(outlineGlyph);
         }
 
         graphics.setColor(color);
-        graphics.drawString(label, posX, posY);
+        if (null == outlineGlyph) {
+            graphics.drawString(label, posX, posY);
+        } else {
+            graphics.fill(outlineGlyph);
+        }
     }
 
     public void renderSVG(SVGTarget target, Edge edge, String label, float x, float y, Color color, float outlineSize, Color outlineColor) {

--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeLabelRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeLabelRenderer.java
@@ -195,9 +195,7 @@ public class NodeLabelRenderer implements Renderer {
         float posX = x - fm.stringWidth(label) / 2f;
         float posY = y + fm.getDescent();
 
-        FontRenderContext frc = graphics.getFontRenderContext();
-        GlyphVector gv = font.createGlyphVector(frc, label);
-        Shape glyph = gv.getOutline(posX, posY);
+        Shape outlineGlyph = null;
 
         //Box
         if (showBox) {
@@ -212,13 +210,20 @@ public class NodeLabelRenderer implements Renderer {
 
         //Outline
         if (outlineSize > 0) {
+            FontRenderContext frc = graphics.getFontRenderContext();
+            GlyphVector gv = font.createGlyphVector(frc, label);
+            outlineGlyph = gv.getOutline(posX, posY);
             graphics.setColor(outlineColor);
             graphics.setStroke(new BasicStroke(outlineSize, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
-            graphics.draw(glyph);
+            graphics.draw(outlineGlyph);
         }
 
         graphics.setColor(color);
-        graphics.fill(glyph);
+        if (null == outlineGlyph) {
+            graphics.drawString(label, posX, posY);
+        } else {
+            graphics.fill(outlineGlyph);
+        }
     }
 
     public void renderSVG(SVGTarget target, Node node, String label, float x, float y, int fontSize, Color color, float outlineSize, Color outlineColor, boolean showBox, Color boxColor) {

--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeLabelRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeLabelRenderer.java
@@ -195,6 +195,10 @@ public class NodeLabelRenderer implements Renderer {
         float posX = x - fm.stringWidth(label) / 2f;
         float posY = y + fm.getDescent();
 
+        FontRenderContext frc = graphics.getFontRenderContext();
+        GlyphVector gv = font.createGlyphVector(frc, label);
+        Shape glyph = gv.getOutline(posX, posY);
+
         //Box
         if (showBox) {
             graphics.setColor(boxColor);
@@ -208,16 +212,13 @@ public class NodeLabelRenderer implements Renderer {
 
         //Outline
         if (outlineSize > 0) {
-            FontRenderContext frc = graphics.getFontRenderContext();
-            GlyphVector gv = font.createGlyphVector(frc, label);
-            Shape glyph = gv.getOutline(posX, posY);
             graphics.setColor(outlineColor);
             graphics.setStroke(new BasicStroke(outlineSize, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
             graphics.draw(glyph);
         }
 
         graphics.setColor(color);
-        graphics.drawString(label, posX, posY);
+        graphics.fill(glyph);
     }
 
     public void renderSVG(SVGTarget target, Node node, String label, float x, float y, int fontSize, Color color, float outlineSize, Color outlineColor, boolean showBox, Color boxColor) {


### PR DESCRIPTION
This fixes both issue #654 (node label outline) and edge label outline.

Before:
![before](https://cloud.githubusercontent.com/assets/183685/10621250/e1ca8f9a-777f-11e5-88e0-610f3d391bf2.png)

After:
![after](https://cloud.githubusercontent.com/assets/183685/10621254/e452480c-777f-11e5-8f67-10649c8edc09.png)

