### PR TITLE
Compute the preview canvas size from the rendered elements

### DIFF
--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/G2DRenderTargetBuilder.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/G2DRenderTargetBuilder.java
@@ -42,15 +42,14 @@
 package org.gephi.preview;
 
 import java.awt.Color;
-import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
-import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.Transparency;
 import java.awt.geom.AffineTransform;
+import org.gephi.preview.api.CanvasSize;
 import org.gephi.preview.api.G2DTarget;
 import org.gephi.preview.api.PreviewController;
 import org.gephi.preview.api.PreviewModel;
@@ -162,7 +161,6 @@ public class G2DRenderTargetBuilder implements RenderTargetBuilder {
     public static class G2DGraphics {
 
         private final PreviewController previewController = Lookup.getDefault().lookup(PreviewController.class);
-        private PreviewModel model;
         private boolean inited;
         //Drawing
         private final Image image;
@@ -186,11 +184,11 @@ public class G2DRenderTargetBuilder implements RenderTargetBuilder {
             g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         }
 
-        public void refresh(PreviewModel previewModel, RenderTarget target) {
-            this.model = previewModel;
-            if (model != null) {
-                background = model.getProperties().getColorValue(PreviewProperty.BACKGROUND_COLOR);
-                initAppletLayout();
+        public void refresh(PreviewModel m, RenderTarget target) {
+            if (m != null) {
+                background = m.getProperties()
+                        .getColorValue(PreviewProperty.BACKGROUND_COLOR);
+                initAppletLayout(m);
 
                 g2.clearRect(0, 0, width, height);
                 g2.setTransform(new AffineTransform());
@@ -251,23 +249,22 @@ public class G2DRenderTargetBuilder implements RenderTargetBuilder {
          * Initializes the preview applet layout according to the graph's
          * dimension.
          */
-        private void initAppletLayout() {
+        private void initAppletLayout(PreviewModel m) {
 //            graphSheet.setMargin(MARGIN);
-            if (!inited && model != null && model.getDimensions() != null && model.getTopLeftPosition() != null) {
+            if (!inited) {
 
                 // initializes zoom
-                Dimension dimensions = model.getDimensions();
-                Point topLeftPostition = model.getTopLeftPosition();
-                Vector box = new Vector((float) dimensions.getWidth(), (float) dimensions.getHeight());
+                CanvasSize cs = m.getGraphicsCanvasSize();
+                Vector box = new Vector(cs.getWidth(), cs.getHeight());
                 float ratioWidth = width / box.x;
                 float ratioHeight = height / box.y;
                 scaling = ratioWidth < ratioHeight ? ratioWidth : ratioHeight;
 
                 // initializes move
                 Vector semiBox = Vector.div(box, 2);
-                Vector topLeftVector = new Vector((float) topLeftPostition.x, (float) topLeftPostition.y);
-                Vector center = new Vector(width / 2f, height / 2f);
-                Vector scaledCenter = Vector.add(topLeftVector, semiBox);
+                Vector topLeft = new Vector(cs.getX(), cs.getY());
+                Vector center = new Vector(width / 2F, height / 2F);
+                Vector scaledCenter = Vector.add(topLeft, semiBox);
                 trans.set(center);
                 trans.sub(scaledCenter);
 //            lastMove.set(trans);

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/PDFRenderTargetBuilder.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/PDFRenderTargetBuilder.java
@@ -42,11 +42,11 @@ Portions Copyrighted 2011 Gephi Consortium.
 package org.gephi.preview;
 
 import com.itextpdf.text.FontFactory;
-import com.itextpdf.text.Rectangle;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.PdfContentByte;
 
 import java.awt.geom.AffineTransform;
+import org.gephi.preview.api.CanvasSize;
 import org.gephi.preview.api.PDFTarget;
 import org.gephi.preview.api.PreviewModel;
 import org.gephi.preview.api.PreviewProperties;
@@ -60,40 +60,43 @@ import org.openide.util.lookup.ServiceProvider;
 
 /**
  * Default implementation to PDFRenderTargetBuilder.
- * 
+ *
  * @author Mathieu Bastian
  */
 @ServiceProvider(service = RenderTargetBuilder.class)
 public class PDFRenderTargetBuilder implements RenderTargetBuilder {
-    
+
     @Override
     public String getName() {
         return RenderTarget.PDF_TARGET;
     }
-    
+
     @Override
     public RenderTarget buildRenderTarget(PreviewModel previewModel) {
-        double width = previewModel.getDimensions().getWidth();
-        double height = previewModel.getDimensions().getHeight();
-        width = Math.max(1, width);
-        height = Math.max(1, height);
-        int topLeftX = previewModel.getTopLeftPosition().x;
-        int topLeftY = previewModel.getTopLeftPosition().y;
+        CanvasSize cs = previewModel.getGraphicsCanvasSize();
         PreviewProperties properties = previewModel.getProperties();
         float marginBottom = properties.getFloatValue(PDFTarget.MARGIN_BOTTOM);
         float marginLeft = properties.getFloatValue(PDFTarget.MARGIN_LEFT);
         float marginRight = properties.getFloatValue(PDFTarget.MARGIN_RIGHT);
         float marginTop = properties.getFloatValue(PDFTarget.MARGIN_TOP);
-        Rectangle pageSize = properties.getValue(PDFTarget.PAGESIZE);
+        com.itextpdf.text.Rectangle pageSize
+                = properties.getValue(PDFTarget.PAGESIZE);
         boolean landscape = properties.getBooleanValue(PDFTarget.LANDSCAPE);
         PdfContentByte cb = properties.getValue(PDFTarget.PDF_CONTENT_BYTE);
-        PDFRenderTargetImpl renderTarget = new PDFRenderTargetImpl(cb, width, height, topLeftX, topLeftY,
-                pageSize, marginLeft, marginRight, marginTop, marginBottom, landscape);
+        PDFRenderTargetImpl renderTarget = new PDFRenderTargetImpl(
+                cb,
+                cs,
+                pageSize,
+                marginLeft,
+                marginRight,
+                marginTop,
+                marginBottom,
+                landscape);
         return renderTarget;
     }
-    
+
     public static class PDFRenderTargetImpl extends AbstractRenderTarget implements PDFTarget {
-        
+
         private final PdfContentByte cb;
         private static boolean fontRegistered = false;
         //Parameters
@@ -102,10 +105,17 @@ public class PDFRenderTargetBuilder implements RenderTargetBuilder {
         private final float marginLeft;
         private final float marginRight;
         private final boolean landscape;
-        private final Rectangle pageSize;
-        
-        public PDFRenderTargetImpl(PdfContentByte cb, double width, double height, double topLeftX, double topLeftY,
-                Rectangle size, float marginLeft, float marginRight, float marginTop, float marginBottom, boolean landscape) {
+        private final com.itextpdf.text.Rectangle pageSize;
+
+        public PDFRenderTargetImpl(
+                PdfContentByte cb,
+                CanvasSize cs,
+                com.itextpdf.text.Rectangle size,
+                float marginLeft,
+                float marginRight,
+                float marginTop,
+                float marginBottom,
+                boolean landscape) {
             this.cb = cb;
             this.marginTop = marginTop;
             this.marginLeft = marginLeft;
@@ -113,35 +123,35 @@ public class PDFRenderTargetBuilder implements RenderTargetBuilder {
             this.marginRight = marginRight;
             this.pageSize = size;
             this.landscape = landscape;
-            
-            double centerX = topLeftX + width / 2;
-            double centerY = topLeftY + height / 2;
+
+            double centerX = cs.getX() + cs.getWidth() / 2;
+            double centerY = cs.getY() + cs.getHeight() / 2;
 
             //Transform
             double pageWidth = size.getWidth() - marginLeft - marginRight;
             double pageHeight = size.getHeight() - marginTop - marginBottom;
-            double ratioWidth = pageWidth / width;
-            double ratioHeight = pageHeight / height;
+            double ratioWidth = pageWidth / cs.getWidth();
+            double ratioHeight = pageHeight / cs.getHeight();
             double scale = (float) (ratioWidth < ratioHeight ? ratioWidth : ratioHeight);
             double translateX = (marginLeft + pageWidth / 2.) / scale;
             double translateY = (marginBottom + pageHeight / 2.) / scale;
             cb.transform(AffineTransform.getTranslateInstance(-centerX * scale, centerY * scale));
             cb.transform(AffineTransform.getScaleInstance(scale, scale));
             cb.transform(AffineTransform.getTranslateInstance(translateX, translateY));
-            
+
             FontFactory.register("/org/gephi/preview/fonts/LiberationSans.ttf", "ArialMT");
         }
-        
+
         @Override
         public PdfContentByte getContentByte() {
             return this.cb;
         }
-        
+
         @Override
         public BaseFont getBaseFont(java.awt.Font font) {
             try {
                 if (font != null) {
-                    BaseFont baseFont = null;
+                    BaseFont baseFont;
                     if (!font.getFontName().equals(FontFactory.COURIER)
                             && !font.getFontName().equals(FontFactory.COURIER_BOLD)
                             && !font.getFontName().equals(FontFactory.COURIER_OBLIQUE)
@@ -159,28 +169,28 @@ public class PDFRenderTargetBuilder implements RenderTargetBuilder {
                             && !font.getFontName().equals(FontFactory.COURIER_BOLD)
                             && !font.getFontName().equals(FontFactory.COURIER_BOLD)
                             && !font.getFontName().equals(FontFactory.COURIER_BOLD)) {
-                        
+
                         com.itextpdf.text.Font itextFont = FontFactory.getFont(font.getFontName(), BaseFont.IDENTITY_H, font.getSize(), font.getStyle());
                         baseFont = itextFont.getBaseFont();
                         if (baseFont == null && !PDFRenderTargetImpl.fontRegistered) {
-                            
+
                             if (progressTicket != null) {
                                 String displayName = progressTicket.getDisplayName();
                                 Progress.setDisplayName(progressTicket, NbBundle.getMessage(PDFRenderTargetImpl.class, "PDFRenderTargetImpl.font.registration"));
                                 registerFonts();
                                 Progress.setDisplayName(progressTicket, displayName);
                             }
-                            
+
                             itextFont = FontFactory.getFont(font.getFontName(), BaseFont.IDENTITY_H, font.getSize(), font.getStyle());
                             baseFont = itextFont.getBaseFont();
-                            
+
                             PDFRenderTargetImpl.fontRegistered = true;
                         }
                     } else {
                         com.itextpdf.text.Font itextFont = FontFactory.getFont(font.getFontName(), BaseFont.IDENTITY_H, font.getSize(), font.getStyle());
                         baseFont = itextFont.getBaseFont();
                     }
-                    
+
                     if (baseFont != null) {
                         return baseFont;
                     }
@@ -192,7 +202,7 @@ public class PDFRenderTargetBuilder implements RenderTargetBuilder {
             }
             return null;
         }
-        
+
         private void registerFonts() {
             FontFactory.registerDirectories();
             if (Utilities.isMac()) {
@@ -205,34 +215,34 @@ public class PDFRenderTargetBuilder implements RenderTargetBuilder {
                 FontFactory.registerDirectory(adobeFonts);
             }
         }
-        
+
         @Override
         public float getMarginBottom() {
             return marginBottom;
         }
-        
+
         @Override
         public float getMarginLeft() {
             return marginLeft;
         }
-        
+
         @Override
         public float getMarginRight() {
             return marginRight;
         }
-        
+
         @Override
         public float getMarginTop() {
             return marginTop;
         }
-        
+
         @Override
         public boolean isLandscape() {
             return landscape;
         }
-        
+
         @Override
-        public Rectangle getPageSize() {
+        public com.itextpdf.text.Rectangle getPageSize() {
             return pageSize;
         }
     }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/PreviewControllerImpl.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/PreviewControllerImpl.java
@@ -41,8 +41,6 @@
  */
 package org.gephi.preview;
 
-import java.awt.Dimension;
-import java.awt.Point;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import org.gephi.graph.api.*;
@@ -182,10 +180,6 @@ public class PreviewControllerImpl implements PreviewController {
             graphModel.destroyView(graph.getView());
         }
 
-        //Refresh dimensions
-        updateDimensions(previewModel, previewModel.getItems(Item.NODE));
-
-
         //Pre process renderers
         for (Renderer r : renderers) {
             r.preProcess(model);
@@ -200,42 +194,6 @@ public class PreviewControllerImpl implements PreviewController {
         }
 
         return false;
-    }
-
-    public void updateDimensions(PreviewModelImpl model, Item[] nodeItems) {
-        float margin = model.getProperties().getFloatValue(PreviewProperty.MARGIN);  //percentage
-        float topLeftX = 0f;
-        float topLeftY = 0f;
-        float bottomRightX = 0f;
-        float bottomRightY = 0f;
-
-        for (Item nodeItem : nodeItems) {
-            float x = (Float) nodeItem.getData("x");
-            float y = (Float) nodeItem.getData("y");
-            float s = ((Float) nodeItem.getData("size")) / 2f;
-
-            if (x - s < topLeftX) {
-                topLeftX = x - s;
-            }
-            if (y - s < topLeftY) {
-                topLeftY = y - s;
-            }
-            if (x + s > bottomRightX) {
-                bottomRightX = x + s;
-            }
-            if (y + s > bottomRightY) {
-                bottomRightY = y + s;
-            }
-        }
-
-        float marginWidth = (bottomRightX - topLeftX) * (margin / 100f);
-        float marginHeight = (bottomRightY - topLeftY) * (margin / 100f);
-        topLeftX -= marginWidth;
-        topLeftY -= marginHeight;
-        bottomRightX += marginWidth;
-        bottomRightY += marginHeight;
-        model.setDimensions(new Dimension((int) (bottomRightX - topLeftX), (int) (bottomRightY - topLeftY)));
-        model.setTopLeftPosition(new Point((int) topLeftX, (int) topLeftY));
     }
 
     @Override

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/PreviewModelImpl.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/PreviewModelImpl.java
@@ -41,7 +41,6 @@
  */
 package org.gephi.preview;
 
-import java.awt.Rectangle;
 import java.beans.PropertyEditorManager;
 import java.util.*;
 import java.util.Map.Entry;
@@ -274,23 +273,24 @@ public class PreviewModelImpl implements PreviewModel {
 
     @Override
     public CanvasSize getGraphicsCanvasSize() {
-        Rectangle.Float rect = new Rectangle.Float();
+        float x1 = Float.MAX_VALUE;
+        float y1 = Float.MAX_VALUE;
+        float x2 = Float.MIN_VALUE;
+        float y2 = Float.MIN_VALUE;
         for (Renderer r : getManagedEnabledRenderers()) {
             for (String type : getItemTypes()) {
                 for (Item item : getItems(type)) {
                     if (r.isRendererForitem(item, getProperties())) {
                         CanvasSize cs = r.getCanvasSize(item, getProperties());
-                        Rectangle.Float itemRect = new Rectangle.Float(
-                            cs.getX(),
-                            cs.getY(),
-                            cs.getWidth(),
-                            cs.getHeight());
-                        java.awt.geom.Rectangle2D.union(rect, itemRect, rect);
+                        x1 = Math.min(x1, cs.getX());
+                        y1 = Math.min(y1, cs.getY());
+                        x2 = Math.max(x2, cs.getMaxX());
+                        y2 = Math.max(y2, cs.getMaxY());
                     }
                 }
             }
         }
-        return new CanvasSize(rect.x, rect.y, rect.width, rect.height);
+        return new CanvasSize(x1, y1, x2 - x1, y2 - y1);
     }
 
     @Override

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/CanvasSize.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/CanvasSize.java
@@ -1,0 +1,114 @@
+/*
+ Copyright 2008-2011 Gephi
+ Authors : Jeremy Subtil
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s):
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+package org.gephi.preview.api;
+
+/**
+ * A canvas size, with a top left coordinate, a width and an heigth.
+ *
+ * @author Jeremy Subtil
+ */
+public class CanvasSize {
+
+    private final float x;
+    private final float y;
+    private final float width;
+    private final float height;
+
+    /**
+     * Constructor.
+     *
+     * @param x The x coordinate of the top left position
+     * @param y The y coordinate of the top left position
+     * @param width The canvas width
+     * @param height The canvas height
+     */
+    public CanvasSize(float x, float y, float width, float height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    /**
+     * Constructs the default <code>CanvasSize</code>, with both width and
+     * height equal to zero.
+     */
+    public CanvasSize() {
+        this(0F, 0F, 0F, 0F);
+    }
+
+    /**
+     * Return the x coordinate of the top left position.
+     *
+     * @return the x coordinate of the top left position
+     */
+    public float getX() {
+        return x;
+    }
+
+    /**
+     * Returns the y coordinate of the top left position.
+     *
+     * @return the y coordinate of the top left position
+     */
+    public float getY() {
+        return y;
+    }
+
+    /**
+     * Returs the canvas width.
+     *
+     * @return the canvas width
+     */
+    public float getWidth() {
+        return width;
+    }
+
+    /**
+     * Returs the canvas height.
+     *
+     * @return the canvas height
+     */
+    public float getHeight() {
+        return height;
+    }
+}

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/CanvasSize.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/CanvasSize.java
@@ -77,7 +77,7 @@ public class CanvasSize {
     }
 
     /**
-     * Return the x coordinate of the top left position.
+     * Returns the x coordinate of the top left position.
      *
      * @return the x coordinate of the top left position
      */
@@ -95,7 +95,7 @@ public class CanvasSize {
     }
 
     /**
-     * Returs the canvas width.
+     * Returns the canvas width.
      *
      * @return the canvas width
      */
@@ -104,11 +104,29 @@ public class CanvasSize {
     }
 
     /**
-     * Returs the canvas height.
+     * Returns the canvas height.
      *
      * @return the canvas height
      */
     public float getHeight() {
         return height;
+    }
+
+    /**
+     * Returns the x coordinate of the bottom right position.
+     *
+     * @return the x coordinate of the bottom right position
+     */
+    public float getMaxX() {
+        return getX() + getWidth();
+    }
+
+    /**
+     * Returns the y coordinate of the bottom right position.
+     *
+     * @return the y coordinate of the bottom right position
+     */
+    public float getMaxY() {
+        return getY() + getHeight();
     }
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewModel.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewModel.java
@@ -41,8 +41,6 @@
  */
 package org.gephi.preview.api;
 
-import java.awt.Dimension;
-import java.awt.Point;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.Node;
@@ -137,16 +135,9 @@ public interface PreviewModel {
     public PreviewMouseListener[] getEnabledMouseListeners();
 
     /**
-     * Returns the width and height of the graph in the graph coordinates.
+     * Computes the graphics canvas size.
      *
-     * @return the graph dimensions
+     * @return the graphics canvas size
      */
-    public Dimension getDimensions();
-
-    /**
-     * Returns the top left position in the graph coordinate (i.e. not the preview coordinates).
-     *
-     * @return the top left position point
-     */
-    public Point getTopLeftPosition();
+    public CanvasSize getGraphicsCanvasSize();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/Renderer.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/Renderer.java
@@ -61,7 +61,7 @@ import org.gephi.preview.api.*;
  * <code>render()</code> which is called many times.</li>
  * <li>The <code>isRendererForitem()</code> is then used to determine which renderer
  * should be used to render an item. The method provides an access to the preview
- * properties. For instance, if the properties says the edge display is disabled, 
+ * properties. For instance, if the properties says the edge display is disabled,
  * the edge renderer should return <code>false</code> for every item. Note that
  * nothing avoids several renderer to returns <code>true</code> for the same item.</li>
  * <li>The <code>render()</code> method is finally called for every item which
@@ -99,7 +99,7 @@ import org.gephi.preview.api.*;
  * @author Yudi Xue, Mathieu Bastian
  */
 public interface Renderer {
-    
+
     /**
      * Provides an user friendly name for the renderer.
      * This name will appear in the renderers manager UI.
@@ -109,14 +109,14 @@ public interface Renderer {
 
     /**
      * This method is called before rendering for all renderers and initializes
-     * items' additional attributes or run complex algorithms. 
+     * items' additional attributes or run complex algorithms.
      * <p>
      * This method has access to any item using the <code>getItems()</code> methods
      * of the preview model.
      * <p>
-     * No data should be stored in the renderer itself but put in items using 
+     * No data should be stored in the renderer itself but put in items using
      * {@link Item#setData(java.lang.String, java.lang.Object)}. Global states can
-     * be stored in properties using 
+     * be stored in properties using
      * {@link PreviewProperties#putValue(java.lang.String, java.lang.Object)}.
      * @param previewModel the model to get items from
      */
@@ -126,25 +126,25 @@ public interface Renderer {
      * Render <code>item</code> to <code>target</code> using the global properties
      * and item data.
      * <p>
-     * The target can be one of the default target {@link G2DTarget}, 
-     * {@link SVGTarget} or {@link PDFTarget}. Each target contains an access to 
+     * The target can be one of the default target {@link G2DTarget},
+     * {@link SVGTarget} or {@link PDFTarget}. Each target contains an access to
      * it's drawing canvas so the renderer can draw visual items.
      * @param item the item to be rendered
      * @param target the target to render the item on
      * @param properties the central properties
      */
     public void render(Item item, RenderTarget target, PreviewProperties properties);
-    
+
     /**
      * Returns all associated properties for this renderer. Properties can be built
-     * using static <code>PreviewProperty.createProperty()</code> methods. 
-     * 
+     * using static <code>PreviewProperty.createProperty()</code> methods.
+     *
      * @return a properties array
      */
     public PreviewProperty[] getProperties();
 
     /**
-     * Based on <code>properties</code>, determine whether this renderer is 
+     * Based on <code>properties</code>, determine whether this renderer is
      * valid to render <code>Item</code>.
      * <p>
      * Additional states in <code>properties</code> helps to make a decision,
@@ -161,7 +161,7 @@ public interface Renderer {
      * renderer, <code>false</code> otherwise
      */
     public boolean isRendererForitem(Item item, PreviewProperties properties);
-    
+
     /**
      * Based on the <code>itemBuilder</code> class and the <code>properties</code>,
      * determine whether this renderer needs the given <code>itemBuilder</code> to be
@@ -172,7 +172,7 @@ public interface Renderer {
      * You can simply return true if the builder builds items that this renderer renders,
      * but you can also check the current properties to see if your renderer is going to produce any graphic.
      * <p>
-     * 
+     *
      * Additional states in <code>properties</code> helps to make a decision,
      * including:
      * <ul>
@@ -182,8 +182,21 @@ public interface Renderer {
      * other than the node renderer usually render nothing while the user is moving
      * to speeds things up.</li></ul>
      * @param itemBuilder builder that your renderer may need
-     * @param properties Current properties
+     * @param properties the current properties
      * @return <code>true</code> if you are going to use built items for rendering, <code>false</code> otherwise
      */
     public boolean needsItemBuilder(ItemBuilder itemBuilder, PreviewProperties properties);
+
+    /**
+     * Compute the canvas size of the item to render.
+     *
+     * The returned <code>CanvasSize</code> has to embed the whole item to
+     * render. If the canvas size cannot be computed, a <code>CanvasSize</code>
+     * with both width and height equlal to zero is returned.
+     *
+     * @param item the item to get the canvas size
+     * @param properties the current properties
+     * @return the item canvas size
+     */
+    public CanvasSize getCanvasSize(Item item, PreviewProperties properties);
 }

--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/EdgeLabelRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/EdgeLabelRenderer.java
@@ -44,7 +44,12 @@ package org.gephi.preview.plugin.renderers;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfGState;
-import java.awt.*;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Shape;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import org.gephi.graph.api.Edge;
@@ -209,6 +214,14 @@ public class EdgeLabelRenderer implements Renderer {
         } else if (target instanceof PDFTarget) {
             renderPDF(((PDFTarget) target), label, x, y, color, outlineSize, outlineColor);
         }
+    }
+
+    @Override
+    public CanvasSize getCanvasSize(
+            final Item item,
+            final PreviewProperties properties) {
+        //FIXME Compute the label canvas
+        return new CanvasSize();
     }
 
     public void renderG2D(G2DTarget target, String label, float x, float y, Color color, float outlineSize, Color outlineColor) {

--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/EdgeRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/EdgeRenderer.java
@@ -89,18 +89,25 @@ public class EdgeRenderer implements Renderer {
     protected int defaultOpacity = 100;
     protected float defaultRadius = 0f;
 
+    private static final StraightEdgeRenderer STRAIGHT_RENDERER
+            = new StraightEdgeRenderer();
+    private static final CurvedEdgeRenderer CURVED_RENDERER
+            = new CurvedEdgeRenderer();
+    private static final SelfLoopEdgeRenderer SELF_LOOP_RENDERER
+            = new SelfLoopEdgeRenderer();
+
     @Override
     public void preProcess(PreviewModel previewModel) {
-        PreviewProperties properties = previewModel.getProperties();
-        Item[] edgeItems = previewModel.getItems(Item.EDGE);
+        final PreviewProperties properties = previewModel.getProperties();
+        final Item[] edgeItems = previewModel.getItems(Item.EDGE);
 
         //Put nodes in edge item
-        for (Item item : edgeItems) {
-            Edge edge = (Edge) item.getSource();
-            Node source = edge.getSource();
-            Node target = edge.getTarget();
-            Item nodeSource = previewModel.getItem(Item.NODE, source);
-            Item nodeTarget = previewModel.getItem(Item.NODE, target);
+        for (final Item item : edgeItems) {
+            final Edge edge = (Edge) item.getSource();
+            final Node source = edge.getSource();
+            final Node target = edge.getTarget();
+            final Item nodeSource = previewModel.getItem(Item.NODE, source);
+            final Item nodeTarget = previewModel.getItem(Item.NODE, target);
             item.setData(SOURCE, nodeSource);
             item.setData(TARGET, nodeTarget);
         }
@@ -110,8 +117,12 @@ public class EdgeRenderer implements Renderer {
         double maxWeight = Double.NEGATIVE_INFINITY;
 
         for (Item edge : edgeItems) {
-            minWeight = Math.min(minWeight, (Double) edge.getData(EdgeItem.WEIGHT));
-            maxWeight = Math.max(maxWeight, (Double) edge.getData(EdgeItem.WEIGHT));
+            minWeight = Math.min(
+                    minWeight,
+                    (Double) edge.getData(EdgeItem.WEIGHT));
+            maxWeight = Math.max(
+                    maxWeight,
+                    (Double) edge.getData(EdgeItem.WEIGHT));
         }
         properties.putValue(EDGE_MIN_WEIGHT, minWeight);
         properties.putValue(EDGE_MAX_WEIGHT, maxWeight);
@@ -122,14 +133,17 @@ public class EdgeRenderer implements Renderer {
         }
 
         //Rescale weight if necessary - and avoid negative weights
-        boolean rescaleWeight = properties.getBooleanValue(PreviewProperty.EDGE_RESCALE_WEIGHT);
-        for (Item item : edgeItems) {
+        final boolean rescaleWeight = properties.getBooleanValue(
+                PreviewProperty.EDGE_RESCALE_WEIGHT);
+        for (final Item item : edgeItems) {
             double weight = (Double) item.getData(EdgeItem.WEIGHT);
 
             //Rescale weight
             if (rescaleWeight) {
-                if (!Double.isInfinite(minWeight) && !Double.isInfinite(maxWeight) && maxWeight != minWeight) {
-                    double ratio = 1.0 / (maxWeight - minWeight);
+                if (!Double.isInfinite(minWeight)
+                        && !Double.isInfinite(maxWeight)
+                        && maxWeight != minWeight) {
+                    final double ratio = 1.0 / (maxWeight - minWeight);
                     weight = (weight - minWeight) * ratio;
                 }
             } else if (minWeight <= 0) {
@@ -142,27 +156,35 @@ public class EdgeRenderer implements Renderer {
         }
 
         //Radius
-        for (Item item : edgeItems) {
+        for (final Item item : edgeItems) {
             if (!(Boolean) item.getData(EdgeItem.SELF_LOOP)) {
-                float edgeRadius = properties.getFloatValue(PreviewProperty.EDGE_RADIUS);
-                float targetRadius = 0;
-                if ((Boolean) item.getData(EdgeItem.DIRECTED) || edgeRadius > 0f) {
+                final float edgeRadius
+                        = properties.getFloatValue(PreviewProperty.EDGE_RADIUS);
+                if ((Boolean) item.getData(EdgeItem.DIRECTED)
+                        || edgeRadius > 0F) {
                     //Target
-                    Item targetItem = (Item) item.getData(TARGET);
-                    Double weight = item.getData(EdgeItem.WEIGHT);
+                    final Item targetItem = (Item) item.getData(TARGET);
+                    final Double weight = item.getData(EdgeItem.WEIGHT);
                     //Avoid negative arrow size:
-                    float arrowSize = properties.getFloatValue(PreviewProperty.ARROW_SIZE);
-                    if (arrowSize < 0) {
-                        arrowSize = 0;
+                    float arrowSize = properties.getFloatValue(
+                            PreviewProperty.ARROW_SIZE);
+                    if (arrowSize < 0F) {
+                        arrowSize = 0F;
                     }
-                    float size = arrowSize * weight.floatValue();
-                    targetRadius = -(edgeRadius + (Float) targetItem.getData(NodeItem.SIZE) / 2f + properties.getFloatValue(PreviewProperty.NODE_BORDER_WIDTH));
+                    final float size = arrowSize * weight.floatValue();
+                    final float targetRadius = -(edgeRadius
+                            + (Float) targetItem.getData(NodeItem.SIZE) / 2F
+                            + properties.getFloatValue(
+                                    PreviewProperty.NODE_BORDER_WIDTH));
                     item.setData(TARGET_RADIUS, targetRadius - size);
                 }
                 if (edgeRadius > 0) {
                     //Source
-                    Item sourceItem = (Item) item.getData(SOURCE);
-                    float sourceRadius = -(edgeRadius + (Float) sourceItem.getData(NodeItem.SIZE) / 2f + properties.getFloatValue(PreviewProperty.NODE_BORDER_WIDTH));
+                    final Item sourceItem = (Item) item.getData(SOURCE);
+                    final float sourceRadius = -(edgeRadius
+                            + (Float) sourceItem.getData(NodeItem.SIZE) / 2f
+                            + properties.getFloatValue(
+                                    PreviewProperty.NODE_BORDER_WIDTH));
                     item.setData(SOURCE_RADIUS, sourceRadius);
                 }
             }
@@ -170,227 +192,27 @@ public class EdgeRenderer implements Renderer {
     }
 
     @Override
-    public void render(Item item, RenderTarget target, PreviewProperties properties) {
-        //Get nodes
-        Item sourceItem = item.getData(SOURCE);
-        Item targetItem = item.getData(TARGET);
-
-        //Weight and color
-        Double weight = item.getData(EdgeItem.WEIGHT);
-        EdgeColor edgeColor = (EdgeColor) properties.getValue(PreviewProperty.EDGE_COLOR);
-        Color color = edgeColor.getColor((Color) item.getData(EdgeItem.COLOR),
-                (Color) sourceItem.getData(NodeItem.COLOR),
-                (Color) targetItem.getData(NodeItem.COLOR));
-        int alpha = (int) ((properties.getIntValue(PreviewProperty.EDGE_OPACITY) / 100f) * 255f);
-        color = new Color(color.getRed(), color.getGreen(), color.getBlue(), alpha);
-
-        if (sourceItem == targetItem) {
-            renderSelfLoop(sourceItem, weight.floatValue(), color, properties, target);
+    public void render(
+            Item item,
+            RenderTarget target,
+            PreviewProperties properties) {
+        if (isSelfLoopEdge(item)) {
+            SELF_LOOP_RENDERER.render(item, target, properties);
         } else if (properties.getBooleanValue(PreviewProperty.EDGE_CURVED)) {
-            renderCurvedEdge(item, sourceItem, targetItem, weight.floatValue(), color, properties, target);
+            CURVED_RENDERER.render(item, target, properties);
         } else {
-            renderStraightEdge(item, sourceItem, targetItem, weight.floatValue(), color, properties, target);
+            STRAIGHT_RENDERER.render(item, target, properties);
         }
     }
 
-    public void renderSelfLoop(Item nodeItem, float thickness, Color color, PreviewProperties properties, RenderTarget renderTarget) {
-        Float x = nodeItem.getData(NodeItem.X);
-        Float y = nodeItem.getData(NodeItem.Y);
-        Float size = nodeItem.getData(NodeItem.SIZE);
-        Node node = (Node) nodeItem.getSource();
-
-        Vector v1 = new Vector(x, y);
-        v1.add(size, -size);
-
-        Vector v2 = new Vector(x, y);
-        v2.add(size, size);
-
-        if (renderTarget instanceof G2DTarget) {
-            Graphics2D graphics = ((G2DTarget) renderTarget).getGraphics();
-
-            graphics.setStroke(new BasicStroke(thickness));
-            graphics.setColor(color);
-            GeneralPath gp = new GeneralPath(GeneralPath.WIND_NON_ZERO);
-            gp.moveTo(x, y);
-            gp.curveTo(v1.x, v1.y, v1.x, v2.y, x, y);
-            graphics.draw(gp);
-
-        } else if (renderTarget instanceof SVGTarget) {
-            SVGTarget svgTarget = (SVGTarget) renderTarget;
-
-            Element selfLoopElem = svgTarget.createElement("path");
-            selfLoopElem.setAttribute("d", String.format(Locale.ENGLISH, "M %f,%f C %f,%f %f,%f %f,%f",
-                    x, y, v1.x, v1.y, v2.x, v2.y, x, y));
-            selfLoopElem.setAttribute("class", node.getId().toString());
-            selfLoopElem.setAttribute("stroke", svgTarget.toHexString(color));
-            selfLoopElem.setAttribute("stroke-opacity", (color.getAlpha() / 255f) + "");
-            selfLoopElem.setAttribute("stroke-width", Float.toString(thickness * svgTarget.getScaleRatio()));
-            selfLoopElem.setAttribute("fill", "none");
-            svgTarget.getTopElement(SVGTarget.TOP_EDGES).appendChild(selfLoopElem);
-        } else if (renderTarget instanceof PDFTarget) {
-            PDFTarget pdfTarget = (PDFTarget) renderTarget;
-            PdfContentByte cb = pdfTarget.getContentByte();
-            cb.moveTo(x, -y);
-            cb.curveTo(v1.x, -v1.y, v2.x, -v2.y, x, -y);
-            cb.setRGBColorStroke(color.getRed(), color.getGreen(), color.getBlue());
-            cb.setLineWidth(thickness);
-            if (color.getAlpha() < 255) {
-                cb.saveState();
-                float alpha = color.getAlpha() / 255f;
-                PdfGState gState = new PdfGState();
-                gState.setStrokeOpacity(alpha);
-                cb.setGState(gState);
-            }
-            cb.stroke();
-            if (color.getAlpha() < 255) {
-                cb.restoreState();
-            }
-        }
-    }
-
-    public void renderCurvedEdge(Item edgeItem, Item sourceItem, Item targetItem, float thickness, Color color, PreviewProperties properties, RenderTarget renderTarget) {
-        Edge edge = (Edge) edgeItem.getSource();
-        Float x1 = sourceItem.getData(NodeItem.X);
-        Float x2 = targetItem.getData(NodeItem.X);
-        Float y1 = sourceItem.getData(NodeItem.Y);
-        Float y2 = targetItem.getData(NodeItem.Y);
-
-        //Curved edgs
-        Vector direction = new Vector(x2, y2);
-        direction.sub(new Vector(x1, y1));
-        float length = direction.mag();
-        direction.normalize();
-
-        float factor = properties.getFloatValue(BEZIER_CURVENESS) * length;
-
-        // normal vector to the edge
-        Vector n = new Vector(direction.y, -direction.x);
-        n.mult(factor);
-
-        // first control point
-        Vector v1 = new Vector(direction.x, direction.y);
-        v1.mult(factor);
-        v1.add(new Vector(x1, y1));
-        v1.add(n);
-
-        // second control point
-        Vector v2 = new Vector(direction.x, direction.y);
-        v2.mult(-factor);
-        v2.add(new Vector(x2, y2));
-        v2.add(n);
-
-        if (renderTarget instanceof G2DTarget) {
-            Graphics2D graphics = ((G2DTarget) renderTarget).getGraphics();
-
-            graphics.setStroke(new BasicStroke(thickness));
-            graphics.setColor(color);
-            GeneralPath gp = new GeneralPath(GeneralPath.WIND_NON_ZERO);
-            gp.moveTo(x1, y1);
-            gp.curveTo(v1.x, v1.y, v2.x, v2.y, x2, y2);
-            graphics.draw(gp);
-
-        } else if (renderTarget instanceof SVGTarget) {
-            SVGTarget svgTarget = (SVGTarget) renderTarget;
-            Element edgeElem = svgTarget.createElement("path");
-            edgeElem.setAttribute("class", edge.getSource().getId() + " " + edge.getTarget().getId());
-            edgeElem.setAttribute("d", String.format(Locale.ENGLISH, "M %f,%f C %f,%f %f,%f %f,%f",
-                    x1, y1, v1.x, v1.y, v2.x, v2.y, x2, y2));
-            edgeElem.setAttribute("stroke", svgTarget.toHexString(color));
-            edgeElem.setAttribute("stroke-width", Float.toString(thickness * svgTarget.getScaleRatio()));
-            edgeElem.setAttribute("stroke-opacity", (color.getAlpha() / 255f) + "");
-            edgeElem.setAttribute("fill", "none");
-            svgTarget.getTopElement(SVGTarget.TOP_EDGES).appendChild(edgeElem);
-        } else if (renderTarget instanceof PDFTarget) {
-            PDFTarget pdfTarget = (PDFTarget) renderTarget;
-            PdfContentByte cb = pdfTarget.getContentByte();
-            cb.moveTo(x1, -y1);
-            cb.curveTo(v1.x, -v1.y, v2.x, -v2.y, x2, -y2);
-            cb.setRGBColorStroke(color.getRed(), color.getGreen(), color.getBlue());
-            cb.setLineWidth(thickness);
-            if (color.getAlpha() < 255) {
-                cb.saveState();
-                float alpha = color.getAlpha() / 255f;
-                PdfGState gState = new PdfGState();
-                gState.setStrokeOpacity(alpha);
-                cb.setGState(gState);
-            }
-            cb.stroke();
-            if (color.getAlpha() < 255) {
-                cb.restoreState();
-            }
-        }
-    }
-
-    public void renderStraightEdge(Item edgeItem, Item sourceItem, Item targetItem, float thickness, Color color, PreviewProperties properties, RenderTarget renderTarget) {
-        Edge edge = (Edge) edgeItem.getSource();
-        Float x1 = sourceItem.getData(NodeItem.X);
-        Float x2 = targetItem.getData(NodeItem.X);
-        Float y1 = sourceItem.getData(NodeItem.Y);
-        Float y2 = targetItem.getData(NodeItem.Y);
-
-        //Target radius - to start at the base of the arrow
-        Float targetRadius = edgeItem.getData(TARGET_RADIUS);
-        //Avoid edge from passing the node's center:
-        if (targetRadius != null && targetRadius < 0) {
-            Vector direction = new Vector(x2, y2);
-            direction.sub(new Vector(x1, y1));
-            direction.normalize();
-            direction = new Vector(direction.x, direction.y);
-            direction.mult(targetRadius);
-            direction.add(new Vector(x2, y2));
-            x2 = direction.x;
-            y2 = direction.y;
-        }
-        //Source radius
-        Float sourceRadius = edgeItem.getData(SOURCE_RADIUS);
-        //Avoid edge from passing the node's center:
-        if (sourceRadius != null && sourceRadius < 0) {
-            Vector direction = new Vector(x1, y1);
-            direction.sub(new Vector(x2, y2));
-            direction.normalize();
-            direction = new Vector(direction.x, direction.y);
-            direction.mult(sourceRadius);
-            direction.add(new Vector(x1, y1));
-            x1 = direction.x;
-            y1 = direction.y;
-        }
-
-        if (renderTarget instanceof G2DTarget) {
-            Graphics2D graphics = ((G2DTarget) renderTarget).getGraphics();
-            graphics.setStroke(new BasicStroke(thickness, BasicStroke.CAP_SQUARE, BasicStroke.JOIN_MITER));
-            graphics.setColor(color);
-            Line2D.Float line = new Line2D.Float(x1, y1, x2, y2);
-            graphics.draw(line);
-        } else if (renderTarget instanceof SVGTarget) {
-            SVGTarget svgTarget = (SVGTarget) renderTarget;
-            Element edgeElem = svgTarget.createElement("path");
-            edgeElem.setAttribute("class", edge.getSource().getId() + " " + edge.getTarget().getId());
-            edgeElem.setAttribute("d", String.format(Locale.ENGLISH, "M %f,%f L %f,%f",
-                    x1, y1, x2, y2));
-            edgeElem.setAttribute("stroke", svgTarget.toHexString(color));
-            DecimalFormat df = new DecimalFormat("#.########");
-            edgeElem.setAttribute("stroke-width", df.format(thickness * svgTarget.getScaleRatio()));
-            edgeElem.setAttribute("stroke-opacity", (color.getAlpha() / 255f) + "");
-            edgeElem.setAttribute("fill", "none");
-            svgTarget.getTopElement(SVGTarget.TOP_EDGES).appendChild(edgeElem);
-        } else if (renderTarget instanceof PDFTarget) {
-            PDFTarget pdfTarget = (PDFTarget) renderTarget;
-            PdfContentByte cb = pdfTarget.getContentByte();
-            cb.moveTo(x1, -y1);
-            cb.lineTo(x2, -y2);
-            cb.setRGBColorStroke(color.getRed(), color.getGreen(), color.getBlue());
-            cb.setLineWidth(thickness);
-            if (color.getAlpha() < 255) {
-                cb.saveState();
-                float alpha = color.getAlpha() / 255f;
-                PdfGState gState = new PdfGState();
-                gState.setStrokeOpacity(alpha);
-                cb.setGState(gState);
-            }
-            cb.stroke();
-            if (color.getAlpha() < 255) {
-                cb.restoreState();
-            }
+    @Override
+    public CanvasSize getCanvasSize(Item item, PreviewProperties properties) {
+        if (isSelfLoopEdge(item)) {
+            return SELF_LOOP_RENDERER.getCanvasSize(item, properties);
+        } else if (properties.getBooleanValue(PreviewProperty.EDGE_CURVED)) {
+            return CURVED_RENDERER.getCanvasSize(item, properties);
+        } else {
+            return STRAIGHT_RENDERER.getCanvasSize(item, properties);
         }
     }
 
@@ -427,11 +249,6 @@ public class EdgeRenderer implements Renderer {
             PreviewProperty.CATEGORY_EDGES, PreviewProperty.SHOW_EDGES).setValue(defaultRadius),};
     }
 
-    private boolean showEdges(PreviewProperties properties) {
-        return properties.getBooleanValue(PreviewProperty.SHOW_EDGES)
-                && !properties.getBooleanValue(PreviewProperty.MOVING);
-    }
-
     @Override
     public boolean isRendererForitem(Item item, PreviewProperties properties) {
         if (item instanceof EdgeItem) {
@@ -442,11 +259,417 @@ public class EdgeRenderer implements Renderer {
 
     @Override
     public boolean needsItemBuilder(ItemBuilder itemBuilder, PreviewProperties properties) {
-        return (itemBuilder instanceof EdgeBuilder || itemBuilder instanceof NodeBuilder) && showEdges(properties);//Needs some properties of nodes
+        return (itemBuilder instanceof EdgeBuilder
+                || itemBuilder instanceof NodeBuilder)
+                && showEdges(properties);//Needs some properties of nodes
     }
 
     @Override
     public String getDisplayName() {
         return NbBundle.getMessage(EdgeRenderer.class, "EdgeRenderer.name");
+    }
+
+    public static Color getColor(
+            final Item item,
+            final PreviewProperties properties) {
+        final Item sourceItem = item.getData(SOURCE);
+        final Item targetItem = item.getData(TARGET);
+        final EdgeColor edgeColor
+                = (EdgeColor) properties.getValue(PreviewProperty.EDGE_COLOR);
+        final Color color = edgeColor.getColor(
+                (Color) item.getData(EdgeItem.COLOR),
+                (Color) sourceItem.getData(NodeItem.COLOR),
+                (Color) targetItem.getData(NodeItem.COLOR));
+        return new Color(
+                color.getRed(),
+                color.getGreen(),
+                color.getBlue(),
+                (int) getAlpha(properties) * 255);
+    }
+
+    private boolean showEdges(PreviewProperties properties) {
+        return properties.getBooleanValue(PreviewProperty.SHOW_EDGES)
+                && !properties.getBooleanValue(PreviewProperty.MOVING);
+    }
+
+    private static boolean isSelfLoopEdge(final Item item) {
+        final Item sourceItem = item.getData(SOURCE);
+        final Item targetItem = item.getData(TARGET);
+        return item instanceof EdgeItem && sourceItem == targetItem;
+    }
+
+    private static float getAlpha(final PreviewProperties properties) {
+        return properties.getIntValue(PreviewProperty.EDGE_OPACITY) / 100F;
+    }
+
+    private static float getThickness(final Item item) {
+        return ((Double) item.getData(EdgeItem.WEIGHT)).floatValue();
+    }
+
+    private static class StraightEdgeRenderer {
+
+        public void render(
+                final Item item,
+                final RenderTarget target,
+                final PreviewProperties properties) {
+            final Helper h = new Helper(item);
+            final Color color = getColor(item, properties);
+
+            if (target instanceof G2DTarget) {
+                final Graphics2D graphics = ((G2DTarget) target).getGraphics();
+                graphics.setStroke(new BasicStroke(
+                        getThickness(item),
+                        BasicStroke.CAP_SQUARE,
+                        BasicStroke.JOIN_MITER));
+                graphics.setColor(color);
+                final Line2D.Float line
+                        = new Line2D.Float(h.x1, h.y1, h.x2, h.y2);
+                graphics.draw(line);
+            } else if (target instanceof SVGTarget) {
+                final SVGTarget svgTarget = (SVGTarget) target;
+                final Element edgeElem = svgTarget.createElement("path");
+                edgeElem.setAttribute("class", String.format(
+                        "%s %s",
+                        ((Node) h.sourceItem.getSource()).getId(),
+                        ((Node) h.targetItem.getSource()).getId()));
+                edgeElem.setAttribute("d", String.format(
+                        Locale.ENGLISH,
+                        "M %f,%f L %f,%f",
+                        h.x1, h.y1, h.x2, h.y2));
+                edgeElem.setAttribute("stroke", svgTarget.toHexString(color));
+                final DecimalFormat df = new DecimalFormat("#.########");
+                edgeElem.setAttribute(
+                        "stroke-width",
+                        df.format(getThickness(item)
+                                * svgTarget.getScaleRatio()));
+                edgeElem.setAttribute(
+                        "stroke-opacity",
+                        (color.getAlpha() / 255f) + "");
+                edgeElem.setAttribute("fill", "none");
+                svgTarget.getTopElement(SVGTarget.TOP_EDGES)
+                        .appendChild(edgeElem);
+            } else if (target instanceof PDFTarget) {
+                final PDFTarget pdfTarget = (PDFTarget) target;
+                final PdfContentByte cb = pdfTarget.getContentByte();
+                cb.moveTo(h.x1, -h.y1);
+                cb.lineTo(h.x2, -h.y2);
+                cb.setRGBColorStroke(
+                        color.getRed(),
+                        color.getGreen(),
+                        color.getBlue());
+                cb.setLineWidth(getThickness(item));
+                if (color.getAlpha() < 255) {
+                    cb.saveState();
+                    final PdfGState gState = new PdfGState();
+                    gState.setStrokeOpacity(
+                            getAlpha(properties));
+                    cb.setGState(gState);
+                }
+                cb.stroke();
+                if (color.getAlpha() < 255) {
+                    cb.restoreState();
+                }
+            }
+        }
+
+        public CanvasSize getCanvasSize(
+                final Item item,
+                final PreviewProperties properties) {
+            final Item sourceItem = item.getData(SOURCE);
+            final Item targetItem = item.getData(TARGET);
+            final Float x1 = sourceItem.getData(NodeItem.X);
+            final Float x2 = targetItem.getData(NodeItem.X);
+            final Float y1 = sourceItem.getData(NodeItem.Y);
+            final Float y2 = targetItem.getData(NodeItem.Y);
+            final float minX = Math.min(x1, x2);
+            final float minY = Math.min(y1, y2);
+            final float maxX = Math.max(x1, x2);
+            final float maxY = Math.max(y1, y2);
+            return new CanvasSize(minX, minY, maxX - minX, maxY - minY);
+        }
+
+        private class Helper {
+
+            public final Item sourceItem;
+            public final Item targetItem;
+            public final Float x1;
+            public final Float x2;
+            public final Float y1;
+            public final Float y2;
+
+            public Helper(final Item item) {
+                sourceItem = item.getData(SOURCE);
+                targetItem = item.getData(TARGET);
+
+                Float _x1 = sourceItem.getData(NodeItem.X);
+                Float _x2 = targetItem.getData(NodeItem.X);
+                Float _y1 = sourceItem.getData(NodeItem.Y);
+                Float _y2 = targetItem.getData(NodeItem.Y);
+
+                //Target radius - to start at the base of the arrow
+                final Float targetRadius = item.getData(TARGET_RADIUS);
+                //Avoid edge from passing the node's center:
+                if (targetRadius != null && targetRadius < 0) {
+                    Vector direction = new Vector(_x2, _y2);
+                    direction.sub(new Vector(_x1, _y1));
+                    direction.normalize();
+                    direction = new Vector(direction.x, direction.y);
+                    direction.mult(targetRadius);
+                    direction.add(new Vector(_x2, _y2));
+                    _x2 = direction.x;
+                    _y2 = direction.y;
+                }
+
+                //Source radius
+                final Float sourceRadius = item.getData(SOURCE_RADIUS);
+                //Avoid edge from passing the node's center:
+                if (sourceRadius != null && sourceRadius < 0) {
+                    Vector direction = new Vector(_x1, _y1);
+                    direction.sub(new Vector(_x2, _y2));
+                    direction.normalize();
+                    direction = new Vector(direction.x, direction.y);
+                    direction.mult(sourceRadius);
+                    direction.add(new Vector(_x1, _y1));
+                    _x1 = direction.x;
+                    _y1 = direction.y;
+                }
+
+                x1 = _x1;
+                y1 = _y1;
+                x2 = _x2;
+                y2 = _y2;
+            }
+        }
+    }
+
+    private static class CurvedEdgeRenderer {
+
+        public void render(
+                final Item item,
+                final RenderTarget target,
+                final PreviewProperties properties) {
+            final Helper h = new Helper(item, properties);
+            final Color color = getColor(item, properties);
+
+            if (target instanceof G2DTarget) {
+                final Graphics2D graphics = ((G2DTarget) target).getGraphics();
+                graphics.setStroke(new BasicStroke(getThickness(item)));
+                graphics.setColor(color);
+                final GeneralPath gp
+                        = new GeneralPath(GeneralPath.WIND_NON_ZERO);
+                gp.moveTo(h.x1, h.y1);
+                gp.curveTo(h.v1.x, h.v1.y, h.v2.x, h.v2.y, h.x2, h.y2);
+                graphics.draw(gp);
+            } else if (target instanceof SVGTarget) {
+                final SVGTarget svgTarget = (SVGTarget) target;
+                final Element edgeElem = svgTarget.createElement("path");
+                edgeElem.setAttribute("class", String.format(
+                        "%s %s",
+                        ((Node) h.sourceItem.getSource()).getId(),
+                        ((Node) h.targetItem.getSource()).getId()));
+                edgeElem.setAttribute("d", String.format(
+                        Locale.ENGLISH,
+                        "M %f,%f C %f,%f %f,%f %f,%f",
+                        h.x1, h.y1,
+                        h.v1.x, h.v1.y, h.v2.x, h.v2.y, h.x2, h.y2));
+                edgeElem.setAttribute("stroke", svgTarget.toHexString(color));
+                edgeElem.setAttribute(
+                        "stroke-width",
+                        Float.toString(getThickness(item)
+                                * svgTarget.getScaleRatio()));
+                edgeElem.setAttribute(
+                        "stroke-opacity",
+                        (color.getAlpha() / 255f) + "");
+                edgeElem.setAttribute("fill", "none");
+                svgTarget.getTopElement(SVGTarget.TOP_EDGES)
+                        .appendChild(edgeElem);
+            } else if (target instanceof PDFTarget) {
+                final PDFTarget pdfTarget = (PDFTarget) target;
+                final PdfContentByte cb = pdfTarget.getContentByte();
+                cb.moveTo(h.x1, -h.y1);
+                cb.curveTo(h.v1.x, -h.v1.y, h.v2.x, -h.v2.y, h.x2, -h.y2);
+                cb.setRGBColorStroke(
+                        color.getRed(),
+                        color.getGreen(),
+                        color.getBlue());
+                cb.setLineWidth(getThickness(item));
+                if (color.getAlpha() < 255) {
+                    cb.saveState();
+                    final PdfGState gState = new PdfGState();
+                    gState.setStrokeOpacity(
+                            getAlpha(properties));
+                    cb.setGState(gState);
+                }
+                cb.stroke();
+                if (color.getAlpha() < 255) {
+                    cb.restoreState();
+                }
+            }
+        }
+
+        public CanvasSize getCanvasSize(
+                final Item item,
+                final PreviewProperties properties) {
+            final Helper h = new Helper(item, properties);
+            final float minX
+                    = Math.min(Math.min(Math.min(h.x1, h.x2), h.v1.x), h.v2.x);
+            final float minY
+                    = Math.min(Math.min(Math.min(h.y1, h.y2), h.v1.y), h.v2.y);
+            final float maxX
+                    = Math.max(Math.max(Math.max(h.x1, h.x2), h.v1.x), h.v2.x);
+            final float maxY
+                    = Math.max(Math.max(Math.max(h.y1, h.y2), h.v1.y), h.v2.y);
+            return new CanvasSize(minX, minY, maxX - minX, maxY - minY);
+        }
+
+        private class Helper {
+
+            public final Item sourceItem;
+            public final Item targetItem;
+            public final Float x1;
+            public final Float x2;
+            public final Float y1;
+            public final Float y2;
+            public final Vector v1;
+            public final Vector v2;
+
+            public Helper(
+                    final Item item,
+                    final PreviewProperties properties) {
+                sourceItem = item.getData(SOURCE);
+                targetItem = item.getData(TARGET);
+
+                x1 = sourceItem.getData(NodeItem.X);
+                x2 = targetItem.getData(NodeItem.X);
+                y1 = sourceItem.getData(NodeItem.Y);
+                y2 = targetItem.getData(NodeItem.Y);
+
+                final Vector direction = new Vector(x2, y2);
+                direction.sub(new Vector(x1, y1));
+
+                final float length = direction.mag();
+
+                direction.normalize();
+                final float factor
+                        = properties.getFloatValue(BEZIER_CURVENESS) * length;
+
+                final Vector n = new Vector(direction.y, -direction.x);
+                n.mult(factor);
+
+                v1 = computeCtrlPoint(x1, y1, direction, factor, n);
+                v2 = computeCtrlPoint(x2, y2, direction, -factor, n);
+            }
+
+            private Vector computeCtrlPoint(
+                    final Float x,
+                    final Float y,
+                    final Vector direction,
+                    final float factor,
+                    final Vector normalVector) {
+                final Vector v = new Vector(direction.x, direction.y);
+                v.mult(factor);
+                v.add(new Vector(x, y));
+                v.add(normalVector);
+                return v;
+            }
+        }
+    }
+
+    private static class SelfLoopEdgeRenderer {
+
+        public static final String ID = "SelfLoopEdge";
+
+        public void render(
+                final Item item,
+                final RenderTarget target,
+                final PreviewProperties properties) {
+            final Helper h = new Helper(item);
+            final Color color = getColor(item, properties);
+
+            if (target instanceof G2DTarget) {
+                final Graphics2D graphics = ((G2DTarget) target).getGraphics();
+                graphics.setStroke(new BasicStroke(getThickness(item)));
+                graphics.setColor(color);
+                final GeneralPath gp
+                        = new GeneralPath(GeneralPath.WIND_NON_ZERO);
+                gp.moveTo(h.x, h.y);
+                gp.curveTo(h.v1.x, h.v1.y, h.v1.x, h.v2.y, h.x, h.y);
+                graphics.draw(gp);
+            } else if (target instanceof SVGTarget) {
+                final SVGTarget svgTarget = (SVGTarget) target;
+
+                final Element selfLoopElem = svgTarget.createElement("path");
+                selfLoopElem.setAttribute("d", String.format(
+                        Locale.ENGLISH,
+                        "M %f,%f C %f,%f %f,%f %f,%f",
+                        h.x, h.y, h.v1.x, h.v1.y, h.v2.x, h.v2.y, h.x, h.y));
+                selfLoopElem.setAttribute("class", h.node.getId().toString());
+                selfLoopElem.setAttribute(
+                        "stroke",
+                        svgTarget.toHexString(color));
+                selfLoopElem.setAttribute(
+                        "stroke-opacity",
+                        (color.getAlpha() / 255f) + "");
+                selfLoopElem.setAttribute("stroke-width", Float.toString(
+                        getThickness(item) * svgTarget.getScaleRatio()));
+                selfLoopElem.setAttribute("fill", "none");
+                svgTarget.getTopElement(SVGTarget.TOP_EDGES)
+                        .appendChild(selfLoopElem);
+            } else if (target instanceof PDFTarget) {
+                final PDFTarget pdfTarget = (PDFTarget) target;
+                final PdfContentByte cb = pdfTarget.getContentByte();
+                cb.moveTo(h.x, -h.y);
+                cb.curveTo(h.v1.x, -h.v1.y, h.v2.x, -h.v2.y, h.x, -h.y);
+                cb.setRGBColorStroke(
+                        color.getRed(),
+                        color.getGreen(),
+                        color.getBlue());
+                cb.setLineWidth(getThickness(item));
+                if (color.getAlpha() < 255) {
+                    cb.saveState();
+                    final PdfGState gState = new PdfGState();
+                    gState.setStrokeOpacity(
+                            getAlpha(properties));
+                    cb.setGState(gState);
+                }
+                cb.stroke();
+                if (color.getAlpha() < 255) {
+                    cb.restoreState();
+                }
+            }
+        }
+
+        public CanvasSize getCanvasSize(
+                final Item item,
+                final PreviewProperties properties) {
+            final Helper h = new Helper(item);
+            final float minX = Math.min(Math.min(h.x, h.v1.x), h.v2.x);
+            final float minY = Math.min(Math.min(h.y, h.v1.y), h.v2.y);
+            final float maxX = Math.max(Math.max(h.x, h.v1.x), h.v2.x);
+            final float maxY = Math.max(Math.max(h.y, h.v1.y), h.v2.y);
+            return new CanvasSize(minX, minY, maxX - minX, maxY - minY);
+        }
+
+        private class Helper {
+
+            public final Float x;
+            public final Float y;
+            public final Node node;
+            public final Vector v1;
+            public final Vector v2;
+
+            public Helper(final Item item) {
+                x = item.getData(NodeItem.X);
+                y = item.getData(NodeItem.Y);
+                final Float size = item.getData(NodeItem.SIZE);
+                node = (Node) item.getSource();
+
+                v1 = new Vector(x, y);
+                v1.add(size, -size);
+
+                v2 = new Vector(x, y);
+                v2.add(size, size);
+            }
+        }
     }
 }

--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeLabelRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeLabelRenderer.java
@@ -44,7 +44,12 @@ package org.gephi.preview.plugin.renderers;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfGState;
-import java.awt.*;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Shape;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.geom.Rectangle2D;
@@ -183,6 +188,14 @@ public class NodeLabelRenderer implements Renderer {
         } else if (target instanceof PDFTarget) {
             renderPDF((PDFTarget) target, node, label, x, y, fontSize, color, outlineSize, outlineColor, showBox, boxColor);
         }
+    }
+
+    @Override
+    public CanvasSize getCanvasSize(
+            final Item item,
+            final PreviewProperties properties) {
+        //FIXME Compute the label canvas
+        return new CanvasSize();
     }
 
     public void renderG2D(G2DTarget target, String label, float x, float y, int fontSize, Color color, float outlineSize, Color outlineColor, boolean showBox, Color boxColor) {

--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeRenderer.java
@@ -85,6 +85,23 @@ public class NodeRenderer implements Renderer {
         }
     }
 
+    @Override
+    public CanvasSize getCanvasSize(
+            final Item item,
+            final PreviewProperties properties) {
+        final float x = item.getData(NodeItem.X);
+        final float y = item.getData(NodeItem.Y);
+        final float s = (Float) item.getData(NodeItem.SIZE)
+                + properties.getFloatValue(PreviewProperty.NODE_BORDER_WIDTH);
+        final float r = s / 2F;
+        final int intS = Math.round(s);
+        return new CanvasSize(
+                Math.round(x - r),
+                Math.round(y - r),
+                intS,
+                intS);
+    }
+
     public void renderG2D(Item item, G2DTarget target, PreviewProperties properties) {
         //Params
         Float x = item.getData(NodeItem.X);
@@ -138,7 +155,9 @@ public class NodeRenderer implements Renderer {
         nodeElem.setAttribute("fill-opacity", "" + alpha);
         if (borderSize > 0) {
             nodeElem.setAttribute("stroke", target.toHexString(borderColor));
-            nodeElem.setAttribute("stroke-width", new Float(borderSize * target.getScaleRatio()).toString());
+            nodeElem.setAttribute(
+                    "stroke-width",
+                    Float.toString(borderSize * target.getScaleRatio()));
             nodeElem.setAttribute("stroke-opacity", "" + alpha);
         }
         target.getTopElement(SVGTarget.TOP_NODES).appendChild(nodeElem);


### PR DESCRIPTION
Fixes issue #572 

For each item to render on a Preview target, the canvas size is computed. Then, from the union of all of these rectangles, one gets the global Preview canvas size.

With such an implementation, any Preview plugin can declare the canvas size of its own items to render, so they can be integrated in the global Preview canvas size just like the regular items.