### PR TITLE
Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
@@ -206,9 +206,6 @@ public class CustomBoundsDialog extends javax.swing.JPanel {
                     if (minDate >= maxDate) {
                         prblms.add(NbBundle.getMessage(CustomBoundsDialog.class, "CustomBoundsDialog.TimeValidator"));
                         return false;
-                    } else if (maxDate <= minDate) {
-                        prblms.add(NbBundle.getMessage(CustomBoundsDialog.class, "CustomBoundsDialog.TimeValidator"));
-                        return false;
                     }
                 } catch (Exception ex) {
                     prblms.add(NbBundle.getMessage(CustomBoundsDialog.class, "CustomBoundsDialog.FormatValidator.date", ISODateTimeFormat.dateTime()));
@@ -230,9 +227,6 @@ public class CustomBoundsDialog extends javax.swing.JPanel {
                         return false;
                     }
                     if (minDate >= maxDate) {
-                        prblms.add(NbBundle.getMessage(CustomBoundsDialog.class, "CustomBoundsDialog.TimeValidator"));
-                        return false;
-                    } else if (maxDate <= minDate) {
                         prblms.add(NbBundle.getMessage(CustomBoundsDialog.class, "CustomBoundsDialog.TimeValidator"));
                         return false;
                     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2583

Please let me know if you have any questions.

Kirill Vlasov
