### PR TITLE
Removing unecessary semicolon

### DIFF
--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
@@ -145,7 +145,8 @@ preferredID = "DataTableTopComponent")
 public class DataTableTopComponent extends TopComponent implements AWTEventListener, DataTablesEventListener {
     private enum DisplayTable {
         NODE, EDGE
-    };
+    }
+
     //Settings
     private static final long AUTO_REFRESH_RATE_MILLISECONDS = 100;
     private static final String DATA_LABORATORY_DYNAMIC_FILTERING = "DataLaboratory_Dynamic_Filtering";

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/general/actions/AddColumnUI.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/general/actions/AddColumnUI.java
@@ -69,7 +69,7 @@ public class AddColumnUI extends javax.swing.JPanel {
 
     public enum Mode {
 
-        NODES_TABLE, EDGES_TABLE;
+        NODES_TABLE, EDGES_TABLE
     }
 
     /**

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsFrontEnd.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsFrontEnd.java
@@ -85,7 +85,6 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
     private StatisticsModelUI currentModel;
 
     //Img
-    ;
 
     public StatisticsFrontEnd(StatisticsUI ui) {
         initComponents();

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/DateTick.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/DateTick.java
@@ -98,7 +98,7 @@ public class DateTick {
         DateTime minDate = new DateTime((long) min);
         DateTime maxDate = new DateTime((long) max);
 
-        Period period = new Period(minDate, maxDate, PeriodType.yearMonthDayTime());;
+        Period period = new Period(minDate, maxDate, PeriodType.yearMonthDayTime());
         int years = period.getYears();
         int months = period.getMonths();
         int days = period.getDays();
@@ -177,7 +177,7 @@ public class DateTick {
             for (int i = 0; i < totalIntervals; i++) {
                 Interval currentInterval;
                 if (i == 0) {
-                    currentInterval = min.property(type).toInterval();;
+                    currentInterval = min.property(type).toInterval();
                 } else {
                     currentInterval = min.property(type).addToCopy(i).property(type).toInterval();
                 }

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TickParameters.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TickParameters.java
@@ -53,7 +53,8 @@ public class TickParameters {
     public enum TickType {
 
         DATE, DOUBLE, START_END
-    };
+    }
+
     private final TickType type;
     private int width, height;
     private int fontSize = 12;

--- a/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGDF.java
+++ b/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGDF.java
@@ -757,7 +757,7 @@ public class ExporterGDF implements GraphExporter, CharacterExporter, LongTask {
     private enum DataTypeGDF {
 
         VARCHAR, BOOL, BOOLEAN, INTEGER, TINYINT, INT, DOUBLE, FLOAT
-    };
+    }
 
     private abstract class NodeColumnsGDF {
 

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/operator/MASKBuilderEdge.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/operator/MASKBuilderEdge.java
@@ -110,7 +110,8 @@ public class MASKBuilderEdge implements FilterBuilder {
         public enum EdgesOptions {
 
             SOURCE, TARGET, ANY, BOTH
-        };
+        }
+
         private EdgesOptions option = EdgesOptions.ANY;
         private FilterProperty[] filterProperties;
 

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeDirection.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeDirection.java
@@ -53,5 +53,5 @@ package org.gephi.io.importer.api;
  */
 public enum EdgeDirection {
 
-    DIRECTED, UNDIRECTED;
+    DIRECTED, UNDIRECTED
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeDirectionDefault.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeDirectionDefault.java
@@ -49,5 +49,5 @@ package org.gephi.io.importer.api;
  */
 public enum EdgeDirectionDefault {
 
-    DIRECTED, UNDIRECTED, MIXED;
+    DIRECTED, UNDIRECTED, MIXED
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/PropertiesAssociations.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/PropertiesAssociations.java
@@ -53,12 +53,12 @@ public final class PropertiesAssociations implements Serializable {
 
     public enum NodeProperties {
 
-        X, Y, Z, R, G, B, COLOR, SIZE, ID, LABEL, FIXED, START, END, START_OPEN, END_OPEN;
+        X, Y, Z, R, G, B, COLOR, SIZE, ID, LABEL, FIXED, START, END, START_OPEN, END_OPEN
     }
 
     public enum EdgeProperties {
 
-        R, G, B, COLOR, WEIGHT, ID, LABEL, ALPHA, SOURCE, TARGET, START, END, START_OPEN, END_OPEN;
+        R, G, B, COLOR, WEIGHT, ID, LABEL, ALPHA, SOURCE, TARGET, START, END, START_OPEN, END_OPEN
     }
     //PropertiesAssociations association
     private final List<PropertyAssociation<NodeProperties>> nodePropertyAssociations = new LinkedList<PropertyAssociation<NodeProperties>>();

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterDL.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterDL.java
@@ -72,7 +72,8 @@ public class ImporterDL implements FileImporter, LongTask {
     private enum Format {
 
         FULLMATRIX, EDGELIST1
-    };
+    }
+
     //Architecture
     private Reader reader;
     private ContainerLoader container;

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGDF.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGDF.java
@@ -561,12 +561,13 @@ public class ImporterGDF implements FileImporter, LongTask {
         public enum NodeGuessColumn {
 
             X, Y, VISIBLE, FIXED, STYLE, COLOR, WIDTH, HEIGHT, LABEL, LABELVISIBLE
-        };
+        }
 
         public enum EdgeGuessColumn {
 
             VISIBLE, COLOR, WEIGHT, DIRECTED, LABEL, LABELVISIBLE
-        };
+        }
+
         private ColumnDraft column;
         private NodeGuessColumn nodeColumn;
         private EdgeGuessColumn edgeColumn;

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterVNA.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterVNA.java
@@ -85,7 +85,7 @@ public class ImporterVNA implements FileImporter, LongTask {
 
         DEFAULT, NODE_DATA, NODE_PROPERTIES, TIE_DATA,
         NODE_DATA_DEF, NODE_PROPERTIES_DEF, TIE_DATA_DEF
-    };
+    }
 
     /**
      * Attributes defined by the VNA file: VNA files allow some or no properties
@@ -95,7 +95,8 @@ public class ImporterVNA implements FileImporter, LongTask {
 
         OTHER, NODE_X, NODE_Y, NODE_COLOR, NODE_SIZE,
         NODE_SHAPE, NODE_SHORT_LABEL, EDGE_STRENGTH
-    };
+    }
+
     /**
      * Declared column labels for all sections.
      */
@@ -390,7 +391,8 @@ public class ImporterVNA implements FileImporter, LongTask {
         public enum Function {
 
             LINEAR, SQUARE_ROOT, LOGARITHMIC
-        };
+        }
+
         public final Function function;
         public final float coefficient;
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/AutoLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/AutoLayout.java
@@ -238,7 +238,7 @@ public class AutoLayout {
     public enum Interpolation {
 
         LINEAR, LOG
-    };
+    }
 
     private static abstract class AbstractDynamicProperty implements DynamicProperty {
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceFactory.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceFactory.java
@@ -56,8 +56,6 @@ public class ForceFactory {
     private ForceFactory() {
     }
 
-    ;
-
     public RepulsionForce buildRepulsion(boolean adjustBySize, double coefficient) {
         if (adjustBySize) {
             return new linRepulsion_antiCollision(coefficient);

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/types/DependantColor.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/types/DependantColor.java
@@ -53,7 +53,8 @@ public final class DependantColor {
     public enum Mode {
 
         PARENT, CUSTOM
-    };
+    }
+
     private final Color customColor;
     private final Mode mode;
 

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/types/DependantOriginalColor.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/types/DependantOriginalColor.java
@@ -53,7 +53,8 @@ public final class DependantOriginalColor {
     public enum Mode {
 
         PARENT, CUSTOM, ORIGINAL
-    };
+    }
+
     private final Color customColor;
     private final Mode mode;
 

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/types/EdgeColor.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/types/EdgeColor.java
@@ -59,7 +59,8 @@ public class EdgeColor {
     public enum Mode {
 
         SOURCE, TARGET, MIXED, CUSTOM, ORIGINAL
-    };
+    }
+
     private Color customColor;
     private final Mode mode;
 

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
@@ -70,7 +70,8 @@ public class ProjectControllerImpl implements ProjectController {
     private enum EventType {
 
         INITIALIZE, SELECT, UNSELECT, CLOSE, DISABLE
-    };
+    }
+
     //Data
     private final ProjectsImpl projects = new ProjectsImpl();
     private final List<WorkspaceListener> listeners;

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectInformationImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectInformationImpl.java
@@ -58,7 +58,8 @@ public class ProjectInformationImpl implements ProjectInformation {
     public enum Status {
 
         NEW, OPEN, CLOSED, INVALID
-    };
+    }
+
     //Data
     private final Project project;
     private String name;

--- a/modules/ProjectAPI/src/main/java/org/gephi/workspace/impl/WorkspaceInformationImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/workspace/impl/WorkspaceInformationImpl.java
@@ -56,7 +56,8 @@ public class WorkspaceInformationImpl implements WorkspaceInformation {
     public enum Status {
 
         OPEN, CLOSED, INVALID
-    };
+    }
+
     private String name;
     private Status status = Status.CLOSED;
     private String source;

--- a/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/Modularity.java
+++ b/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/Modularity.java
@@ -616,7 +616,7 @@ public class Modularity implements Statistics, LongTask {
             modCol = nodeTable.addColumn(MODULARITY_CLASS, "Modularity Class", Integer.class, new Integer(0));
         }
         for (Node n : hgraph.getNodes()) {
-            int n_index = theStructure.map.get(n);;
+            int n_index = theStructure.map.get(n);
             n.setAttribute(modCol, struct[n_index]);
         }
     }

--- a/modules/StatisticsPlugin/src/test/java/org/gephi/statistics/plugin/ClusteringCoefficientNGTest.java
+++ b/modules/StatisticsPlugin/src/test/java/org/gephi/statistics/plugin/ClusteringCoefficientNGTest.java
@@ -276,9 +276,9 @@ public class ClusteringCoefficientNGTest {
         undirectedGraph.addEdge(edge31);
         undirectedGraph.addEdge(edge14);
         undirectedGraph.addEdge(edge25);
-        undirectedGraph.addEdge(edge36);;
+        undirectedGraph.addEdge(edge36);
 
-        Graph hgraph = graphModel.getGraph();
+       Graph hgraph = graphModel.getGraph();
         ClusteringCoefficient cc = new ClusteringCoefficient();
 
         ArrayWrapper[] network = new ArrayWrapper[6];

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModel.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModel.java
@@ -69,7 +69,7 @@ public interface TimelineModel {
          * Both interval bounds are moved. The interval size remains unchanged.
          */
         TWO_BOUNDS
-    };
+    }
 
     /**
      * Returns <code>true</code> if the timeline is enabled. When enabled, the timeline

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModelEvent.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModelEvent.java
@@ -52,7 +52,8 @@ public final class TimelineModelEvent {
     public enum EventType {
 
         MODEL, MIN_MAX, INTERVAL, CUSTOM_BOUNDS, ENABLED, PLAY_START, PLAY_STOP, CHART, VALID_BOUNDS
-    };
+    }
+
     private final EventType type;
     private final TimelineModel source;
     private final Object data;

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/JHTMLEditorPane.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/JHTMLEditorPane.java
@@ -614,7 +614,6 @@ public class JHTMLEditorPane extends JEditorPane implements HyperlinkListener, M
         } catch (Exception ex) {
         }
 
-        ;
     }
 
     @Override

--- a/modules/UIPropertyEditor/src/main/java/org/gephi/ui/propertyeditor/AbstractAttributeColumnPropertyEditor.java
+++ b/modules/UIPropertyEditor/src/main/java/org/gephi/ui/propertyeditor/AbstractAttributeColumnPropertyEditor.java
@@ -59,12 +59,13 @@ abstract class AbstractAttributeColumnPropertyEditor extends PropertyEditorSuppo
     public enum EditorClass {
 
         NODE, EDGE, NODEEDGE
-    };
+    }
 
     public enum AttributeTypeClass {
 
         ALL, NUMBER, STRING, DYNAMIC_NUMBER, ALL_NUMBER
-    };
+    }
+
     private Column[] columns;
     private Column selectedColumn;
     private final EditorClass editorClass;

--- a/modules/Utils/src/main/java/org/gephi/utils/sparklines/SparklineParameters.java
+++ b/modules/Utils/src/main/java/org/gephi/utils/sparklines/SparklineParameters.java
@@ -68,7 +68,7 @@ public class SparklineParameters {
 
         X_VALUES,
         Y_VALUES,
-        X_AND_Y_VALUES;
+        X_AND_Y_VALUES
     }
     public static final Color DEFAULT_LINE_COLOR = Color.BLUE;
     public static final Color DEFAULT_AREA_COLOR = new Color(DEFAULT_LINE_COLOR.getRed(), DEFAULT_LINE_COLOR.getRed(), DEFAULT_LINE_COLOR.getBlue(), 50);

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/VizEvent.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/VizEvent.java
@@ -66,7 +66,8 @@ public class VizEvent extends EventObject {
         MOUSE_RELEASED,
         NODE_LEFT_PRESS,
         NODE_LEFT_PRESSING,
-    };
+    }
+
     private Type type;
     private Object data;
 

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/opengl/AbstractEngine.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/opengl/AbstractEngine.java
@@ -75,7 +75,8 @@ public abstract class AbstractEngine implements Engine, VizArchitecture {
     public enum Limits {
 
         MIN_X, MAX_X, MIN_Y, MAX_Y, MIN_Z, MAX_Z
-    };
+    }
+
     //Architecture
     protected GraphDrawable graphDrawable;
     protected GraphIO graphIO;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of unnecessary semicolon - remove any unnecessary semicolons, whether between class members, inside block statements, or after class definitions. While valid Java, these semicolons are redundant, and may be removed.

Please let me know if you have any questions.

Kirill Vlasov