### PR TITLE
Removing any redundant modifiers on interfaces or interface components

### DIFF
--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/AppearanceController.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/AppearanceController.java
@@ -60,13 +60,13 @@ public interface AppearanceController {
      * @param useLocalScale <code>true</code> for local, <code>false</code> for
      * global
      */
-    public void setUseLocalScale(boolean useLocalScale);
+    void setUseLocalScale(boolean useLocalScale);
 
-    public void transform(Function function);
+    void transform(Function function);
 
-    public AppearanceModel getModel();
+    AppearanceModel getModel();
 
-    public AppearanceModel getModel(Workspace workspace);
+    AppearanceModel getModel(Workspace workspace);
 
-    public Transformer getTransformer(TransformerUI ui);
+    Transformer getTransformer(TransformerUI ui);
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/AppearanceModel.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/AppearanceModel.java
@@ -56,7 +56,7 @@ public interface AppearanceModel {
      *
      * @return the workspace of this model
      */
-    public Workspace getWorkspace();
+    Workspace getWorkspace();
 
     /**
      * Returns <code>true</code> if rankings are using the currently visible
@@ -66,13 +66,13 @@ public interface AppearanceModel {
      * @return <code>true</code> if using a local scale, <code>false</code> if
      * global scale
      */
-    public boolean isLocalScale();
+    boolean isLocalScale();
 
-    public Partition getNodePartition(Graph graph, Column column);
+    Partition getNodePartition(Graph graph, Column column);
 
-    public Partition getEdgePartition(Graph graph, Column column);
+    Partition getEdgePartition(Graph graph, Column column);
 
-    public Function[] getNodeFunctions(Graph graph);
+    Function[] getNodeFunctions(Graph graph);
 
-    public Function[] getEdgeFunctions(Graph graph);
+    Function[] getEdgeFunctions(Graph graph);
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/AttributeFunction.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/AttributeFunction.java
@@ -49,5 +49,5 @@ import org.gephi.graph.api.Column;
  */
 public interface AttributeFunction extends Function {
 
-    public Column getColumn();
+    Column getColumn();
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/Function.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/Function.java
@@ -52,21 +52,21 @@ import org.gephi.graph.api.Graph;
  */
 public interface Function {
 
-    public void transform(Element element, Graph graph);
+    void transform(Element element, Graph graph);
 
-    public Transformer getTransformer();
+    Transformer getTransformer();
 
-    public TransformerUI getUI();
+    TransformerUI getUI();
 
-    public boolean isSimple();
+    boolean isSimple();
 
-    public boolean isAttribute();
+    boolean isAttribute();
 
-    public boolean isRanking();
+    boolean isRanking();
 
-    public boolean isPartition();
+    boolean isPartition();
 
-    public Graph getGraph();
+    Graph getGraph();
 
-    public Class<? extends Element> getElementClass();
+    Class<? extends Element> getElementClass();
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/Partition.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/Partition.java
@@ -53,23 +53,23 @@ import org.gephi.graph.api.Graph;
  */
 public interface Partition {
 
-    public Collection getValues();
+    Collection getValues();
 
-    public Collection getSortedValues();
+    Collection getSortedValues();
 
-    public int getElementCount();
+    int getElementCount();
 
-    public int count(Object value);
+    int count(Object value);
 
-    public Object getValue(Element element, Graph graph);
+    Object getValue(Element element, Graph graph);
 
-    public Color getColor(Object value);
+    Color getColor(Object value);
 
-    public void setColor(Object value, Color color);
+    void setColor(Object value, Color color);
 
-    public float percentage(Object value);
+    float percentage(Object value);
 
-    public int size();
+    int size();
 
-    public Column getColumn();
+    Column getColumn();
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/PartitionFunction.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/PartitionFunction.java
@@ -47,5 +47,5 @@ package org.gephi.appearance.api;
  */
 public interface PartitionFunction extends Function {
 
-    public Partition getPartition();
+    Partition getPartition();
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/Ranking.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/Ranking.java
@@ -50,11 +50,11 @@ import org.gephi.graph.api.Graph;
  */
 public interface Ranking {
 
-    public Number getMinValue();
+    Number getMinValue();
 
-    public Number getMaxValue();
+    Number getMaxValue();
 
-    public Number getValue(Element element, Graph graph);
+    Number getValue(Element element, Graph graph);
 
-    public float normalize(Number value, Interpolator interpolator);
+    float normalize(Number value, Interpolator interpolator);
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/RankingFunction.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/api/RankingFunction.java
@@ -47,9 +47,9 @@ package org.gephi.appearance.api;
  */
 public interface RankingFunction extends Function {
 
-    public Ranking getRanking();
+    Ranking getRanking();
 
-    public void setInterpolator(Interpolator interpolator);
+    void setInterpolator(Interpolator interpolator);
 
-    public Interpolator getInterpolator();
+    Interpolator getInterpolator();
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/PartitionTransformer.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/PartitionTransformer.java
@@ -50,5 +50,5 @@ import org.gephi.graph.api.Element;
  */
 public interface PartitionTransformer<E extends Element> extends Transformer {
 
-    public void transform(E element, Partition partition, Object value);
+    void transform(E element, Partition partition, Object value);
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/RankingTransformer.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/RankingTransformer.java
@@ -51,5 +51,5 @@ import org.gephi.graph.api.Element;
  */
 public interface RankingTransformer<E extends Element> extends Transformer {
 
-    public void transform(E element, Ranking ranking, Interpolator interpolator, Number value);
+    void transform(E element, Ranking ranking, Interpolator interpolator, Number value);
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/SimpleTransformer.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/SimpleTransformer.java
@@ -49,5 +49,5 @@ import org.gephi.graph.api.Element;
  */
 public interface SimpleTransformer<E extends Element> extends Transformer {
 
-    public void transform(E element);
+    void transform(E element);
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/Transformer.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/Transformer.java
@@ -47,7 +47,7 @@ package org.gephi.appearance.spi;
  */
 public interface Transformer {
 
-    public boolean isNode();
+    boolean isNode();
 
-    public boolean isEdge();
+    boolean isEdge();
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/TransformerCategory.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/TransformerCategory.java
@@ -49,7 +49,7 @@ import javax.swing.Icon;
  */
 public interface TransformerCategory {
 
-    public String getDisplayName();
+    String getDisplayName();
 
-    public Icon getIcon();
+    Icon getIcon();
 }

--- a/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/TransformerUI.java
+++ b/modules/AppearanceAPI/src/main/java/org/gephi/appearance/spi/TransformerUI.java
@@ -52,17 +52,17 @@ import org.gephi.appearance.api.Function;
  */
 public interface TransformerUI<T extends Transformer> {
 
-    public TransformerCategory getCategory();
+    TransformerCategory getCategory();
 
-    public JPanel getPanel(Function function);
+    JPanel getPanel(Function function);
 
-    public String getDisplayName();
+    String getDisplayName();
 
-    public String getDescription();
+    String getDescription();
 
-    public Icon getIcon();
+    Icon getIcon();
 
-    public AbstractButton[] getControlButton();
+    AbstractButton[] getControlButton();
 
-    public Class<? extends T> getTransformerClass();
+    Class<? extends T> getTransformerClass();
 }

--- a/modules/DBDrivers/src/main/java/org/gephi/io/database/drivers/SQLDriver.java
+++ b/modules/DBDrivers/src/main/java/org/gephi/io/database/drivers/SQLDriver.java
@@ -51,10 +51,10 @@ import java.sql.SQLException;
  */
 public interface SQLDriver extends Serializable {
 
-    public String getPrefix();
+    String getPrefix();
 
-    public Connection getConnection(String connectionUrl, String username, String passwd) throws SQLException;
+    Connection getConnection(String connectionUrl, String username, String passwd) throws SQLException;
 
     @Override
-    public String toString();
+    String toString();
 }

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/AttributeColumnsMergeStrategiesController.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/AttributeColumnsMergeStrategiesController.java
@@ -55,7 +55,7 @@ public interface AttributeColumnsMergeStrategiesController {
     /**
      * Enumeration that defines the supported logic operations for a merge with <code>booleanLogicOperationsMerge</code> strategy.
      */
-    public enum BooleanOperations {
+    enum BooleanOperations {
         AND,
         OR,
         XOR,

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/datatables/DataTablesCommonInterface.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/api/datatables/DataTablesCommonInterface.java
@@ -162,7 +162,7 @@ interface DataTablesCommonInterface {
      */
     void setShowEdgesNodesLabels(boolean showEdgesNodesLabels);
 
-    public enum ExportMode {
+    enum ExportMode {
 
         CSV
     }

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/spi/ManipulatorUI.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/spi/ManipulatorUI.java
@@ -74,11 +74,11 @@ public interface ManipulatorUI {
      * Returns a settings panel instance for this Manipulator.
      * @return Settings panel instance
      */
-    public JPanel getSettingsPanel();
+    JPanel getSettingsPanel();
 
     /**
      * Indicates if the created dialog has to be modal
      * @return True if modal, false otherwise
      */
-    public boolean isModal();
+    boolean isModal();
 }

--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/spi/columns/AttributeColumnsManipulatorUI.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/spi/columns/AttributeColumnsManipulatorUI.java
@@ -83,11 +83,11 @@ public interface AttributeColumnsManipulatorUI {
      * Returns a settings panel instance for this AttributeColumnsManipulator.
      * @return Settings panel instance
      */
-    public JPanel getSettingsPanel();
+    JPanel getSettingsPanel();
 
     /**
      * Indicates if the created dialog has to be modal
      * @return True if modal, false otherwise
      */
-    public boolean isModal();
+    boolean isModal();
 }

--- a/modules/DesktopBanner/src/main/java/org/gephi/desktop/banner/perspective/spi/BottomComponent.java
+++ b/modules/DesktopBanner/src/main/java/org/gephi/desktop/banner/perspective/spi/BottomComponent.java
@@ -49,9 +49,9 @@ import javax.swing.JComponent;
  */
 public interface BottomComponent {
     
-    public JComponent getComponent();
+    JComponent getComponent();
     
-    public void setVisible(boolean visible);
+    void setVisible(boolean visible);
     
-    public boolean isVisible();
+    boolean isVisible();
 }

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/tables/columns/ElementDataColumn.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/tables/columns/ElementDataColumn.java
@@ -50,15 +50,15 @@ import org.gephi.graph.api.Element;
  */
 public interface ElementDataColumn<T extends Element> {
 
-    public Class getColumnClass();
+    Class getColumnClass();
 
-    public String getColumnName();
+    String getColumnName();
 
-    public Object getValueFor(T element);
+    Object getValueFor(T element);
 
-    public void setValueFor(T element, Object value);
+    void setValueFor(T element, Object value);
 
-    public boolean isEditable();
+    boolean isEditable();
     
-    public Column getColumn();
+    Column getColumn();
 }

--- a/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/ExportControllerUI.java
+++ b/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/ExportControllerUI.java
@@ -51,7 +51,7 @@ import org.openide.filesystems.FileObject;
  */
 public interface ExportControllerUI {
 
-    public void exportFile(final FileObject fileObject, final Exporter exporter);
+    void exportFile(final FileObject fileObject, final Exporter exporter);
 
-    public ExportController getExportController();
+    ExportController getExportController();
 }

--- a/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/spi/ExporterClassUI.java
+++ b/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/spi/ExporterClassUI.java
@@ -47,9 +47,9 @@ package org.gephi.desktop.io.export.spi;
  */
 public interface ExporterClassUI {
 
-    public String getName();
+    String getName();
 
-    public boolean isEnable();
+    boolean isEnable();
 
-    public void action();
+    void action();
 }

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/api/PreviewUIController.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/api/PreviewUIController.java
@@ -51,29 +51,29 @@ import org.gephi.preview.api.PreviewPreset;
 public interface PreviewUIController {
 
     //Property
-    public static final String SELECT = "select";
-    public static final String UNSELECT = "unselect";
-    public static final String REFRESHED = "refreshed";
-    public static final String REFRESHING = "refreshing";
-    public static final String GRAPH_CHANGED = "graph_changed";
+    String SELECT = "select";
+    String UNSELECT = "unselect";
+    String REFRESHED = "refreshed";
+    String REFRESHING = "refreshing";
+    String GRAPH_CHANGED = "graph_changed";
 
-    public void refreshPreview();
+    void refreshPreview();
 
-    public void setCurrentPreset(PreviewPreset preset);
+    void setCurrentPreset(PreviewPreset preset);
 
-    public void setVisibilityRatio(float visibilityRatio);
+    void setVisibilityRatio(float visibilityRatio);
 
-    public PreviewPreset[] getDefaultPresets();
+    PreviewPreset[] getDefaultPresets();
 
-    public PreviewPreset[] getUserPresets();
+    PreviewPreset[] getUserPresets();
 
-    public void addPreset(PreviewPreset preset);
+    void addPreset(PreviewPreset preset);
 
-    public void savePreset(String name);
+    void savePreset(String name);
 
-    public PreviewUIModel getModel();
+    PreviewUIModel getModel();
 
-    public void addPropertyChangeListener(PropertyChangeListener listener);
+    void addPropertyChangeListener(PropertyChangeListener listener);
 
-    public void removePropertyChangeListener(PropertyChangeListener listener);
+    void removePropertyChangeListener(PropertyChangeListener listener);
 }

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/api/PreviewUIModel.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/api/PreviewUIModel.java
@@ -50,13 +50,13 @@ import org.gephi.preview.api.PreviewPreset;
  */
 public interface PreviewUIModel {
 
-    public PreviewModel getPreviewModel();
+    PreviewModel getPreviewModel();
 
-    public PreviewPreset getCurrentPreset();
+    PreviewPreset getCurrentPreset();
 
-    public float getVisibilityRatio();
+    float getVisibilityRatio();
 
-    public boolean isRefreshing();
+    boolean isRefreshing();
 
-    public boolean isWorkspaceBarVisible();
+    boolean isWorkspaceBarVisible();
 }

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/importer/api/ImportControllerUI.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/importer/api/ImportControllerUI.java
@@ -55,19 +55,19 @@ import org.openide.filesystems.FileObject;
  */
 public interface ImportControllerUI {
 
-    public void importFile(FileObject fileObject);
+    void importFile(FileObject fileObject);
 
-    public void importFiles(FileObject[] fileObjects);
+    void importFiles(FileObject[] fileObjects);
 
-    public void importStream(InputStream stream, String importerName);
+    void importStream(InputStream stream, String importerName);
 
-    public void importFile(Reader reader, String importerName);
+    void importFile(Reader reader, String importerName);
 
-    public void importDatabase(Database database, DatabaseImporter importer);
+    void importDatabase(Database database, DatabaseImporter importer);
 
-    public void importDatabase(DatabaseImporter importer);
+    void importDatabase(DatabaseImporter importer);
 
-    public void importSpigot(SpigotImporter importer);
+    void importSpigot(SpigotImporter importer);
 
-    public ImportController getImportController();
+    ImportController getImportController();
 }

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/api/ProjectControllerUI.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/api/ProjectControllerUI.java
@@ -51,47 +51,47 @@ import org.gephi.project.api.Workspace;
  */
 public interface ProjectControllerUI {
 
-    public void saveProject();
+    void saveProject();
 
-    public void saveAsProject();
+    void saveAsProject();
 
-    public void openProject(File file);
+    void openProject(File file);
 
-    public void renameProject(final String name);
+    void renameProject(final String name);
 
-    public void projectProperties();
+    void projectProperties();
 
-    public void openFile();
+    void openFile();
 
-    public Workspace newWorkspace();
+    Workspace newWorkspace();
 
-    public Workspace duplicateWorkspace();
+    Workspace duplicateWorkspace();
 
-    public Project newProject();
+    Project newProject();
 
-    public void deleteWorkspace();
+    void deleteWorkspace();
 
-    public void closeProject();
+    void closeProject();
 
-    public void renameWorkspace(final String name);
+    void renameWorkspace(final String name);
 
-    public boolean canNewProject();
+    boolean canNewProject();
 
-    public boolean canCloseProject();
+    boolean canCloseProject();
 
-    public boolean canOpenFile();
+    boolean canOpenFile();
 
-    public boolean canSave();
+    boolean canSave();
 
-    public boolean canSaveAs();
+    boolean canSaveAs();
 
-    public boolean canNewWorkspace();
+    boolean canNewWorkspace();
 
-    public boolean canDuplicateWorkspace();
+    boolean canDuplicateWorkspace();
 
-    public boolean canDeleteWorkspace();
+    boolean canDeleteWorkspace();
 
-    public boolean canRenameWorkspace();
+    boolean canRenameWorkspace();
 
-    public boolean canProjectProperties();
+    boolean canProjectProperties();
 }

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/api/StatisticsControllerUI.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/api/StatisticsControllerUI.java
@@ -61,7 +61,7 @@ public interface StatisticsControllerUI {
      * The <code>statistics</code> should implement {@link LongTask}.
      * @param statistics    the statistics algorithm instance
      */
-    public void execute(Statistics statistics);
+    void execute(Statistics statistics);
     
     /**
      * Execute the statistics in a background thread an call the listener when finished.
@@ -69,12 +69,12 @@ public interface StatisticsControllerUI {
      * @param statistics    the statistics algorithm instance
      * @param listener      a listener that is notified when execution finished
      */
-    public void execute(Statistics statistics, LongTaskListener listener);
+    void execute(Statistics statistics, LongTaskListener listener);
 
     /**
      * Sets the visible state for a given <code>StatisticsUI</code>.
      * @param ui            the UI instance
      * @param visible       <code>true</code> to display the front-end
      */
-    public void setStatisticsUIVisible(StatisticsUI ui, boolean visible);
+    void setStatisticsUIVisible(StatisticsUI ui, boolean visible);
 }

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/api/StatisticsModelUI.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/api/StatisticsModelUI.java
@@ -57,7 +57,7 @@ public interface StatisticsModelUI {
      * @param statisticsUI      a statisticsUI class
      * @return                  the result or <code>null</code> if not found
      */
-    public String getResult(StatisticsUI statisticsUI);
+    String getResult(StatisticsUI statisticsUI);
 
     /**
      * Returns <code>true</code> if the statistics front-end is visible, <code>
@@ -66,7 +66,7 @@ public interface StatisticsModelUI {
      * @return                  <code>true</code> if the statistics front-end
      *                          is visible, <code>false</code> otherwise
      */
-    public boolean isStatisticsUIVisible(StatisticsUI statisticsUI);
+    boolean isStatisticsUIVisible(StatisticsUI statisticsUI);
 
     /**
      * Returns <code>true</code> if the UI is in running state, <code>false</code>
@@ -75,7 +75,7 @@ public interface StatisticsModelUI {
      * @return                  <code>true</code> if the statistics is running,
      *                          <code>false</code> otherwise
      */
-    public boolean isRunning(StatisticsUI statisticsUI);
+    boolean isRunning(StatisticsUI statisticsUI);
 
     /**
      * Returns the <code>Statistics</code> instance currently running for the
@@ -85,7 +85,7 @@ public interface StatisticsModelUI {
      * @return                  the statistics instance if it is running, or
      *                          <code>null</code> if not running
      */
-    public Statistics getRunning(StatisticsUI statisticsUI);
+    Statistics getRunning(StatisticsUI statisticsUI);
     
     /**
      * Returns the report for the given statistics class or <code>null</code> if no report
@@ -93,9 +93,9 @@ public interface StatisticsModelUI {
      * @param statistics        a statistics class
      * @return                  the report or <code>null</code> if not found
      */
-    public String getReport(Class<? extends Statistics> statistics);
+    String getReport(Class<? extends Statistics> statistics);
 
-    public void addChangeListener(ChangeListener changeListener);
+    void addChangeListener(ChangeListener changeListener);
 
-    public void removeChangeListener(ChangeListener changeListener);
+    void removeChangeListener(ChangeListener changeListener);
 }

--- a/modules/DesktopTools/src/main/java/org/gephi/desktop/tools/DesktopToolController.java
+++ b/modules/DesktopTools/src/main/java/org/gephi/desktop/tools/DesktopToolController.java
@@ -244,11 +244,11 @@ public class DesktopToolController implements ToolController {
     }
 
     //Event handlers classes
-    private static interface ToolEventHandler {
+    private interface ToolEventHandler {
 
-        public void select();
+        void select();
 
-        public void unselect();
+        void unselect();
     }
 
     //HANDLERS

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/api/ExportController.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/api/ExportController.java
@@ -62,19 +62,19 @@ import org.gephi.project.api.Workspace;
  */
 public interface ExportController {
 
-    public void exportFile(File file) throws IOException;
+    void exportFile(File file) throws IOException;
 
-    public void exportFile(File file, Workspace workspace) throws IOException;
+    void exportFile(File file, Workspace workspace) throws IOException;
 
-    public void exportFile(File file, Exporter fileExporter) throws IOException;
+    void exportFile(File file, Exporter fileExporter) throws IOException;
 
-    public void exportWriter(Writer writer, CharacterExporter characterExporter);
+    void exportWriter(Writer writer, CharacterExporter characterExporter);
 
-    public void exportStream(OutputStream stream, ByteExporter byteExporter);
+    void exportStream(OutputStream stream, ByteExporter byteExporter);
 
-    public Exporter getFileExporter(File file);
+    Exporter getFileExporter(File file);
 
-    public Exporter getExporter(String exporterName);
+    Exporter getExporter(String exporterName);
 
-    public ExporterUI getUI(Exporter exporter);
+    ExporterUI getUI(Exporter exporter);
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/ByteExporter.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/ByteExporter.java
@@ -54,5 +54,5 @@ public interface ByteExporter extends Exporter {
      * Set the stream where to export.
      * @param stream      the stream the exporter is to write
      */
-    public void setOutputStream(OutputStream stream);
+    void setOutputStream(OutputStream stream);
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/CharacterExporter.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/CharacterExporter.java
@@ -54,5 +54,5 @@ public interface CharacterExporter extends Exporter {
      * Set the writer where to export.
      * @param writer      the writer the exporter is to write
      */
-    public void setWriter(Writer writer);
+    void setWriter(Writer writer);
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/Exporter.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/Exporter.java
@@ -56,17 +56,17 @@ public interface Exporter {
      * @return          <code>true</code> if the operation is successful,
      *                  <code>false</code> if it has been cancelled
      */
-    public boolean execute();
+    boolean execute();
 
     /**
      * Sets the worksapce from where to export data
      * @param workspace the workspace to export
      */
-    public void setWorkspace(Workspace workspace);
+    void setWorkspace(Workspace workspace);
 
     /**
      * Returns the workspace from where data are exported
      * @return          the workspace the data are to be exported
      */
-    public Workspace getWorkspace();
+    Workspace getWorkspace();
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/ExporterBuilder.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/ExporterBuilder.java
@@ -60,11 +60,11 @@ public interface ExporterBuilder {
      * Builds a new exporter instance, ready to be used.
      * @return  a new exporter
      */
-    public Exporter buildExporter();
+    Exporter buildExporter();
 
     /**
      * Returns the name of this builder
      * @return  the name of this exporter
      */
-    public String getName();
+    String getName();
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/ExporterUI.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/ExporterUI.java
@@ -55,7 +55,7 @@ public interface ExporterUI {
      *
      * @return a settings panel, or <code>null</code>
      */
-    public JPanel getPanel();
+    JPanel getPanel();
 
     /**
      * Link the UI to the exporter and therefore to settings values. This method
@@ -63,7 +63,7 @@ public interface ExporterUI {
      *
      * @param exporter  the exporter that settings is to be set
      */
-    public void setup(Exporter exporter);
+    void setup(Exporter exporter);
 
     /**
      * Notify UI the settings panel has been closed and that new values can be
@@ -72,7 +72,7 @@ public interface ExporterUI {
      * @param update    <code>true</code> if user clicked OK or <code>false</code>
      *                  if CANCEL.
      */
-    public void unsetup(boolean update);
+    void unsetup(boolean update);
 
     /**
      * Returns <code>true</code> if this UI belongs to the given exporter.
@@ -81,11 +81,11 @@ public interface ExporterUI {
      * @return          <code>true</code> if the UI is matching with <code>exporter</code>,
      *                  <code>false</code> otherwise.
      */
-    public boolean isUIForExporter(Exporter exporter);
+    boolean isUIForExporter(Exporter exporter);
 
     /**
      * Returns the exporter display name
      * @return          the exporter display name
      */
-    public String getDisplayName();
+    String getDisplayName();
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/FileExporterBuilder.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/FileExporterBuilder.java
@@ -54,5 +54,5 @@ public interface FileExporterBuilder extends ExporterBuilder {
      * Get default file types this exporter can deal with.
      * @return  an array of file types this exporter can read
      */
-    public FileType[] getFileTypes();
+    FileType[] getFileTypes();
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/GraphExporter.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/GraphExporter.java
@@ -54,12 +54,12 @@ public interface GraphExporter extends Exporter {
      * the complete graph is exported.
      * @param exportVisible the export visible parameter value
      */
-    public void setExportVisible(boolean exportVisible);
+    void setExportVisible(boolean exportVisible);
 
     /**
      * Returns <code>true</code> if only the visible graph has to be exported.
      * @return  <code>true</code> if only the visible graph has to be exported,
      *          <code>false</code> for the complete graph.
      */
-    public boolean isExportVisible();
+    boolean isExportVisible();
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/GraphFileExporterBuilder.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/GraphFileExporterBuilder.java
@@ -53,5 +53,5 @@ public interface GraphFileExporterBuilder extends FileExporterBuilder {
      * @return  a new graph exporter
      */
     @Override
-    public GraphExporter buildExporter();
+    GraphExporter buildExporter();
 }

--- a/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/VectorFileExporterBuilder.java
+++ b/modules/ExportAPI/src/main/java/org/gephi/io/exporter/spi/VectorFileExporterBuilder.java
@@ -53,5 +53,5 @@ public interface VectorFileExporterBuilder extends FileExporterBuilder {
      * @return  a new vector exporter
      */
     @Override
-    public VectorExporter buildExporter();
+    VectorExporter buildExporter();
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/api/FilterController.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/api/FilterController.java
@@ -88,7 +88,7 @@ public interface FilterController {
      * @param builder the builder that can create the filter that is to be wrapped in a new query
      * @return a query that is wrapping <code>filter</code>
      */
-    public Query createQuery(FilterBuilder builder);
+    Query createQuery(FilterBuilder builder);
 
     /**
      * Adds <code>query</code> as a new query in the system. The query should be
@@ -96,14 +96,14 @@ public interface FilterController {
      *
      * @param query the query that is to be added
      */
-    public void add(Query query);
+    void add(Query query);
 
     /**
      * Removes <code>query</code> from the system if exists.
      *
      * @param query the query that is to be removed
      */
-    public void remove(Query query);
+    void remove(Query query);
 
     /**
      * Renames <code>query</code> with <code>name</code>.
@@ -111,7 +111,7 @@ public interface FilterController {
      * @param query the query that is to be renamed
      * @param name the new query's name
      */
-    public void rename(Query query, String name);
+    void rename(Query query, String name);
 
     /**
      * Sets <code>subQuery</code> as a child of <code>query</code>. If
@@ -123,7 +123,7 @@ public interface FilterController {
      * @param subQuery the query that is to be added as a child of <code>
      * query</code>
      */
-    public void setSubQuery(Query query, Query subQuery);
+    void setSubQuery(Query query, Query subQuery);
 
     /**
      * Removes <code>query</code> from <code>parent</code> query.
@@ -132,7 +132,7 @@ public interface FilterController {
      * @param parent the query that <code>query</code> is to be removed as a
      * child
      */
-    public void removeSubQuery(Query query, Query parent);
+    void removeSubQuery(Query query, Query parent);
 
     /**
      * Filters main graph with <code>query</code> and set result as the new
@@ -144,7 +144,7 @@ public interface FilterController {
      *
      * @param query the query that is to be executed
      */
-    public void filterVisible(Query query);
+    void filterVisible(Query query);
 
     /**
      * Selects <code>query</code> results on the main graph visualization
@@ -155,7 +155,7 @@ public interface FilterController {
      *
      * @param query the query that is to be executed
      */
-    public void selectVisible(Query query);
+    void selectVisible(Query query);
 
     /**
      * Filtering method for API users. The <code>query</code> is executed and
@@ -164,7 +164,7 @@ public interface FilterController {
      * @param query the query that is to be executed
      * @return a graph view that represents the query result
      */
-    public GraphView filter(Query query);
+    GraphView filter(Query query);
 
     /**
      * Exports <code>query</code> result in a new column <code>title</code>.
@@ -175,7 +175,7 @@ public interface FilterController {
      * @param title the column's title
      * @param query the query that is to be executed
      */
-    public void exportToColumn(String title, Query query);
+    void exportToColumn(String title, Query query);
 
     /**
      * Exports <code>query</code> result in a new workspace. Note that query is
@@ -184,7 +184,7 @@ public interface FilterController {
      *
      * @param query the query that is to be executed
      */
-    public void exportToNewWorkspace(Query query);
+    void exportToNewWorkspace(Query query);
 
     /**
      * Exports <code>query</code> result to visible/hidden labels. Each node and
@@ -194,18 +194,18 @@ public interface FilterController {
      *
      * @param query the query that is to be used to hide labels
      */
-    public void exportToLabelVisible(Query query);
+    void exportToLabelVisible(Query query);
 
-    public void setAutoRefresh(boolean autoRefresh);
+    void setAutoRefresh(boolean autoRefresh);
 
-    public void setCurrentQuery(Query query);
+    void setCurrentQuery(Query query);
 
     /**
      * Returns the filter's model.
      *
      * @return the filter's model
      */
-    public FilterModel getModel();
+    FilterModel getModel();
 
     /**
      * Returns the filter's model for <code>workspace</code>.
@@ -213,5 +213,5 @@ public interface FilterController {
      * @param workspace workspace
      * @return the filter's model in the given workspace
      */
-    public FilterModel getModel(Workspace workspace);
+    FilterModel getModel(Workspace workspace);
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/api/FilterLibrary.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/api/FilterLibrary.java
@@ -66,7 +66,7 @@ public interface FilterLibrary extends Lookup.Provider {
      * for filters working on graph topology, i.e. the structure of nodes and
      * edges.
      */
-    public final static Category TOPOLOGY = new Category(
+    Category TOPOLOGY = new Category(
             NbBundle.getMessage(FilterLibrary.class, "FiltersLibrary.Category.Topology"),
             null,
             null);
@@ -75,7 +75,7 @@ public interface FilterLibrary extends Lookup.Provider {
      * Default <code>Category</code> for attributes filters. Use this category
      * for filters working on attribute values.
      */
-    public final static Category ATTRIBUTES = new Category(
+    Category ATTRIBUTES = new Category(
             NbBundle.getMessage(FilterLibrary.class, "FiltersLibrary.Category.Attributes"),
             null,
             null);
@@ -83,7 +83,7 @@ public interface FilterLibrary extends Lookup.Provider {
     /**
      * Default <code>Category</code> for filters working on edges only.
      */
-    public final static Category EDGE = new Category(
+    Category EDGE = new Category(
             NbBundle.getMessage(FilterLibrary.class, "FiltersLibrary.Category.Edge"),
             null,
             null);
@@ -93,14 +93,14 @@ public interface FilterLibrary extends Lookup.Provider {
      *
      * @param builder the builder that is to be added
      */
-    public void addBuilder(FilterBuilder builder);
+    void addBuilder(FilterBuilder builder);
 
     /**
      * Removes <code>builder</code> from this library.
      *
      * @param builder the builder that is to be removed
      */
-    public void removeBuilder(FilterBuilder builder);
+    void removeBuilder(FilterBuilder builder);
 
     /**
      * Returns this library's lookup. The lookup is a general container for
@@ -121,7 +121,7 @@ public interface FilterLibrary extends Lookup.Provider {
      * @return the lookup container of this library
      */
     @Override
-    public Lookup getLookup();
+    Lookup getLookup();
 
     /**
      * Registers <code>mask</code> as a new <code>FilterLibraryMask</code>. Such
@@ -130,7 +130,7 @@ public interface FilterLibrary extends Lookup.Provider {
      *
      * @param mask the mask that is to be registered
      */
-    public void registerMask(FilterLibraryMask mask);
+    void registerMask(FilterLibraryMask mask);
 
     /**
      * Unregisters <code>mask</code> in the library. The mask will no longer be
@@ -138,7 +138,7 @@ public interface FilterLibrary extends Lookup.Provider {
      *
      * @param mask the mask that is to be unregistered
      */
-    public void unregisterMask(FilterLibraryMask mask);
+    void unregisterMask(FilterLibraryMask mask);
 
     /**
      * Returns the builder that has created <code>filter</code>.
@@ -146,7 +146,7 @@ public interface FilterLibrary extends Lookup.Provider {
      * @param filter the filter that the builder is to be returned
      * @return the builder that has created <code>filter</code>
      */
-    public FilterBuilder getBuilder(Filter filter);
+    FilterBuilder getBuilder(Filter filter);
 
     /**
      * Save <code>query</code> in the library in order it can be reused. Saved
@@ -154,7 +154,7 @@ public interface FilterLibrary extends Lookup.Provider {
      *
      * @param query the query that is to be saved
      */
-    public void saveQuery(Query query);
+    void saveQuery(Query query);
 
     /**
      * Delete a saved <code>query</code> from the library. Deleted queries are
@@ -162,5 +162,5 @@ public interface FilterLibrary extends Lookup.Provider {
      *
      * @param query the query that is to be deleted
      */
-    public void deleteQuery(Query query);
+    void deleteQuery(Query query);
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/api/FilterModel.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/api/FilterModel.java
@@ -61,14 +61,14 @@ public interface FilterModel {
      *
      * @return the filter library
      */
-    public FilterLibrary getLibrary();
+    FilterLibrary getLibrary();
 
     /**
      * Returns all queries in the model, represented by their root query.
      *
      * @return all root queries in the model
      */
-    public Query[] getQueries();
+    Query[] getQueries();
 
     /**
      * Returns the query currently active or <code>null</code> if none is
@@ -76,7 +76,7 @@ public interface FilterModel {
      *
      * @return the current query
      */
-    public Query getCurrentQuery();
+    Query getCurrentQuery();
 
     /**
      * Returns <code>true</code> if the system is currently in filtering mode.
@@ -84,7 +84,7 @@ public interface FilterModel {
      * @return          <code>true</code> if the result graph is filtered,
      * <code>false</code> if it's in selection mode
      */
-    public boolean isFiltering();
+    boolean isFiltering();
 
     /**
      * Returns <code>true</code> if the system is currently in selection mode.
@@ -92,11 +92,11 @@ public interface FilterModel {
      * @return          <code>true</code> if the result is selected on the graph,
      * <code>false</code> if it's filtered
      */
-    public boolean isSelecting();
+    boolean isSelecting();
 
-    public boolean isAutoRefresh();
+    boolean isAutoRefresh();
 
-    public void addChangeListener(ChangeListener listener);
+    void addChangeListener(ChangeListener listener);
 
-    public void removeChangeListener(ChangeListener listener);
+    void removeChangeListener(ChangeListener listener);
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/api/PropertyExecutor.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/api/PropertyExecutor.java
@@ -64,14 +64,14 @@ public interface PropertyExecutor {
      * @param callback the callback function to be notified when setting has to
      * be done
      */
-    public void setValue(FilterProperty property, Object value, Callback callback);
+    void setValue(FilterProperty property, Object value, Callback callback);
 
     /**
      * Callback interface for setting value. When called, setting value is done
      * in a safe window between filter execution.
      */
-    public interface Callback {
+    interface Callback {
 
-        public void setValue(Object value);
+        void setValue(Object value);
     }
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/api/Query.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/api/Query.java
@@ -68,14 +68,14 @@ public interface Query {
      *
      * @return query's name
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns queries that are children of this query.
      *
      * @return query's children
      */
-    public Query[] getChildren();
+    Query[] getChildren();
 
     /**
      * Returns the limit number of children this query can have. Return 1 for a
@@ -83,21 +83,21 @@ public interface Query {
      *
      * @return the number of allowed children query
      */
-    public int getChildrenSlotsCount();
+    int getChildrenSlotsCount();
 
     /**
      * Returns the parent query or <code>null</code> if this query is root.
      *
      * @return the query's parent query, or <code>null</code>
      */
-    public Query getParent();
+    Query getParent();
 
     /**
      * Returns the number of properties this query has.
      *
      * @return the query's number of properties
      */
-    public int getPropertiesCount();
+    int getPropertiesCount();
 
     /**
      * Returns the name of the property at the specified <code>index</code>.
@@ -107,7 +107,7 @@ public interface Query {
      * @throws ArrayIndexOutOfBoundsException if <code>index</code> is out of
      * bounds
      */
-    public String getPropertyName(int index);
+    String getPropertyName(int index);
 
     /**
      * Returns the value of the property at the specified <code>index</code>.
@@ -117,7 +117,7 @@ public interface Query {
      * @throws ArrayIndexOutOfBoundsException if <code>index</code> is out of
      * bounds
      */
-    public Object getPropertyValue(int index);
+    Object getPropertyValue(int index);
 
     /**
      * Utility method that returns all queries in this query hierarchy that are
@@ -127,21 +127,21 @@ public interface Query {
      * @return all queries, including self that are <code>filterClass</code>
      * instance
      */
-    public Query[] getQueries(Class<? extends Filter> filterClass);
+    Query[] getQueries(Class<? extends Filter> filterClass);
 
     /**
      * Utility method that returns all descendant queries plus this query.
      *
      * @return all descendant queries and self
      */
-    public Query[] getDescendantsAndSelf();
+    Query[] getDescendantsAndSelf();
 
     /**
      * Returns the filter this query is wrapping.
      *
      * @return the filter
      */
-    public Filter getFilter();
+    Filter getFilter();
 
     /**
      * Returns the filter builder that creates the filter this query is
@@ -149,5 +149,5 @@ public interface Query {
      *
      * @return the builder or null
      */
-    public FilterBuilder getBuilder();
+    FilterBuilder getBuilder();
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/CategoryBuilder.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/CategoryBuilder.java
@@ -62,7 +62,7 @@ public interface CategoryBuilder {
      *
      * @return the builders this category builder is building
      */
-    public FilterBuilder[] getBuilders();
+    FilterBuilder[] getBuilders();
 
     /**
      * Returns the category builders are to be grouped in. It can't be a default
@@ -70,5 +70,5 @@ public interface CategoryBuilder {
      *
      * @return the category builders belong to
      */
-    public Category getCategory();
+    Category getCategory();
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/ComplexFilter.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/ComplexFilter.java
@@ -52,5 +52,5 @@ import org.gephi.graph.api.Graph;
  */
 public interface ComplexFilter extends Filter {
 
-    public Graph filter(Graph graph);
+    Graph filter(Graph graph);
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/ElementFilter.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/ElementFilter.java
@@ -58,9 +58,9 @@ import org.gephi.graph.api.Graph;
  */
 public interface ElementFilter<K extends Element> extends Filter {
 
-    public boolean init(Graph graph);
+    boolean init(Graph graph);
 
-    public boolean evaluate(Graph graph, K element);
+    boolean evaluate(Graph graph, K element);
 
-    public void finish();
+    void finish();
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/Filter.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/Filter.java
@@ -65,7 +65,7 @@ public interface Filter {
      *
      * @return the filter's display name
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns the filter properties. Property values can be get and set from
@@ -73,5 +73,5 @@ public interface Filter {
      *
      * @return the filter's properties
      */
-    public FilterProperty[] getProperties();
+    FilterProperty[] getProperties();
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/FilterBuilder.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/FilterBuilder.java
@@ -70,35 +70,35 @@ public interface FilterBuilder {
      *
      * @return the category this builder belongs to
      */
-    public Category getCategory();
+    Category getCategory();
 
     /**
      * Returns the display name of this filter builder
      *
      * @return the display name
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns the icon of this filter builder
      *
      * @return the icon
      */
-    public Icon getIcon();
+    Icon getIcon();
 
     /**
      * Returns this description text of this filter builder
      *
      * @return the description
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * Builds a new <code>Filter</code> instance.
      *
      * @return a new <code>Filter</code> object
      */
-    public Filter getFilter();
+    Filter getFilter();
 
     /**
      * Returns the settings panel for the filter this builder is building, the
@@ -107,11 +107,11 @@ public interface FilterBuilder {
      * @param filter the filter that the panel is to be configuring
      * @return the filter's settings panel
      */
-    public JPanel getPanel(Filter filter);
+    JPanel getPanel(Filter filter);
 
     /**
      * Notification when the filter is destroyed, to perform clean-up tasks.
      * @param filter filter to be destroyed
      */
-    public void destroy(Filter filter);
+    void destroy(Filter filter);
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/FilterLibraryMask.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/FilterLibraryMask.java
@@ -61,7 +61,7 @@ public interface FilterLibraryMask {
      *
      * @return the <code>Category</code> this filter is describing
      */
-    public Category getCategory();
+    Category getCategory();
 
     /**
      * Returns <code>true</code> if this masks' category is valid.
@@ -69,5 +69,5 @@ public interface FilterLibraryMask {
      * @return <code>true</code> if the category is valid, <code>false</code>
      * otherwise
      */
-    public boolean isValid();
+    boolean isValid();
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/Operator.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/Operator.java
@@ -50,9 +50,9 @@ import org.gephi.graph.api.Subgraph;
  */
 public interface Operator extends Filter {
 
-    public Graph filter(Subgraph[] graphs);
+    Graph filter(Subgraph[] graphs);
 
-    public Graph filter(Graph graph, Filter[] filters);
+    Graph filter(Graph graph, Filter[] filters);
 
-    public int getInputCount();
+    int getInputCount();
 }

--- a/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/RangeFilter.java
+++ b/modules/FiltersAPI/src/main/java/org/gephi/filters/spi/RangeFilter.java
@@ -49,8 +49,8 @@ import org.gephi.graph.api.Graph;
  */
 public interface RangeFilter extends Filter {
 
-    public Number[] getValues(Graph graph);
+    Number[] getValues(Graph graph);
 
-    public FilterProperty getRangeProperty();
+    FilterProperty getRangeProperty();
 
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/EqualBooleanUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/EqualBooleanUI.java
@@ -49,5 +49,5 @@ import javax.swing.JPanel;
  */
 public interface EqualBooleanUI {
 
-    public JPanel getPanel(AttributeEqualBuilder.EqualBooleanFilter filter);
+    JPanel getPanel(AttributeEqualBuilder.EqualBooleanFilter filter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/EqualNumberUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/EqualNumberUI.java
@@ -49,6 +49,6 @@ import javax.swing.JPanel;
  */
 public interface EqualNumberUI {
 
-    public JPanel getPanel(AttributeEqualBuilder.EqualNumberFilter filter);
+    JPanel getPanel(AttributeEqualBuilder.EqualNumberFilter filter);
 }
 

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/EqualStringUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/EqualStringUI.java
@@ -50,5 +50,5 @@ import org.gephi.filters.plugin.attribute.AttributeEqualBuilder.EqualStringFilte
  */
 public interface EqualStringUI {
 
-    public JPanel getPanel(EqualStringFilter filter);
+    JPanel getPanel(EqualStringFilter filter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/dynamic/DynamicRangeUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/dynamic/DynamicRangeUI.java
@@ -50,5 +50,5 @@ import org.gephi.filters.plugin.dynamic.DynamicRangeBuilder.DynamicRangeFilter;
  */
 public interface DynamicRangeUI {
 
-    public JPanel getPanel(DynamicRangeFilter filter);
+    JPanel getPanel(DynamicRangeFilter filter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/edge/EdgeTypeUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/edge/EdgeTypeUI.java
@@ -49,5 +49,5 @@ import javax.swing.JPanel;
  */
 public interface EdgeTypeUI {
 
-    public JPanel getPanel(EdgeTypeBuilder.EdgeTypeFilter filter);
+    JPanel getPanel(EdgeTypeBuilder.EdgeTypeFilter filter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/EgoUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/EgoUI.java
@@ -49,5 +49,5 @@ import javax.swing.JPanel;
  */
 public interface EgoUI {
 
-    public JPanel getPanel(EgoBuilder.EgoFilter egoFilter);
+    JPanel getPanel(EgoBuilder.EgoFilter egoFilter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/KCoreUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/KCoreUI.java
@@ -49,5 +49,5 @@ import javax.swing.JPanel;
  */
 public interface KCoreUI {
 
-    public JPanel getPanel(KCoreBuilder.KCoreFilter filter);
+    JPanel getPanel(KCoreBuilder.KCoreFilter filter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/NeighborsUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/NeighborsUI.java
@@ -49,5 +49,5 @@ import javax.swing.JPanel;
  */
 public interface NeighborsUI {
 
-    public JPanel getPanel(NeighborsBuilder.NeighborsFilter neighborsFilter);
+    JPanel getPanel(NeighborsBuilder.NeighborsFilter neighborsFilter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/RangeUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/graph/RangeUI.java
@@ -50,5 +50,5 @@ import org.gephi.filters.spi.RangeFilter;
  */
 public interface RangeUI {
 
-    public JPanel getPanel(RangeFilter rangeFilter);
+    JPanel getPanel(RangeFilter rangeFilter);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/operator/MASKEdgeUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/operator/MASKEdgeUI.java
@@ -49,5 +49,5 @@ import javax.swing.JPanel;
  */
 public interface MASKEdgeUI {
 
-    public JPanel getPanel(MASKBuilderEdge.MaskEdgeOperator edgesOperator);
+    JPanel getPanel(MASKBuilderEdge.MaskEdgeOperator edgesOperator);
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/PartitionUI.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/PartitionUI.java
@@ -50,5 +50,5 @@ import org.gephi.filters.plugin.partition.PartitionBuilder.PartitionFilter;
  */
 public interface PartitionUI {
 
-    public JPanel getPanel(PartitionFilter filter);
+    JPanel getPanel(PartitionFilter filter);
 }

--- a/modules/GeneratorAPI/src/main/java/org/gephi/io/generator/api/GeneratorController.java
+++ b/modules/GeneratorAPI/src/main/java/org/gephi/io/generator/api/GeneratorController.java
@@ -58,7 +58,7 @@ public interface GeneratorController {
      * Returns generators currently loaded in the system.
      * @return          generators array that are available
      */
-    public Generator[] getGenerators();
+    Generator[] getGenerators();
 
     /**
      * Execute a generator task in a background thread.
@@ -67,5 +67,5 @@ public interface GeneratorController {
      * workspace if the project is empty.
      * @param generator the generator that is to be executed
      */
-    public void generate(Generator generator);
+    void generate(Generator generator);
 }

--- a/modules/GeneratorAPI/src/main/java/org/gephi/io/generator/spi/Generator.java
+++ b/modules/GeneratorAPI/src/main/java/org/gephi/io/generator/spi/Generator.java
@@ -59,18 +59,18 @@ public interface Generator extends LongTask {
      * the graph to <code>GraphAPI</code>.
      * @param container the container the graph is to be pushed
      */
-    public void generate(ContainerLoader container);
+    void generate(ContainerLoader container);
 
     /**
      * Returns the generator display name.
      * @return          returns the generator name
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns the UI that belongs to this generator, or <code>null</code> if UI
      * is not needed.
      * @return          the UI thet belongs to this generator, or <code>null</code>
      */
-    public GeneratorUI getUI();
+    GeneratorUI getUI();
 }

--- a/modules/GeneratorAPI/src/main/java/org/gephi/io/generator/spi/GeneratorUI.java
+++ b/modules/GeneratorAPI/src/main/java/org/gephi/io/generator/spi/GeneratorUI.java
@@ -58,17 +58,17 @@ public interface GeneratorUI {
      * Returns the panel settings.
      * @return          the panel settings
      */
-    public JPanel getPanel();
+    JPanel getPanel();
 
     /**
      * Push the generator instance to get settings values.
      * @param generator the generator instance that is to be configured
      */
-    public void setup(Generator generator);
+    void setup(Generator generator);
 
     /**
      * Notify UI that generator settings panel has been closed and that
      * settings values can be written into current generator instance.
      */
-    public void unsetup();
+    void unsetup();
 }

--- a/modules/GraphAPI/src/main/java/org/gephi/graph/api/GraphController.java
+++ b/modules/GraphAPI/src/main/java/org/gephi/graph/api/GraphController.java
@@ -59,7 +59,7 @@ public interface GraphController {
      *
      * @return the current graph model
      */
-    public GraphModel getGraphModel();
+    GraphModel getGraphModel();
 
     /**
      * Returns the graph model for the given <code>workspace</code>.
@@ -67,5 +67,5 @@ public interface GraphController {
      * @param workspace the workspace that graph model is to be returned
      * @return the <code>workspace</code>'s graph model
      */
-    public GraphModel getGraphModel(Workspace workspace);
+    GraphModel getGraphModel(Workspace workspace);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ColumnDraft.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ColumnDraft.java
@@ -55,42 +55,42 @@ public interface ColumnDraft {
      *
      * @return column's id
      */
-    public String getId();
+    String getId();
 
     /**
      * Gets the column's title.
      *
      * @return column's title or null if empty
      */
-    public String getTitle();
+    String getTitle();
 
     /**
      * Gets the column's type.
      *
      * @return column's type
      */
-    public Class getTypeClass();
+    Class getTypeClass();
 
     /**
      * Gets the column's default value.
      *
      * @return default value or null if empty
      */
-    public Object getDefaultValue();
+    Object getDefaultValue();
 
     /**
      * Returns true if this column is dynamic.
      *
      * @return true if dynamic, false otherwise
      */
-    public boolean isDynamic();
+    boolean isDynamic();
 
     /**
      * Sets the column's title.
      *
      * @param title column title
      */
-    public void setTitle(String title);
+    void setTitle(String title);
 
     /**
      * Sets the column's default value.
@@ -99,7 +99,7 @@ public interface ColumnDraft {
      *
      * @param value default value
      */
-    public void setDefaultValue(Object value);
+    void setDefaultValue(Object value);
 
     /**
      * Sets the column's default value as a string.
@@ -108,5 +108,5 @@ public interface ColumnDraft {
      *
      * @param value value to parse and to be set as default
      */
-    public void setDefaultValueString(String value);
+    void setDefaultValueString(String value);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Container.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Container.java
@@ -64,14 +64,14 @@ public interface Container {
     /**
      * Container factory.
      */
-    public interface Factory {
+    interface Factory {
 
         /**
          * Returns a newly created container instance.
          *
          * @return new container
          */
-        public Container newContainer();
+        Container newContainer();
     }
 
     /**
@@ -80,7 +80,7 @@ public interface Container {
      * @param source original source of data.
      * @throws NullPointerException if <code>source</code> is <code>null</code>
      */
-    public void setSource(String source);
+    void setSource(String source);
 
     /**
      * If exists, returns the source of the data.
@@ -88,7 +88,7 @@ public interface Container {
      * @return source of the data, or <code>null</code> if source is not
      * defined.
      */
-    public String getSource();
+    String getSource();
 
     /**
      * Gets the container loading interface.
@@ -99,7 +99,7 @@ public interface Container {
      *
      * @return containers loading interface
      */
-    public ContainerLoader getLoader();
+    ContainerLoader getLoader();
 
     /**
      * Get the container unloading interface.
@@ -110,7 +110,7 @@ public interface Container {
      *
      * @return container unloading interface
      */
-    public ContainerUnloader getUnloader();
+    ContainerUnloader getUnloader();
 
     /**
      * Sets a report this container can use to report issues detected when
@@ -123,7 +123,7 @@ public interface Container {
      * container
      * @throws NullPointerException if <code>report</code> is <code>null</code>
      */
-    public void setReport(Report report);
+    void setReport(Report report);
 
     /**
      * Returns the report associated to this container, if it exists.
@@ -131,7 +131,7 @@ public interface Container {
      * @return report set for this container or <code>null</code> if no report
      * is defined
      */
-    public Report getReport();
+    Report getReport();
 
     /**
      * This method must be called after the loading is complete and before
@@ -142,12 +142,12 @@ public interface Container {
      * @return <code>true</code> if container data is consistent,
      * <code>false</code> otherwise
      */
-    public boolean verify();
+    boolean verify();
 
     /**
      * Close the current loading and clean content before unloading.
      */
-    public void closeLoader();
+    void closeLoader();
 
     /**
      * Returns true if this container contains a dynamic graph.
@@ -156,7 +156,7 @@ public interface Container {
      *
      * @return true if dynamic, false otherwise
      */
-    public boolean isDynamicGraph();
+    boolean isDynamicGraph();
 
     /**
      * Returns true if this container contains elements that have dynamic
@@ -166,14 +166,14 @@ public interface Container {
      *
      * @return true if dynamic attributes, false otherwise
      */
-    public boolean hasDynamicAttributes();
+    boolean hasDynamicAttributes();
 
     /**
      * Returns true if edges in this container are self-loops.
      *
      * @return true if presence of self-loops, false otherwise
      */
-    public boolean hasSelfLoops();
+    boolean hasSelfLoops();
 
     /**
      * Returns true if this container contains a multigraph.
@@ -183,5 +183,5 @@ public interface Container {
      *
      * @return true if multigraph, false otherwise
      */
-    public boolean isMultiGraph();
+    boolean isMultiGraph();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerLoader.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerLoader.java
@@ -70,7 +70,7 @@ public interface ContainerLoader {
      *
      * @param edgeDraft edge that is to be pushed to this container
      */
-    public void addEdge(EdgeDraft edgeDraft);
+    void addEdge(EdgeDraft edgeDraft);
 
     /**
      * Adds a node to this container. Identified by its <b>id</b>. If no id is
@@ -78,7 +78,7 @@ public interface ContainerLoader {
      *
      * @param nodeDraft node that is to be pushed to this container
      */
-    public void addNode(NodeDraft nodeDraft);
+    void addNode(NodeDraft nodeDraft);
 
     /**
      * Removes an edge from this container. Do nothing if the edge is not in the
@@ -86,7 +86,7 @@ public interface ContainerLoader {
      *
      * @param edgeDraft edge that is to be removed from this container
      */
-    public void removeEdge(EdgeDraft edgeDraft);
+    void removeEdge(EdgeDraft edgeDraft);
 
     /**
      * Returns the node with the given <code>id</code>, or create a new node
@@ -95,7 +95,7 @@ public interface ContainerLoader {
      * @param id node identifier
      * @return found node, or a new default node
      */
-    public NodeDraft getNode(String id);
+    NodeDraft getNode(String id);
 
     /**
      * Returns <code>true</code> if a node exists with the given
@@ -104,7 +104,7 @@ public interface ContainerLoader {
      * @param id node identifier
      * @return <code>true</code> if node exists, <code>false</code> otherwise
      */
-    public boolean nodeExists(String id);
+    boolean nodeExists(String id);
 
     /**
      * Returns the edge with the given <code>id</code>, or <code>null</code> if
@@ -114,7 +114,7 @@ public interface ContainerLoader {
      * @return edge with <code>id</code> as an identifier, or <code>null</code>
      * if not found
      */
-    public EdgeDraft getEdge(String id);
+    EdgeDraft getEdge(String id);
 
     /**
      * Returns <code>true</code> if an edge exists with the given
@@ -123,7 +123,7 @@ public interface ContainerLoader {
      * @param id an edge identifier
      * @return <code>true</code> if edge exists, <code>false</code> otherwise
      */
-    public boolean edgeExists(String id);
+    boolean edgeExists(String id);
 
     /**
      * Returns <code>true</code> if an edge exists from <code>source</code> to
@@ -133,7 +133,7 @@ public interface ContainerLoader {
      * @param target edge target node
      * @return <code>true</code> if edges exists, <code>false</code> otherwise
      */
-    public boolean edgeExists(String source, String target);
+    boolean edgeExists(String source, String target);
 
     /**
      * Set edge default type: <b>DIRECTED</b>, <b>UNDIRECTED</b> or
@@ -141,7 +141,7 @@ public interface ContainerLoader {
      *
      * @param edgeDefault edge default type value
      */
-    public void setEdgeDefault(EdgeDirectionDefault edgeDefault);
+    void setEdgeDefault(EdgeDirectionDefault edgeDefault);
 
     /**
      * Returns the node column draft with <code>key</code> as identifier.
@@ -149,7 +149,7 @@ public interface ContainerLoader {
      * @param key node column key
      * @return column draft or null if not found
      */
-    public ColumnDraft getNodeColumn(String key);
+    ColumnDraft getNodeColumn(String key);
 
     /**
      * Returns the edge column draft with <code>key</code> as identifier.
@@ -157,7 +157,7 @@ public interface ContainerLoader {
      * @param key edge column key
      * @return column draft or null if not found
      */
-    public ColumnDraft getEdgeColumn(String key);
+    ColumnDraft getEdgeColumn(String key);
 
     /**
      * Adds a new node column to this container.
@@ -169,7 +169,7 @@ public interface ContainerLoader {
      * @param typeClass node column type
      * @return column draft
      */
-    public ColumnDraft addNodeColumn(String key, Class typeClass);
+    ColumnDraft addNodeColumn(String key, Class typeClass);
 
     /**
      * Adds a new edge column to this container.
@@ -181,7 +181,7 @@ public interface ContainerLoader {
      * @param typeClass edge column type
      * @return column draft
      */
-    public ColumnDraft addEdgeColumn(String key, Class typeClass);
+    ColumnDraft addEdgeColumn(String key, Class typeClass);
 
     /**
      * Adds a new dynamic node column to this container.
@@ -196,7 +196,7 @@ public interface ContainerLoader {
      * @param dynamic true if the column needs to be dynamic, false otherwise
      * @return column draft
      */
-    public ColumnDraft addNodeColumn(String key, Class typeClass, boolean dynamic);
+    ColumnDraft addNodeColumn(String key, Class typeClass, boolean dynamic);
 
     /**
      * Adds a new dynamic edge column to this container.
@@ -211,14 +211,14 @@ public interface ContainerLoader {
      * @param dynamic true if the column needs to be dynamic, false otherwise
      * @return column draft
      */
-    public ColumnDraft addEdgeColumn(String key, Class typeClass, boolean dynamic);
+    ColumnDraft addEdgeColumn(String key, Class typeClass, boolean dynamic);
 
     /**
      * Returns the <b>factory</b> for building nodes and edges instances.
      *
      * @return the draft factory
      */
-    public ElementDraft.Factory factory();
+    ElementDraft.Factory factory();
 
     /**
      * Sets the current Time Format for dynamic data, either <code>DATE</code>,
@@ -229,7 +229,7 @@ public interface ContainerLoader {
      *
      * @param timeFormat time format
      */
-    public void setTimeFormat(TimeFormat timeFormat);
+    void setTimeFormat(TimeFormat timeFormat);
 
     /**
      * Sets the timestamp for the entire graph. All elements and all dynamic
@@ -238,7 +238,7 @@ public interface ContainerLoader {
      *
      * @param timestamp timestamp
      */
-    public void setTimestamp(String timestamp);
+    void setTimestamp(String timestamp);
 
     /**
      * Sets the interval for the entire graph. All elements and all dynamic
@@ -248,14 +248,14 @@ public interface ContainerLoader {
      * @param start interval start
      * @param end interval end
      */
-    public void setInterval(String start, String end);
+    void setInterval(String start, String end);
 
     /**
      * Sets the type of the id for elements.
      *
      * @param type id type
      */
-    public void setElementIdType(ElementIdType type);
+    void setElementIdType(ElementIdType type);
 
     /**
      * Sets the current time representation, either <code>TIMESTAMP</code> or
@@ -265,7 +265,7 @@ public interface ContainerLoader {
      *
      * @param timeRepresentation time representation
      */
-    public void setTimeRepresentation(TimeRepresentation timeRepresentation);
+    void setTimeRepresentation(TimeRepresentation timeRepresentation);
 
     /**
      * Gets the current time representation, either <code>TIMESTAMP</code> or
@@ -273,7 +273,7 @@ public interface ContainerLoader {
      * <p>
      * @return time representation
      */
-    public TimeRepresentation getTimeRepresentation();
+    TimeRepresentation getTimeRepresentation();
 
     /**
      * Sets the time zone that is used to parse date and time.
@@ -282,16 +282,16 @@ public interface ContainerLoader {
      *
      * @param timeZone time zone
      */
-    public void setTimeZone(DateTimeZone timeZone);
+    void setTimeZone(DateTimeZone timeZone);
 
     //PARAMETERS SETTERS
-    public void setAllowSelfLoop(boolean value);
+    void setAllowSelfLoop(boolean value);
 
-    public void setAllowAutoNode(boolean value);
+    void setAllowAutoNode(boolean value);
 
-    public void setAllowParallelEdge(boolean value);
+    void setAllowParallelEdge(boolean value);
 
-    public void setAutoScale(boolean autoscale);
+    void setAutoScale(boolean autoscale);
 
-    public void setEdgesMergeStrategy(EdgeWeightMergeStrategy edgesMergeStrategy);
+    void setEdgesMergeStrategy(EdgeWeightMergeStrategy edgesMergeStrategy);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerUnloader.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerUnloader.java
@@ -61,48 +61,48 @@ import org.joda.time.DateTimeZone;
  */
 public interface ContainerUnloader {
 
-    public Iterable<NodeDraft> getNodes();
+    Iterable<NodeDraft> getNodes();
 
-    public int getNodeCount();
+    int getNodeCount();
 
-    public Iterable<EdgeDraft> getEdges();
+    Iterable<EdgeDraft> getEdges();
 
-    public int getEdgeCount();
+    int getEdgeCount();
 
-    public boolean hasNodeColumn(String key);
+    boolean hasNodeColumn(String key);
 
-    public boolean hasEdgeColumn(String key);
+    boolean hasEdgeColumn(String key);
 
-    public Iterable<ColumnDraft> getNodeColumns();
+    Iterable<ColumnDraft> getNodeColumns();
 
-    public Iterable<ColumnDraft> getEdgeColumns();
+    Iterable<ColumnDraft> getEdgeColumns();
 
-    public EdgeDirectionDefault getEdgeDefault();
+    EdgeDirectionDefault getEdgeDefault();
 
-    public TimeFormat getTimeFormat();
+    TimeFormat getTimeFormat();
 
-    public TimeRepresentation getTimeRepresentation();
+    TimeRepresentation getTimeRepresentation();
 
-    public DateTimeZone getTimeZone();
+    DateTimeZone getTimeZone();
 
-    public String getSource();
+    String getSource();
 
-    public Class getEdgeTypeLabelClass();
+    Class getEdgeTypeLabelClass();
 
-    public Double getTimestamp();
+    Double getTimestamp();
 
-    public Interval getInterval();
+    Interval getInterval();
 
-    public ElementIdType getElementIdType();
+    ElementIdType getElementIdType();
 
     //PARAMETERS GETTERS
-    public boolean allowSelfLoop();
+    boolean allowSelfLoop();
 
-    public boolean allowAutoNode();
+    boolean allowAutoNode();
 
-    public boolean allowParallelEdges();
+    boolean allowParallelEdges();
 
-    public boolean isAutoScale();
+    boolean isAutoScale();
 
-    public EdgeWeightMergeStrategy getEdgesMergeStrategy();
+    EdgeWeightMergeStrategy getEdgesMergeStrategy();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Database.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Database.java
@@ -52,33 +52,33 @@ import org.gephi.io.database.drivers.SQLDriver;
  */
 public interface Database extends Serializable {
 
-    public String getName();
+    String getName();
 
-    public SQLDriver getSQLDriver();
+    SQLDriver getSQLDriver();
 
-    public String getHost();
+    String getHost();
 
-    public int getPort();
+    int getPort();
 
-    public String getUsername();
+    String getUsername();
 
-    public String getPasswd();
+    String getPasswd();
 
-    public String getDBName();
+    String getDBName();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public void setSQLDriver(SQLDriver driver);
+    void setSQLDriver(SQLDriver driver);
 
-    public void setHost(String host);
+    void setHost(String host);
 
-    public void setPort(int port);
+    void setPort(int port);
 
-    public void setUsername(String username);
+    void setUsername(String username);
 
-    public void setPasswd(String passwd);
+    void setPasswd(String passwd);
 
-    public void setDBName(String dbName);
+    void setDBName(String dbName);
 
-    public PropertiesAssociations getPropertiesAssociations();
+    PropertiesAssociations getPropertiesAssociations();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeDraft.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeDraft.java
@@ -58,14 +58,14 @@ public interface EdgeDraft extends ElementDraft {
      *
      * @param weight edge's weight
      */
-    public void setWeight(double weight);
+    void setWeight(double weight);
 
     /**
      * Returns this edge's weight.
      *
      * @return edge's weight
      */
-    public double getWeight();
+    double getWeight();
 
     /**
      * Sets this edge's type.
@@ -75,7 +75,7 @@ public interface EdgeDraft extends ElementDraft {
      *
      * @param type edge type
      */
-    public void setType(Object type);
+    void setType(Object type);
 
     /**
      * Gets this edge's type.
@@ -85,28 +85,28 @@ public interface EdgeDraft extends ElementDraft {
      *
      * @return edge's type or null if unset
      */
-    public Object getType();
+    Object getType();
 
     /**
      * Sets this edge's direction setting.
      *
      * @param direction edge's direction
      */
-    public void setDirection(EdgeDirection direction);
+    void setDirection(EdgeDirection direction);
 
     /**
      * Returns this edge's direction setting.
      *
      * @return edge's direction or null if unset
      */
-    public EdgeDirection getDirection();
+    EdgeDirection getDirection();
 
     /**
      * Sets this edge's source.
      *
      * @param nodeSource node source
      */
-    public void setSource(NodeDraft nodeSource);
+    void setSource(NodeDraft nodeSource);
 
     /**
      * Sets this edge's target.
@@ -115,21 +115,21 @@ public interface EdgeDraft extends ElementDraft {
      *
      * @param nodeTarget node target
      */
-    public void setTarget(NodeDraft nodeTarget);
+    void setTarget(NodeDraft nodeTarget);
 
     /**
      * Get edge's source.
      *
      * @return edge's source or null if unset
      */
-    public NodeDraft getSource();
+    NodeDraft getSource();
 
     /**
      * Get edge's target.
      *
      * @return edge's target or null if unset
      */
-    public NodeDraft getTarget();
+    NodeDraft getTarget();
 
     /**
      * Returns true if this edge is a self-loop.
@@ -138,5 +138,5 @@ public interface EdgeDraft extends ElementDraft {
      *
      * @return true if self-loop, false otherwise
      */
-    public boolean isSelfLoop();
+    boolean isSelfLoop();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ElementDraft.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ElementDraft.java
@@ -60,14 +60,14 @@ public interface ElementDraft {
      * Node and edge draft factory. Creates node and edge to push in the
      * container.
      */
-    public interface Factory {
+    interface Factory {
 
         /**
          * Returns an empty node draft instance.
          *
          * @return an instance of <code>NodeDraft</code>
          */
-        public NodeDraft newNodeDraft();
+        NodeDraft newNodeDraft();
 
         /**
          * Returns an empty node draft instance.
@@ -75,7 +75,7 @@ public interface ElementDraft {
          * @param id node id
          * @return an instance of <code>NodeDraft</code>
          */
-        public NodeDraft newNodeDraft(String id);
+        NodeDraft newNodeDraft(String id);
 
         /**
          * Returns an empty edge draft instance. Note that <b>source</b> and
@@ -83,7 +83,7 @@ public interface ElementDraft {
          *
          * @return an instance of <code>EdgeDraft</code>
          */
-        public EdgeDraft newEdgeDraft();
+        EdgeDraft newEdgeDraft();
 
         /**
          * Returns an empty edge draft instance.
@@ -91,7 +91,7 @@ public interface ElementDraft {
          * @param id edge id
          * @return an instance of <code>EdgeDraft</code>
          */
-        public EdgeDraft newEdgeDraft(String id);
+        EdgeDraft newEdgeDraft(String id);
     }
 
     /**
@@ -101,7 +101,7 @@ public interface ElementDraft {
      *
      * @return element's id
      */
-    public String getId();
+    String getId();
 
     /**
      * Returns the element's value for <code>key</code>.
@@ -109,21 +109,21 @@ public interface ElementDraft {
      * @param key key
      * @return value or null if not found
      */
-    public Object getValue(String key);
+    Object getValue(String key);
 
     /**
      * Returns the element's label.
      *
      * @return label or null if unset
      */
-    public String getLabel();
+    String getLabel();
 
     /**
      * Returns the element's color.
      *
      * @return color or null if unset
      */
-    public Color getColor();
+    Color getColor();
 
     /**
      * Returns true if the label is visible.
@@ -132,7 +132,7 @@ public interface ElementDraft {
      *
      * @return true if label is visible, false otherwise
      */
-    public boolean isLabelVisible();
+    boolean isLabelVisible();
 
     /**
      * Returns the label's size.
@@ -141,14 +141,14 @@ public interface ElementDraft {
      *
      * @return label size
      */
-    public float getLabelSize();
+    float getLabelSize();
 
     /**
      * Returns the label's color.
      *
      * @return label's color
      */
-    public Color getLabelColor();
+    Color getLabelColor();
 
     /**
      * Sets the <code>value</code> for <code>key</code>.
@@ -156,7 +156,7 @@ public interface ElementDraft {
      * @param key key
      * @param value value
      */
-    public void setValue(String key, Object value);
+    void setValue(String key, Object value);
 
     /**
      * Sets the <code>value</code> for <code>key</code> at the given
@@ -166,7 +166,7 @@ public interface ElementDraft {
      * @param value value
      * @param timestamp timestamp
      */
-    public void setValue(String key, Object value, double timestamp);
+    void setValue(String key, Object value, double timestamp);
 
     /**
      * Sets the <code>value</code> for <code>key</code> at the given interval
@@ -177,7 +177,7 @@ public interface ElementDraft {
      * @param start interval start
      * @param end interval end
      */
-    public void setValue(String key, Object value, double start, double end);
+    void setValue(String key, Object value, double start, double end);
 
     /**
      * Sets the <code>value</code> for <code>key</code> at the given
@@ -187,7 +187,7 @@ public interface ElementDraft {
      * @param value value
      * @param dateTime dateTime
      */
-    public void setValue(String key, Object value, String dateTime);
+    void setValue(String key, Object value, String dateTime);
 
     /**
      * Sets the <code>value</code> for <code>key</code> at the given interval
@@ -198,7 +198,7 @@ public interface ElementDraft {
      * @param startDateTime interval start datetime
      * @param endDateTime interval end datetime
      */
-    public void setValue(String key, Object value, String startDateTime, String endDateTime);
+    void setValue(String key, Object value, String startDateTime, String endDateTime);
 
     /**
      * Parses and sets the <code>value</code> for <code>key</code>.
@@ -206,7 +206,7 @@ public interface ElementDraft {
      * @param key key
      * @param value value
      */
-    public void parseAndSetValue(String key, String value);
+    void parseAndSetValue(String key, String value);
 
     /**
      * Parses and sets the <code>value</code> for <code>key</code> at the given
@@ -216,7 +216,7 @@ public interface ElementDraft {
      * @param value value
      * @param timestamp timestamp
      */
-    public void parseAndSetValue(String key, String value, double timestamp);
+    void parseAndSetValue(String key, String value, double timestamp);
 
     /**
      * Parses and sets the <code>value</code> for <code>key</code> at the given
@@ -227,7 +227,7 @@ public interface ElementDraft {
      * @param start interval start
      * @param end interval end
      */
-    public void parseAndSetValue(String key, String value, double start, double end);
+    void parseAndSetValue(String key, String value, double start, double end);
 
     /**
      * Parses and sets the <code>value</code> for <code>key</code> at the given
@@ -237,7 +237,7 @@ public interface ElementDraft {
      * @param value value
      * @param dateTime dateTime
      */
-    public void parseAndSetValue(String key, String value, String dateTime);
+    void parseAndSetValue(String key, String value, String dateTime);
 
     /**
      * Parses and sets the <code>value</code> for <code>key</code> at the given
@@ -248,21 +248,21 @@ public interface ElementDraft {
      * @param startDateTime interval start datetime
      * @param endDateTime interval end datetime
      */
-    public void parseAndSetValue(String key, String value, String startDateTime, String endDateTime);
+    void parseAndSetValue(String key, String value, String startDateTime, String endDateTime);
 
     /**
      * Sets this element's label.
      *
      * @param label label
      */
-    public void setLabel(String label);
+    void setLabel(String label);
 
     /**
      * Sets this element's color.
      *
      * @param color color
      */
-    public void setColor(Color color);
+    void setColor(Color color);
 
     /**
      * Parses and sets this element's color using string components.
@@ -273,7 +273,7 @@ public interface ElementDraft {
      * @param g green component as string
      * @param b blue component as string
      */
-    public void setColor(String r, String g, String b);
+    void setColor(String r, String g, String b);
 
     /**
      * Sets this element's color using real color numbers (i.e numbers between 0
@@ -283,7 +283,7 @@ public interface ElementDraft {
      * @param g green component as float
      * @param b blue component as float
      */
-    public void setColor(float r, float g, float b);
+    void setColor(float r, float g, float b);
 
     /**
      * Sets this element's color using int color numbers (i.e numbers between 0
@@ -293,7 +293,7 @@ public interface ElementDraft {
      * @param g green component as int
      * @param b blue component as int
      */
-    public void setColor(int r, int g, int b);
+    void setColor(int r, int g, int b);
 
     /**
      * Parse and sets this element's color.
@@ -303,28 +303,28 @@ public interface ElementDraft {
      *
      * @param color color to be parsed and set
      */
-    public void setColor(String color);
+    void setColor(String color);
 
     /**
      * Sets whether the label is visible.
      *
      * @param labelVisible label visible flag
      */
-    public void setLabelVisible(boolean labelVisible);
+    void setLabelVisible(boolean labelVisible);
 
     /**
      * Sets the label's size.
      *
      * @param size label size
      */
-    public void setLabelSize(float size);
+    void setLabelSize(float size);
 
     /**
      * Sets the label's color.
      *
      * @param color label color
      */
-    public void setLabelColor(Color color);
+    void setLabelColor(Color color);
 
     /**
      * Parses and sets the label's color using string components.
@@ -335,7 +335,7 @@ public interface ElementDraft {
      * @param g green component as string
      * @param b blue component as string
      */
-    public void setLabelColor(String r, String g, String b);
+    void setLabelColor(String r, String g, String b);
 
     /**
      * Sets the label's color using real color numbers (i.e numbers between 0
@@ -345,7 +345,7 @@ public interface ElementDraft {
      * @param g green component as float
      * @param b blue component as float
      */
-    public void setLabelColor(float r, float g, float b);
+    void setLabelColor(float r, float g, float b);
 
     /**
      * Sets the label's color using int color numbers (i.e numbers between 0 and
@@ -355,7 +355,7 @@ public interface ElementDraft {
      * @param g green component as int
      * @param b blue component as int
      */
-    public void setLabelColor(int r, int g, int b);
+    void setLabelColor(int r, int g, int b);
 
     /**
      * Parses and sets the label's color.
@@ -365,25 +365,25 @@ public interface ElementDraft {
      *
      * @param color color to be parsed and set
      */
-    public void setLabelColor(String color);
+    void setLabelColor(String color);
 
-    public void addTimestamp(double timestamp);
+    void addTimestamp(double timestamp);
 
-    public void addTimestamp(String dateTime);
+    void addTimestamp(String dateTime);
 
-    public void addTimestamps(String timestamps);
+    void addTimestamps(String timestamps);
 
-    public void addInterval(double start, double end);
+    void addInterval(double start, double end);
 
-    public void addInterval(String startDateTime, String endDateTime);
+    void addInterval(String startDateTime, String endDateTime);
 
-    public void addIntervals(String intervals);
+    void addIntervals(String intervals);
 
-    public TimeSet getTimeSet();
+    TimeSet getTimeSet();
 
-    public Iterable<ColumnDraft> getColumns();
+    Iterable<ColumnDraft> getColumns();
 
-    public Double getGraphTimestamp();
+    Double getGraphTimestamp();
 
-    public Interval getGraphInterval();
+    Interval getGraphInterval();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportController.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportController.java
@@ -63,33 +63,33 @@ import org.gephi.project.api.Workspace;
  */
 public interface ImportController {
 
-    public Container importFile(File file) throws FileNotFoundException;
+    Container importFile(File file) throws FileNotFoundException;
 
-    public Container importFile(File file, FileImporter importer) throws FileNotFoundException;
+    Container importFile(File file, FileImporter importer) throws FileNotFoundException;
 
-    public Container importFile(Reader reader, FileImporter importer);
+    Container importFile(Reader reader, FileImporter importer);
 
-    public Container importFile(InputStream stream, FileImporter importer);
+    Container importFile(InputStream stream, FileImporter importer);
 
-    public Container importSpigot(SpigotImporter importer);
+    Container importSpigot(SpigotImporter importer);
 
-    public FileImporter getFileImporter(File file);
+    FileImporter getFileImporter(File file);
 
-    public FileImporter getFileImporter(String importerName);
+    FileImporter getFileImporter(String importerName);
 
-    public Container importDatabase(Database database, DatabaseImporter importer);
+    Container importDatabase(Database database, DatabaseImporter importer);
 
-    public void process(Container container);
+    void process(Container container);
 
-    public void process(Container container, Processor processor, Workspace workspace);
+    void process(Container container, Processor processor, Workspace workspace);
 
-    public void process(Container[] containers, Processor processor, Workspace workspace);
+    void process(Container[] containers, Processor processor, Workspace workspace);
 
-    public FileType[] getFileTypes();
+    FileType[] getFileTypes();
 
-    public boolean isFileSupported(File file);
+    boolean isFileSupported(File file);
 
-    public ImporterUI getUI(Importer importer);
+    ImporterUI getUI(Importer importer);
 
-    public ImporterWizardUI getWizardUI(Importer importer);
+    ImporterWizardUI getWizardUI(Importer importer);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/NodeDraft.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/NodeDraft.java
@@ -56,28 +56,28 @@ public interface NodeDraft extends ElementDraft {
      *
      * @return x position
      */
-    public float getX();
+    float getX();
 
     /**
      * Returns this node's Y position.
      *
      * @return y position
      */
-    public float getY();
+    float getY();
 
     /**
      * Returns this node's Z position.
      *
      * @return z position
      */
-    public float getZ();
+    float getZ();
 
     /**
      * Returns this node's size.
      *
      * @return size
      */
-    public float getSize();
+    float getSize();
 
     /**
      * Returns whether this node's position is fixed.
@@ -86,35 +86,35 @@ public interface NodeDraft extends ElementDraft {
      *
      * @return true if fixed, false otherwise
      */
-    public boolean isFixed();
+    boolean isFixed();
 
     /**
      * Sets this node's X position.
      *
      * @param x x position
      */
-    public void setX(float x);
+    void setX(float x);
 
     /**
      * Sets this node's Y position.
      *
      * @param y y position
      */
-    public void setY(float y);
+    void setY(float y);
 
     /**
      * Sets this node's Z position.
      *
      * @param z z position
      */
-    public void setZ(float z);
+    void setZ(float z);
 
     /**
      * Sets this node's size.
      *
      * @param size size
      */
-    public void setSize(float size);
+    void setSize(float size);
 
     /**
      * Sets whether this node's position is fixed.
@@ -124,5 +124,5 @@ public interface NodeDraft extends ElementDraft {
      *
      * @param fixed true if fixed, false otherwise
      */
-    public void setFixed(boolean fixed);
+    void setFixed(boolean fixed);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/DatabaseImporter.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/DatabaseImporter.java
@@ -56,11 +56,11 @@ public interface DatabaseImporter extends Importer {
      * Sets the database description, connection details and queries
      * @param database  the database that is to be used to import
      */
-    public void setDatabase(Database database);
+    void setDatabase(Database database);
 
     /**
      * Returns the current database description, connection details and queries
      * @return         the database that is to be used to import
      */
-    public Database getDatabase();
+    Database getDatabase();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/DatabaseImporterBuilder.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/DatabaseImporterBuilder.java
@@ -54,5 +54,5 @@ public interface DatabaseImporterBuilder extends ImporterBuilder {
      * @return a new database importer
      */
     @Override
-    public DatabaseImporter buildImporter();
+    DatabaseImporter buildImporter();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/FileImporter.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/FileImporter.java
@@ -55,5 +55,5 @@ public interface FileImporter extends Importer {
      *
      * @param reader the reader on data
      */
-    public void setReader(Reader reader);
+    void setReader(Reader reader);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/FileImporterBuilder.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/FileImporterBuilder.java
@@ -57,14 +57,14 @@ public interface FileImporterBuilder extends ImporterBuilder {
      * @return a new file importer
      */
     @Override
-    public FileImporter buildImporter();
+    FileImporter buildImporter();
 
     /**
      * Get default file types this importer can deal with.
      *
      * @return an array of file types this importer can read
      */
-    public FileType[] getFileTypes();
+    FileType[] getFileTypes();
 
     /**
      * Returns <code>true</code> if this importer can import
@@ -79,5 +79,5 @@ public interface FileImporterBuilder extends ImporterBuilder {
      * @return <code>true</code> if the importer is compatible with
      * <code>fileObject</code> or <code>false</code> otherwise
      */
-    public boolean isMatchingImporter(FileObject fileObject);
+    boolean isMatchingImporter(FileObject fileObject);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/Importer.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/Importer.java
@@ -64,7 +64,7 @@ public interface Importer {
      * @return          <code>true</code> if the import is successful or
      * <code>false</code> if it has been cancelled
      */
-    public boolean execute(ContainerLoader loader);
+    boolean execute(ContainerLoader loader);
 
     /**
      * Returns the import container. The container is the import "result", all
@@ -72,12 +72,12 @@ public interface Importer {
      *
      * @return the import container
      */
-    public ContainerLoader getContainer();
+    ContainerLoader getContainer();
 
     /**
      * Returns the import report, filled with logs and potential issues.
      *
      * @return the import report
      */
-    public Report getReport();
+    Report getReport();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/ImporterBuilder.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/ImporterBuilder.java
@@ -62,12 +62,12 @@ public interface ImporterBuilder {
      *
      * @return a new importer
      */
-    public Importer buildImporter();
+    Importer buildImporter();
 
     /**
      * Returns the name of this builder
      *
      * @return the name of this importer
      */
-    public String getName();
+    String getName();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/ImporterUI.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/ImporterUI.java
@@ -65,14 +65,14 @@ public interface ImporterUI {
      *
      * @param importers the importers that settings is to be set
      */
-    public void setup(Importer[] importers);
+    void setup(Importer[] importers);
 
     /**
      * Returns the importer settings panel.
      *
      * @return a settings panel, or <code>null</code>
      */
-    public JPanel getPanel();
+    JPanel getPanel();
 
     /**
      * Notify UI the settings panel has been closed and that new values can be
@@ -81,14 +81,14 @@ public interface ImporterUI {
      * @param update    <code>true</code> if user clicked OK or <code>false</code>
      * if CANCEL.
      */
-    public void unsetup(boolean update);
+    void unsetup(boolean update);
 
     /**
      * Returns the importer display name
      *
      * @return the importer display name
      */
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Returns <code>true</code> if this UI belongs to the given importer.
@@ -97,5 +97,5 @@ public interface ImporterUI {
      * @return          <code>true</code> if the UI is matching with
      * <code>importer</code>, <code>false</code> otherwise.
      */
-    public boolean isUIForImporter(Importer importer);
+    boolean isUIForImporter(Importer importer);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/ImporterWizardUI.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/ImporterWizardUI.java
@@ -65,7 +65,7 @@ public interface ImporterWizardUI {
      *
      * @return the importer display name
      */
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * There are two levels for wizard UIs, the category and then the display
@@ -73,21 +73,21 @@ public interface ImporterWizardUI {
      *
      * @return the importer category
      */
-    public String getCategory();
+    String getCategory();
 
     /**
      * Returns the description for this importer
      *
      * @return the description test
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * Returns wizard panels.
      *
      * @return panels of the current importer
      */
-    public WizardDescriptor.Panel[] getPanels();
+    WizardDescriptor.Panel[] getPanels();
 
     /**
      * Configure <code>panel</code> with previously remembered settings. This
@@ -95,7 +95,7 @@ public interface ImporterWizardUI {
      *
      * @param panel the panel that settings are to be set
      */
-    public void setup(WizardDescriptor.Panel panel);
+    void setup(WizardDescriptor.Panel panel);
 
     /**
      * Notify UI the settings panel has been closed and that new values can be
@@ -105,7 +105,7 @@ public interface ImporterWizardUI {
      * @param importer the importer that settings are to be written
      * @param panel the panel that settings are read
      */
-    public void unsetup(SpigotImporter importer, WizardDescriptor.Panel panel);
+    void unsetup(SpigotImporter importer, WizardDescriptor.Panel panel);
 
     /**
      * Returns <code>true</code> if this UI belongs to the given importer.
@@ -114,5 +114,5 @@ public interface ImporterWizardUI {
      * @return          <code>true</code> if the UI is matching with
      * <code>importer</code>, <code>false</code> otherwise.
      */
-    public boolean isUIForImporter(Importer importer);
+    boolean isUIForImporter(Importer importer);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/SpigotImporterBuilder.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/spi/SpigotImporterBuilder.java
@@ -54,5 +54,5 @@ public interface SpigotImporterBuilder extends ImporterBuilder {
      * @return a new spigot importer
      */
     @Override
-    public SpigotImporter buildImporter();
+    SpigotImporter buildImporter();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/Processor.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/Processor.java
@@ -67,7 +67,7 @@ public interface Processor {
      *
      * @see Importer
      */
-    public void process();
+    void process();
 
     /**
      * Sets the data containers. The processor's job is to get data from the
@@ -75,7 +75,7 @@ public interface Processor {
      *
      * @param containers the containers where data are
      */
-    public void setContainers(ContainerUnloader[] containers);
+    void setContainers(ContainerUnloader[] containers);
 
     /**
      * Sets the destination workspace for the data in the containers. If no
@@ -83,19 +83,19 @@ public interface Processor {
      *
      * @param workspace the workspace where data are to be pushed
      */
-    public void setWorkspace(Workspace workspace);
+    void setWorkspace(Workspace workspace);
 
     /**
      * Returns the processor's name.
      *
      * @return the processor display name
      */
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Sets the progress ticket.
      *
      * @param progressTicket progress ticket
      */
-    public void setProgressTicket(ProgressTicket progressTicket);
+    void setProgressTicket(ProgressTicket progressTicket);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/ProcessorUI.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/ProcessorUI.java
@@ -67,20 +67,20 @@ public interface ProcessorUI {
      *
      * @param processor the processor that settings is to be set
      */
-    public void setup(Processor processor);
+    void setup(Processor processor);
 
     /**
      * Returns the processor settings panel.
      *
      * @return a settings panel, or <code>null</code>
      */
-    public JPanel getPanel();
+    JPanel getPanel();
 
     /**
      * Notify UI the settings panel has been closed and that new values can be
      * written.
      */
-    public void unsetup();
+    void unsetup();
 
     /**
      * Returns <code>true</code> if this UI belongs to the given processor.
@@ -89,7 +89,7 @@ public interface ProcessorUI {
      * @return <code>true</code> if the UI is matching with
      * <code>processor</code>, <code>false</code> otherwise.
      */
-    public boolean isUIFoProcessor(Processor processor);
+    boolean isUIFoProcessor(Processor processor);
 
     /**
      * Returns <code>true</code> if the processor this UI represents is valid
@@ -100,5 +100,5 @@ public interface ProcessorUI {
      * @return <code>true</code> if the processor this UI represents is valid
      * for <code>containers</code>.
      */
-    public boolean isValid(Container[] containers);
+    boolean isValid(Container[] containers);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/Scaler.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/Scaler.java
@@ -57,5 +57,5 @@ public interface Scaler {
      * the scale of nodes positions and sizes.
      * @param container the container that is to be scaled to the right scale
      */
-    public void doScale(Container container);
+    void doScale(Container container);
 }

--- a/modules/LayoutAPI/src/main/java/org/gephi/layout/api/LayoutController.java
+++ b/modules/LayoutAPI/src/main/java/org/gephi/layout/api/LayoutController.java
@@ -57,40 +57,40 @@ public interface LayoutController {
     /**
      * Returns the model of the currently selected {@link Workspace}.
      */
-    public LayoutModel getModel();
+    LayoutModel getModel();
 
     /**
      * Sets the Layout to execute.
      * @param layout the layout that is to be selected
      */
-    public void setLayout(Layout layout);
+    void setLayout(Layout layout);
 
     /**
      * Executes the current Layout.
      */
-    public void executeLayout();
+    void executeLayout();
 
     /**
      * Executes the current layout for <code>numIterations</code> iterations.
      * @param numIterations the number of iterations of the algorithm
      */
-    public void executeLayout(int numIterations);
+    void executeLayout(int numIterations);
 
     /**
      * Determine if the current Layout can be executed.
      * @return <code>true</code> if the layout is executable.
      */
-    public boolean canExecute();
+    boolean canExecute();
 
     /**
      * Stop the Layout's execution.
      */
-    public void stopLayout();
+    void stopLayout();
 
     /**
      * Determine if the current Layout execution can be stopped.
      * If the current Layout is not running, it generally cannot be stopped.
      * @return <code>true</code> if the layout can be stopped.
      */
-    public boolean canStop();
+    boolean canStop();
 }

--- a/modules/LayoutAPI/src/main/java/org/gephi/layout/api/LayoutModel.java
+++ b/modules/LayoutAPI/src/main/java/org/gephi/layout/api/LayoutModel.java
@@ -56,14 +56,14 @@ import org.gephi.project.api.Workspace;
  */
 public interface LayoutModel {
 
-    public static final String SELECTED_LAYOUT = "selectedLayout";
-    public static final String RUNNING = "running";
+    String SELECTED_LAYOUT = "selectedLayout";
+    String RUNNING = "running";
 
     /**
      * Returns the currently selected layout or <code>null</code> if no
      * layout is selected.
      */
-    public Layout getSelectedLayout();
+    Layout getSelectedLayout();
 
     /**
      * Return a layout instance for the given <code>layoutBuilder</code>. If
@@ -76,30 +76,30 @@ public interface LayoutModel {
      * @return the layout build from <code>layoutBuilder</code> with formely
      * saved properties.
      */
-    public Layout getLayout(LayoutBuilder layoutBuilder);
+    Layout getLayout(LayoutBuilder layoutBuilder);
 
     /**
      * Returns the builder used for building the currently selected layout or
      * <code>null</code> if no layout is selected.
      */
-    public LayoutBuilder getSelectedBuilder();
+    LayoutBuilder getSelectedBuilder();
 
     /**
      * Returns <code>true</code> if a layout is currently running, <code>false</code>
      * otherwise.
      */
-    public boolean isRunning();
+    boolean isRunning();
 
     /**
      * Add a property change listener for this model. The <code>listener</code>
      * is notified when layout is selected and when running flag change.
      * @param listener a property change listener
      */
-    public void addPropertyChangeListener(PropertyChangeListener listener);
+    void addPropertyChangeListener(PropertyChangeListener listener);
 
     /**
      * Remove listerner.
      * @param listener a property change listener.
      */
-    public void removePropertyChangeListener(PropertyChangeListener listener);
+    void removePropertyChangeListener(PropertyChangeListener listener);
 }

--- a/modules/LayoutAPI/src/main/java/org/gephi/layout/spi/Layout.java
+++ b/modules/LayoutAPI/src/main/java/org/gephi/layout/spi/Layout.java
@@ -62,7 +62,7 @@ public interface Layout {
     /**
      * initAlgo() is called to initialize the algorithm (prepare to run).
      */
-    public void initAlgo();
+    void initAlgo();
 
     /**
      * Injects the graph model for the graph this Layout should operate on.
@@ -70,41 +70,41 @@ public interface Layout {
      * It's preferable to get <b>visible</b> graph to perform on visualization.
      * @param graphModel    the graph model that the layout is to be working on
      */
-    public void setGraphModel(GraphModel graphModel);
+    void setGraphModel(GraphModel graphModel);
 
     /**
      * Run a step in the algorithm, should be called only if canAlgo() returns
      * true.
      */
-    public void goAlgo();
+    void goAlgo();
 
     /**
      * Tests if the algorithm can run, called before each pass.
      * @return              <code>true</code> if the algorithm can run, <code>
      *                      false</code> otherwise
      */
-    public boolean canAlgo();
+    boolean canAlgo();
 
     /**
      * Called when the algorithm is finished (canAlgo() returns false).
      */
-    public void endAlgo();
+    void endAlgo();
 
     /**
      * The properties for this layout.
      * @return              the layout properties
      * @throws NoSuchMethodException 
      */
-    public LayoutProperty[] getProperties();
+    LayoutProperty[] getProperties();
 
     /**
      * Resets the properties values to the default values.
      */
-    public void resetPropertiesValues();
+    void resetPropertiesValues();
 
     /**
      * The reference to the LayoutBuilder that instanciated this Layout.
      * @return              the reference to the builder that builts this instance
      */
-    public LayoutBuilder getBuilder();
+    LayoutBuilder getBuilder();
 }

--- a/modules/LayoutAPI/src/main/java/org/gephi/layout/spi/LayoutBuilder.java
+++ b/modules/LayoutAPI/src/main/java/org/gephi/layout/spi/LayoutBuilder.java
@@ -66,18 +66,18 @@ public interface LayoutBuilder {
      * The name of the behaviour of the Layout's provided by this Builder.
      * @return  the display neame of the layout algorithm
      */
-    public String getName();
+    String getName();
 
     /**
      * User interface attributes (name, description, icon...) for all Layouts
      * built by this builder.
      * @return a <code>LayoutUI</code> instance
      */
-    public LayoutUI getUI();
+    LayoutUI getUI();
 
     /**
      * Builds an instance of the Layout.
      * @return  a new <code>Layout</code> instance
      */
-    public Layout buildLayout();
+    Layout buildLayout();
 }

--- a/modules/LayoutAPI/src/main/java/org/gephi/layout/spi/LayoutUI.java
+++ b/modules/LayoutAPI/src/main/java/org/gephi/layout/spi/LayoutUI.java
@@ -55,13 +55,13 @@ public interface LayoutUI {
      * The description of the layout algorithm purpose.
      * @return  a description snippet for the algorithm
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * The icon that represents the layout action.
      * @return  a icon for this particular layout
      */
-    public Icon getIcon();
+    Icon getIcon();
 
     /**
      * A <code>LayoutUI</code> can have a optional settings panel, that will be
@@ -70,7 +70,7 @@ public interface LayoutUI {
      * @return A simple settings panel for <code>layout</code> or
      * <code>null</code>
      */
-    public JPanel getSimplePanel(Layout layout);
+    JPanel getSimplePanel(Layout layout);
 
     /**
      * An appraisal of quality for this algorithm. The rank must be between 1 and
@@ -78,7 +78,7 @@ public interface LayoutUI {
      * algorithm. Return -1 if you don't want to display a rank.
      * @return an integer between 1 and 5 or -1 if you don't want to show a rank
      */
-    public int getQualityRank();
+    int getQualityRank();
 
     /**
      * An appraisal of speed for this algorithm. The rank must be between 1 and
@@ -86,5 +86,5 @@ public interface LayoutUI {
      * algorithm. Return -1 if you don't want to display a rank.
      * @return an integer between 1 and 5 or -1 if you don't want to show a rank
      */
-    public int getSpeedRank();
+    int getSpeedRank();
 }

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/AutoLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/AutoLayout.java
@@ -226,13 +226,13 @@ public class AutoLayout {
         return new InterpolateDynamicProperty(propertyName, value, ratio, interpolation);
     }
 
-    public static interface DynamicProperty {
+    public interface DynamicProperty {
 
-        public Object getValue(float ratio);
+        Object getValue(float ratio);
 
-        public Property getProperty();
+        Property getProperty();
 
-        public String getCanonicalName();
+        String getCanonicalName();
     }
 
     public enum Interpolation {

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/force/Displacement.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/force/Displacement.java
@@ -49,7 +49,7 @@ import org.gephi.graph.api.Node;
  */
 public interface Displacement {
 
-    public void setStep(float step);
+    void setStep(float step);
 
-    public void moveNode(Node node, ForceVector forceData);
+    void moveNode(Node node, ForceVector forceData);
 }

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/force/quadtree/QuadTree.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/force/quadtree/QuadTree.java
@@ -526,5 +526,5 @@ public class QuadTree implements Node {
 
 interface AddBehaviour {
 
-    public boolean addNode(NodeProperties node);
+    boolean addNode(NodeProperties node);
 }

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskErrorHandler.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskErrorHandler.java
@@ -49,5 +49,5 @@ package org.gephi.utils.longtask.api;
  */
 public interface LongTaskErrorHandler {
 
-    public void fatalError(Throwable t);
+    void fatalError(Throwable t);
 }

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskListener.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskListener.java
@@ -50,5 +50,5 @@ import org.gephi.utils.longtask.spi.LongTask;
  */
 public interface LongTaskListener {
 
-    public void taskFinished(LongTask task);
+    void taskFinished(LongTask task);
 }

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/spi/LongTask.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/spi/LongTask.java
@@ -54,11 +54,11 @@ public interface LongTask {
      * Cancel the task. Returns <code>true</code> if the task has been sucessfully cancelled, <code>false</code> otherwise.
      * @return  <code>true</code> if the task has been sucessfully cancelled, <code>false</code> otherwise
      */
-    public boolean cancel();
+    boolean cancel();
 
     /**
      * Set the progress ticket for the long task. Can't be null.
      * @param progressTicket the progress ticket for this task
      */
-    public void setProgressTicket(ProgressTicket progressTicket);
+    void setProgressTicket(ProgressTicket progressTicket);
 }

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/progress/ProgressTicketProvider.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/progress/ProgressTicketProvider.java
@@ -50,5 +50,5 @@ import org.openide.util.Cancellable;
  */
 public interface ProgressTicketProvider {
 
-    public ProgressTicket createTicket(String taskName, Cancellable cancellable);
+    ProgressTicket createTicket(String taskName, Cancellable cancellable);
 }

--- a/modules/MostRecentFilesAPI/src/main/java/org/gephi/desktop/mrufiles/api/MostRecentFiles.java
+++ b/modules/MostRecentFilesAPI/src/main/java/org/gephi/desktop/mrufiles/api/MostRecentFiles.java
@@ -49,7 +49,7 @@ import java.util.List;
  */
 public interface MostRecentFiles {
 
-    public void addFile(String absolutePath);
+    void addFile(String absolutePath);
 
-    public List<String> getMRUFileList();
+    List<String> getMRUFileList();
 }

--- a/modules/PerspectiveAPI/src/main/java/org/gephi/perspective/api/PerspectiveController.java
+++ b/modules/PerspectiveAPI/src/main/java/org/gephi/perspective/api/PerspectiveController.java
@@ -67,19 +67,19 @@ public interface PerspectiveController {
      * is selected. By default the 'Overview' perspective is selected.
      * @return the currently selected perspective or <code>null</code>
      */
-    public Perspective getSelectedPerspective();
+    Perspective getSelectedPerspective();
 
     /**
      * Returns all perspectives installed. This is equivalent to
      * <code>Lookup.getDefault().lookupAll(Perspective.class)</code>.
      * @return all installed perspectives
      */
-    public Perspective[] getPerspectives();
+    Perspective[] getPerspectives();
 
     /**
      * Switch the current perspective to the given perspective. Only one perspective
      * can be selected at a time.
      * @param perspective the perspective to select
      */
-    public void selectPerspective(Perspective perspective);
+    void selectPerspective(Perspective perspective);
 }

--- a/modules/PerspectiveAPI/src/main/java/org/gephi/perspective/spi/Perspective.java
+++ b/modules/PerspectiveAPI/src/main/java/org/gephi/perspective/spi/Perspective.java
@@ -63,17 +63,17 @@ public interface Perspective {
      * Return the name to display in the user interface.
      * @return the perspective display name
      */
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Return a unique identifier for this perspective.
      * @return the name of the perspective
      */
-    public String getName();
+    String getName();
 
     /**
      * Return the icon of the perspective.
      * @return the perspective's icon, or <code>null</code>
      */
-    public Icon getIcon();
+    Icon getIcon();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/G2DTarget.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/G2DTarget.java
@@ -59,28 +59,28 @@ public interface G2DTarget extends RenderTarget {
      *
      * @return the current graphics to draw to
      */
-    public Graphics2D getGraphics();
+    Graphics2D getGraphics();
 
-    public Image getImage();
+    Image getImage();
 
-    public int getWidth();
+    int getWidth();
 
-    public int getHeight();
+    int getHeight();
 
-    public void resize(int width, int height);
+    void resize(int width, int height);
 
-    public void setMoving(boolean moving);
+    void setMoving(boolean moving);
 
-    public Vector getTranslate();
+    Vector getTranslate();
 
-    public float getScaling();
+    float getScaling();
 
-    public void setScaling(float scaling);
+    void setScaling(float scaling);
 
-    public void reset();
+    void reset();
 
     /**
      * Redraw the Processing canvas
      */
-    public void refresh();
+    void refresh();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/Item.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/Item.java
@@ -58,24 +58,24 @@ import org.gephi.preview.spi.Renderer;
  */
 public interface Item {
 
-    public static final String NODE = "node";
-    public static final String EDGE = "edge";
-    public static final String NODE_LABEL = "node_label";
-    public static final String EDGE_LABEL = "edge_label";
+    String NODE = "node";
+    String EDGE = "edge";
+    String NODE_LABEL = "node_label";
+    String EDGE_LABEL = "edge_label";
 
     /**
      * Returns the source of the item. The source is usually a graph object like
      * a <code>Node</code> or <code>Edge</code>.
      * @return the item's source object
      */
-    public Object getSource();
+    Object getSource();
 
     /**
      * Returns the type of the item. Default types are <code>Item.NODE</code>, 
      * <code>Item.EDGE</code>, <code>Item.NODE_LABEL</code> and <code>Item.EDGE_LABEL</code>.
      * @return the item's type
      */
-    public String getType();
+    String getType();
 
     /**
      * Returns data associated to this item.
@@ -84,19 +84,19 @@ public interface Item {
      * @return the value associated to <code>key</code>, or <code>null</code> if
      * not exist
      */
-    public <D> D getData(String key);
+    <D> D getData(String key);
 
     /**
      * Sets data to this item.
      * @param key the key
      * @param value the value to be associated with <code>key</code>
      */
-    public void setData(String key, Object value);
+    void setData(String key, Object value);
 
     /**
      * Returns all the keys. That allows to enumerate all data associated with
      * this item.
      * @return all keys
      */
-    public String[] getKeys();
+    String[] getKeys();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PDFTarget.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PDFTarget.java
@@ -62,13 +62,13 @@ import com.itextpdf.text.pdf.PdfContentByte;
  */
 public interface PDFTarget extends RenderTarget {
 
-    public static final String PDF_CONTENT_BYTE = "pdf.contentbyte";
-    public static final String MARGIN_LEFT = "pdf.margin.left";
-    public static final String MARGIN_TOP = "pdf.margin.top";
-    public static final String MARGIN_BOTTOM = "pfd.margin.bottom";
-    public static final String MARGIN_RIGHT = "pdf.margin.right";
-    public static final String LANDSCAPE = "pdf.landscape";
-    public static final String PAGESIZE = "pdf.pagesize";
+    String PDF_CONTENT_BYTE = "pdf.contentbyte";
+    String MARGIN_LEFT = "pdf.margin.left";
+    String MARGIN_TOP = "pdf.margin.top";
+    String MARGIN_BOTTOM = "pfd.margin.bottom";
+    String MARGIN_RIGHT = "pdf.margin.right";
+    String LANDSCAPE = "pdf.landscape";
+    String PAGESIZE = "pdf.pagesize";
 
     /**
      * Returns the <code>PDFContentBype</code> instance of the PDFTarget. PDFContentByte
@@ -76,7 +76,7 @@ public interface PDFTarget extends RenderTarget {
      * 
      * @return a PDFContentBype object 
      */
-    public PdfContentByte getContentByte();
+    PdfContentByte getContentByte();
 
     /**
      * Get a the equivalent in iText of the Java font. Base fonts are either
@@ -91,35 +91,35 @@ public interface PDFTarget extends RenderTarget {
      * @param font  the reference Java font
      * @return      the iText BaseFont, or Helvetica is not found
      */
-    public BaseFont getBaseFont(java.awt.Font font);
+    BaseFont getBaseFont(java.awt.Font font);
 
     /**
      * Returns the margin at the bottom of the page.
      * 
      * @return the bottom margin, in pixels
      */
-    public float getMarginBottom();
+    float getMarginBottom();
 
     /**
      * Returns the margin at the left of the page.
      *
      * @return the left margin, in pixels
      */
-    public float getMarginLeft();
+    float getMarginLeft();
 
     /**
      * Returns the margin at the right of the page.
      *
      * @return the right margin, in pixels
      */
-    public float getMarginRight();
+    float getMarginRight();
 
     /**
      * Returns the margin at the top of the page.
      *
      * @return the top margin, in pixels
      */
-    public float getMarginTop();
+    float getMarginTop();
 
     /**
      * Returns whether the orientation is in landscape or portrait.
@@ -127,12 +127,12 @@ public interface PDFTarget extends RenderTarget {
      * @return <code>true</code> if the orientation is landscape, <code>false</code>
      * if portrait.
      */
-    public boolean isLandscape();
+    boolean isLandscape();
 
     /**
      * Returns the page's size.
      *
      * @return the page size
      */
-    public Rectangle getPageSize();
+    Rectangle getPageSize();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewController.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewController.java
@@ -65,7 +65,7 @@ public interface PreviewController {
      * method.
      * @param workspace the workspace to get the preview model from
      */
-    public void refreshPreview(Workspace workspace);
+    void refreshPreview(Workspace workspace);
 
     /**
      * Refreshes the current preview model. 
@@ -74,20 +74,20 @@ public interface PreviewController {
      * refresh graph dimensions and call all <code>Renderer.preProcess()</code>
      * method.
      */
-    public void refreshPreview();
+    void refreshPreview();
 
     /**
      * Returns the current preview model in the current workspace.
      * @return the current preview model
      */
-    public PreviewModel getModel();
+    PreviewModel getModel();
 
     /**
      * Returns the preview model in <code>workspace</code>.
      * @param workspace the workspace to lookup
      * @return the preview model in <code>workspace</code>
      */
-    public PreviewModel getModel(Workspace workspace);
+    PreviewModel getModel(Workspace workspace);
 
     /**
      * Renders the current preview model to <code>target</code>.
@@ -96,7 +96,7 @@ public interface PreviewController {
      * Then all items in the preview model are rendered.
      * @param target the target to render items to
      */
-    public void render(RenderTarget target);
+    void render(RenderTarget target);
 
     /**
      * Renders the preview model in <code>workspace</code> to <code>target</code>.
@@ -106,7 +106,7 @@ public interface PreviewController {
      * @param target the target to render items to
      * @param workspace the workspace to get the preview model from
      */
-    public void render(RenderTarget target, Workspace workspace);
+    void render(RenderTarget target, Workspace workspace);
     
     /**
      * Renders the current preview model to <code>target</code>.
@@ -116,7 +116,7 @@ public interface PreviewController {
      * @param target the target to render items to
      * @param renderers renderers to use
      */
-    public void render(RenderTarget target, Renderer[] renderers);
+    void render(RenderTarget target, Renderer[] renderers);
     
     /**
      * Renders the preview model in <code>workspace</code> to <code>target</code>.
@@ -127,7 +127,7 @@ public interface PreviewController {
      * @param renderers renderers to use
      * @param workspace the workspace to get the preview model from
      */
-    public void render(RenderTarget target, Renderer[] renderers, Workspace workspace);
+    void render(RenderTarget target, Renderer[] renderers, Workspace workspace);
 
     /**
      * Creates a new render target of the given type. 
@@ -141,7 +141,7 @@ public interface PreviewController {
      * @return a new render target or <code>null</code> if <code>name</code> is
      * unknown
      */
-    public RenderTarget getRenderTarget(String name);
+    RenderTarget getRenderTarget(String name);
 
     /**
      * Creates a new render target of the given type in the preview model
@@ -157,27 +157,27 @@ public interface PreviewController {
      * @return a new render target or <code>null</code> if <code>name</code> is
      * unknown
      */
-    public RenderTarget getRenderTarget(String name, Workspace workspace);
+    RenderTarget getRenderTarget(String name, Workspace workspace);
     
     /**
      * Uses <code>Lookup</code> to retrieve registered renderer providers but replaces default renderers with plugins that extend them.
      * @see Renderer
      * @return Registered renderers replacing default renderers with their extension plugins in case they exist
      */
-    public Renderer[] getRegisteredRenderers();
+    Renderer[] getRegisteredRenderers();
     
     /**
      * Returns true if any renderer plugin is registered.
      * @return True if any plugin renderer is found in the system
      */
-    public boolean isAnyPluginRendererRegistered();
+    boolean isAnyPluginRendererRegistered();
     
     /**
      * Sends a <code>PreviewMouseEvent</code> to the current workspace, if any.
      * @param event PreviewMouseEvent
      * @return True if the event was consumed, false otherwise
      */
-    public boolean sendMouseEvent(PreviewMouseEvent event);
+    boolean sendMouseEvent(PreviewMouseEvent event);
     
     /**
      * Sends a <code>PreviewMouseEvent</code> to the given workspace.
@@ -185,5 +185,5 @@ public interface PreviewController {
      * @param workspace workspace
      * @return True if the event was consumed, false otherwise
      */
-    public boolean sendMouseEvent(PreviewMouseEvent event, Workspace workspace);
+    boolean sendMouseEvent(PreviewMouseEvent event, Workspace workspace);
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewModel.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewModel.java
@@ -65,7 +65,7 @@ public interface PreviewModel {
      *
      * @return the preview properties
      */
-    public PreviewProperties getProperties();
+    PreviewProperties getProperties();
 
     /**
      * Returns all items with
@@ -74,7 +74,7 @@ public interface PreviewModel {
      * @param type the item's type
      * @return all items from this type
      */
-    public Item[] getItems(String type);
+    Item[] getItems(String type);
 
     /**
      * Returns all items attached to
@@ -87,7 +87,7 @@ public interface PreviewModel {
      * @return all items with
      * <code>source</code> as source
      */
-    public Item[] getItems(Object source);
+    Item[] getItems(Object source);
 
     /**
      * Returns the item attached to
@@ -100,7 +100,7 @@ public interface PreviewModel {
      * @return the item or
      * <code>null</code> if not found
      */
-    public Item getItem(String type, Object source);
+    Item getItem(String type, Object source);
 
     /**
      * <p>Returns currently managed renderers, or null.</p> <p>If
@@ -108,7 +108,7 @@ public interface PreviewModel {
      *
      * @return Enabled renderers or null
      */
-    public ManagedRenderer[] getManagedRenderers();
+    ManagedRenderer[] getManagedRenderers();
 
     /**
      * <p>Sets an user-defined array of managed renderers to use when rendering.</p> <p><b>Only</b> the renderers marked as enabled will be executed when rendering, and <b>respecting the array
@@ -118,7 +118,7 @@ public interface PreviewModel {
      *
      * @param managedRenderers Managed renderers for future renderings
      */
-    public void setManagedRenderers(ManagedRenderer[] managedRenderers);
+    void setManagedRenderers(ManagedRenderer[] managedRenderers);
 
     /**
      * Returns
@@ -127,17 +127,17 @@ public interface PreviewModel {
      *
      * @return Enabled renderers or null
      */
-    public Renderer[] getManagedEnabledRenderers();
+    Renderer[] getManagedEnabledRenderers();
 
     /*
      * Returns <code>managedPreviewMouseListeners</code> containing the <code>PreviewMouseListeners</code> that are declared by the current enabled managed renderers.
      */
-    public PreviewMouseListener[] getEnabledMouseListeners();
+    PreviewMouseListener[] getEnabledMouseListeners();
 
     /**
      * Computes the graphics canvas size.
      *
      * @return the graphics canvas size
      */
-    public CanvasSize getGraphicsCanvasSize();
+    CanvasSize getGraphicsCanvasSize();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/RenderTarget.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/RenderTarget.java
@@ -66,7 +66,7 @@ import org.gephi.preview.spi.Renderer;
  */
 public interface RenderTarget {
 
-    public static final String G2D_TARGET = "g2d";
-    public static final String SVG_TARGET = "svg";
-    public static final String PDF_TARGET = "pdf";
+    String G2D_TARGET = "g2d";
+    String SVG_TARGET = "svg";
+    String PDF_TARGET = "pdf";
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/SVGTarget.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/SVGTarget.java
@@ -66,49 +66,49 @@ public interface SVGTarget extends RenderTarget {
     /**
      * SVG <code>Boolean</code> property whether to rescale stroke's width/thickness.
      */
-    public static final String SCALE_STROKES = "svg.scale.strokes";
+    String SCALE_STROKES = "svg.scale.strokes";
     /**
      * Default top element name for nodes
      */
-    public static final String TOP_NODES = "nodes";
+    String TOP_NODES = "nodes";
     /**
      * Default top element name for edges
      */
-    public static final String TOP_EDGES = "edges";
+    String TOP_EDGES = "edges";
     /**
      * Default top element name for node labels
      */
-    public static final String TOP_NODE_LABELS = "node-labels";
+    String TOP_NODE_LABELS = "node-labels";
     /**
      * Default top element name for node labels outline
      */
-    public static final String TOP_NODE_LABELS_OUTLINE = "node-labels-outline";
+    String TOP_NODE_LABELS_OUTLINE = "node-labels-outline";
     /**
      * Default top element name for edge labels
      */
-    public static final String TOP_EDGE_LABELS = "edge-labels";
+    String TOP_EDGE_LABELS = "edge-labels";
     /**
      * Default top element name for edge labels outline
      */
-    public static final String TOP_EDGE_LABELS_OUTLINE = "edge-labels-outline";
+    String TOP_EDGE_LABELS_OUTLINE = "edge-labels-outline";
     /**
      * Default top element name for arrows
      */
-    public static final String TOP_ARROWS = "arrows";
+    String TOP_ARROWS = "arrows";
 
     /**
      * Create a new element <code>qualifiedName</code> in the document.
      * @param qualifiedName the name of the element
      * @return the newly created element
      */
-    public Element createElement(String qualifiedName);
+    Element createElement(String qualifiedName);
 
     /**
      * Create a new text node with <code>data</code> in it.
      * @param data the text data
      * @return the newly created text node
      */
-    public Text createTextNode(String data);
+    Text createTextNode(String data);
 
     /**
      * Returns the top element <code>name</code> in the document. Top elements are
@@ -117,25 +117,25 @@ public interface SVGTarget extends RenderTarget {
      * @param name the top element name to lookup
      * @return the top element
      */
-    public Element getTopElement(String name);
+    Element getTopElement(String name);
 
     /**
      * Returns the SVG document
      * @return the SVG document
      */
-    public Document getDocument();
+    Document getDocument();
 
     /**
      * When <code>SCALE_STROKES</code> property is <code>true</code> returns
      * the scale ratio to scale strokes with.
      * @return the current scale ratio
      */
-    public float getScaleRatio();
+    float getScaleRatio();
 
     /**
      * Returns <code>color</code> in the hex format (e.g. #ff0000).
      * @param color the color to convert
      * @return the color in a hex format
      */
-    public String toHexString(Color color);
+    String toHexString(Color color);
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/ItemBuilder.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/ItemBuilder.java
@@ -65,10 +65,10 @@ import org.gephi.preview.api.Item;
  */
 public interface ItemBuilder {
 
-    public static final String NODE_BUILDER = Item.NODE;
-    public static final String NODE_LABEL_BUILDER = Item.NODE_LABEL;
-    public static final String EDGE_BUILDER = Item.EDGE;
-    public static final String EDGE_LABEL_BUILDER = Item.EDGE_LABEL;
+    String NODE_BUILDER = Item.NODE;
+    String NODE_LABEL_BUILDER = Item.NODE_LABEL;
+    String EDGE_BUILDER = Item.EDGE;
+    String EDGE_LABEL_BUILDER = Item.EDGE_LABEL;
 
     /**
      * Build items from the
@@ -78,7 +78,7 @@ public interface ItemBuilder {
      * @return an array of new items, from the same type returned by
      * {@link #getType()}
      */
-    public Item[] getItems(Graph graph);
+    Item[] getItems(Graph graph);
 
     /**
      * Returns the type of this builder.
@@ -91,5 +91,5 @@ public interface ItemBuilder {
      *
      * @return the builder item type.
      */
-    public String getType();
+    String getType();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/MouseResponsiveRenderer.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/MouseResponsiveRenderer.java
@@ -51,5 +51,5 @@ package org.gephi.preview.spi;
  */
 public interface MouseResponsiveRenderer {
 
-    public boolean needsPreviewMouseListener(PreviewMouseListener previewMouseListener);
+    boolean needsPreviewMouseListener(PreviewMouseListener previewMouseListener);
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/PreviewMouseListener.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/PreviewMouseListener.java
@@ -61,7 +61,7 @@ public interface PreviewMouseListener {
      * @param properties Preview properties for the workspace
      * @param workspace  Current workspace
      */
-    public void mouseClicked(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
+    void mouseClicked(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
     
     /**
      * A mouse press event. If your listener needs to receive drag or release events, you <b>must</b> mark the previous press event as consumed.
@@ -69,7 +69,7 @@ public interface PreviewMouseListener {
      * @param properties Preview properties for the workspace
      * @param workspace  Current workspace
      */
-    public void mousePressed(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
+    void mousePressed(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
     
     /**
      * If your listener needs to receive drag events, you <b>must</b> mark the previous press event as consumed.
@@ -77,7 +77,7 @@ public interface PreviewMouseListener {
      * @param properties Preview properties for the workspace
      * @param workspace  Current workspace
      */
-    public void mouseDragged(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
+    void mouseDragged(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
     
     /**
      * If your listener needs to receive release events, you <b>must</b> mark the previous press event as consumed.
@@ -85,5 +85,5 @@ public interface PreviewMouseListener {
      * @param properties Preview properties for the workspace
      * @param workspace  Current workspace
      */
-    public void mouseReleased(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
+    void mouseReleased(PreviewMouseEvent event, PreviewProperties properties, Workspace workspace);
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/PreviewUI.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/PreviewUI.java
@@ -70,7 +70,7 @@ public interface PreviewUI {
      * <code>getPanel()</code>.
      * @param previewModel the model associated to the current workspace
      */
-    public void setup(PreviewModel previewModel);
+    void setup(PreviewModel previewModel);
 
     /**
      * Returns the <code>JPanel</code> component to be displayed. 
@@ -82,24 +82,24 @@ public interface PreviewUI {
      * requested at each workspace selection.
      * @return the panel to be displayed
      */
-    public JPanel getPanel();
+    JPanel getPanel();
 
     /**
      * Method called when the UI is unloaded and the panel to be destroyed. This
      * happens when the workspace changes and before a new <code>PreviewModel</code>
      * is passed through <code>setup()</code>.
      */
-    public void unsetup();
+    void unsetup();
 
     /**
      * Returns the icon of the tab or <code>null</code> if none
      * @return the tab's icon or <code>null</code>
      */
-    public Icon getIcon();
+    Icon getIcon();
 
     /**
      * Returns the title of the tab
      * @return the tab's title
      */
-    public String getPanelTitle();
+    String getPanelTitle();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/RenderTargetBuilder.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/RenderTargetBuilder.java
@@ -66,12 +66,12 @@ public interface RenderTargetBuilder {
      * @param previewModel the preview model to get the dimensions and properties from
      * @return a new render target instance
      */
-    public RenderTarget buildRenderTarget(PreviewModel previewModel);
+    RenderTarget buildRenderTarget(PreviewModel previewModel);
     
     /**
      * Returns the name of the target builder. This value is used by the
      * <code>PreviewController</code> to identify render targets.
      * @return the name of the target builder
      */
-    public String getName();
+    String getName();
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/Renderer.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/spi/Renderer.java
@@ -105,7 +105,7 @@ public interface Renderer {
      * This name will appear in the renderers manager UI.
      * @return User friendly renderer name, not null
      */
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * This method is called before rendering for all renderers and initializes
@@ -120,7 +120,7 @@ public interface Renderer {
      * {@link PreviewProperties#putValue(java.lang.String, java.lang.Object)}.
      * @param previewModel the model to get items from
      */
-    public void preProcess(PreviewModel previewModel);
+    void preProcess(PreviewModel previewModel);
 
     /**
      * Render <code>item</code> to <code>target</code> using the global properties
@@ -133,7 +133,7 @@ public interface Renderer {
      * @param target the target to render the item on
      * @param properties the central properties
      */
-    public void render(Item item, RenderTarget target, PreviewProperties properties);
+    void render(Item item, RenderTarget target, PreviewProperties properties);
 
     /**
      * Returns all associated properties for this renderer. Properties can be built
@@ -141,7 +141,7 @@ public interface Renderer {
      *
      * @return a properties array
      */
-    public PreviewProperty[] getProperties();
+    PreviewProperty[] getProperties();
 
     /**
      * Based on <code>properties</code>, determine whether this renderer is
@@ -160,7 +160,7 @@ public interface Renderer {
      * @return <code>true</code> if <code>item</code> can be rendered by this
      * renderer, <code>false</code> otherwise
      */
-    public boolean isRendererForitem(Item item, PreviewProperties properties);
+    boolean isRendererForitem(Item item, PreviewProperties properties);
 
     /**
      * Based on the <code>itemBuilder</code> class and the <code>properties</code>,
@@ -185,7 +185,7 @@ public interface Renderer {
      * @param properties the current properties
      * @return <code>true</code> if you are going to use built items for rendering, <code>false</code> otherwise
      */
-    public boolean needsItemBuilder(ItemBuilder itemBuilder, PreviewProperties properties);
+    boolean needsItemBuilder(ItemBuilder itemBuilder, PreviewProperties properties);
 
     /**
      * Compute the canvas size of the item to render.
@@ -198,5 +198,5 @@ public interface Renderer {
      * @param properties the current properties
      * @return the item canvas size
      */
-    public CanvasSize getCanvasSize(Item item, PreviewProperties properties);
+    CanvasSize getCanvasSize(Item item, PreviewProperties properties);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/Project.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/Project.java
@@ -59,14 +59,14 @@ public interface Project extends Lookup.Provider {
      *
      * @param instance the instance that is to be added to the lookup
      */
-    public void add(Object instance);
+    void add(Object instance);
 
     /**
      * Removes an abilities to this project.
      *
      * @param instance the instance that is to be removed from the lookup
      */
-    public void remove(Object instance);
+    void remove(Object instance);
 
     /**
      * Gets any optional abilities of this project.
@@ -79,5 +79,5 @@ public interface Project extends Lookup.Provider {
      * @return the project's lookup
      */
     @Override
-    public Lookup getLookup();
+    Lookup getLookup();
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectController.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectController.java
@@ -55,43 +55,43 @@ import java.io.File;
  */
 public interface ProjectController {
 
-    public void startup();
+    void startup();
 
-    public void newProject();
+    void newProject();
 
-    public Runnable openProject(File file);
+    Runnable openProject(File file);
 
-    public Runnable saveProject(Project project);
+    Runnable saveProject(Project project);
 
-    public Runnable saveProject(Project project, File file);
+    Runnable saveProject(Project project, File file);
 
-    public void closeCurrentProject();
+    void closeCurrentProject();
 
-    public void removeProject(Project project);
+    void removeProject(Project project);
 
-    public Projects getProjects();
+    Projects getProjects();
 
-    public Workspace newWorkspace(Project project);
+    Workspace newWorkspace(Project project);
 
-    public void deleteWorkspace(Workspace workspace);
+    void deleteWorkspace(Workspace workspace);
 
-    public void renameWorkspace(Workspace workspace, String name);
+    void renameWorkspace(Workspace workspace, String name);
 
-    public Project getCurrentProject();
+    Project getCurrentProject();
 
-    public void renameProject(Project project, String name);
+    void renameProject(Project project, String name);
 
-    public Workspace getCurrentWorkspace();
+    Workspace getCurrentWorkspace();
 
-    public void openWorkspace(Workspace workspace);
+    void openWorkspace(Workspace workspace);
 
-    public void closeCurrentWorkspace();
+    void closeCurrentWorkspace();
 
-    public Workspace duplicateWorkspace(Workspace workspace);
+    Workspace duplicateWorkspace(Workspace workspace);
 
-    public void setSource(Workspace workspace, String source);
+    void setSource(Workspace workspace, String source);
 
-    public void addWorkspaceListener(WorkspaceListener workspaceListener);
+    void addWorkspaceListener(WorkspaceListener workspaceListener);
 
-    public void removeWorkspaceListener(WorkspaceListener workspaceListener);
+    void removeWorkspaceListener(WorkspaceListener workspaceListener);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectInformation.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectInformation.java
@@ -62,31 +62,31 @@ import java.io.File;
  */
 public interface ProjectInformation {
 
-    public static final String EVENT_OPEN = "open";
-    public static final String EVENT_CLOSE = "close";
-    public static final String EVENT_RENAME = "rename";
-    public static final String EVENT_SET_FILE = "setFile";
+    String EVENT_OPEN = "open";
+    String EVENT_CLOSE = "close";
+    String EVENT_RENAME = "rename";
+    String EVENT_SET_FILE = "setFile";
 
     /**
      * Returns true if the project is open.
      *
      * @return true if open, false otherwise
      */
-    public boolean isOpen();
+    boolean isOpen();
 
     /**
      * Returns true if the project is closed.
      *
      * @return true if closed, false otherwise
      */
-    public boolean isClosed();
+    boolean isClosed();
 
     /**
      * Returns true if the project is invalid.
      *
      * @return true if invalid, false otherwise
      */
-    public boolean isInvalid();
+    boolean isInvalid();
 
     /**
      * Returns the name of the project.
@@ -95,7 +95,7 @@ public interface ProjectInformation {
      *
      * @return the project's name
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns true if the project is associated with a file.
@@ -105,7 +105,7 @@ public interface ProjectInformation {
      *
      * @return true if associated with a file, false otherwise
      */
-    public boolean hasFile();
+    boolean hasFile();
 
     /**
      * Returns the filename associated with this project.
@@ -115,7 +115,7 @@ public interface ProjectInformation {
      * @see #hasFile()
      * @return file name
      */
-    public String getFileName();
+    String getFileName();
 
     /**
      * Returns the file associated with this project.
@@ -125,26 +125,26 @@ public interface ProjectInformation {
      * @see #hasFile()
      * @return file or null if none
      */
-    public File getFile();
+    File getFile();
 
     /**
      * Returns the project this information class belongs to.
      *
      * @return project reference
      */
-    public Project getProject();
+    Project getProject();
 
     /**
      * Add change listener.
      *
      * @param listener change listener
      */
-    public void addChangeListener(PropertyChangeListener listener);
+    void addChangeListener(PropertyChangeListener listener);
 
     /**
      * Remove change listener.
      *
      * @param listener change listener
      */
-    public void removeChangeListener(PropertyChangeListener listener);
+    void removeChangeListener(PropertyChangeListener listener);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectMetaData.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectMetaData.java
@@ -55,7 +55,7 @@ public interface ProjectMetaData {
      *
      * @return the project's keywords or empty string if missing
      */
-    public String getKeywords();
+    String getKeywords();
 
     /**
      * Returns the author of this project.
@@ -64,47 +64,47 @@ public interface ProjectMetaData {
      *
      * @return project's author
      */
-    public String getAuthor();
+    String getAuthor();
 
     /**
      * Returns the description of this project.
      *
      * @return the project's description or empty string if missing
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * Returns the title of this project.
      *
      * @return the project's title or empty string if missing
      */
-    public String getTitle();
+    String getTitle();
 
     /**
      * Sets the project's author.
      *
      * @param author author
      */
-    public void setAuthor(String author);
+    void setAuthor(String author);
 
     /**
      * Sets the project's description.
      *
      * @param description description
      */
-    public void setDescription(String description);
+    void setDescription(String description);
 
     /**
      * Sets the project's keywords.
      *
      * @param keywords keywords
      */
-    public void setKeywords(String keywords);
+    void setKeywords(String keywords);
 
     /**
      * Sets the project's title.
      *
      * @param title title
      */
-    public void setTitle(String title);
+    void setTitle(String title);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/Projects.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/Projects.java
@@ -53,19 +53,19 @@ public interface Projects {
      *
      * @return true if current project, false otherwise
      */
-    public boolean hasCurrentProject();
+    boolean hasCurrentProject();
 
     /**
      * Returns the current project or null if missing.
      *
      * @return current project or null if missing
      */
-    public Project getCurrentProject();
+    Project getCurrentProject();
 
     /**
      * Returns an array of all projects.
      *
      * @return project array
      */
-    public Project[] getProjects();
+    Project[] getProjects();
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/Workspace.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/Workspace.java
@@ -77,14 +77,14 @@ public interface Workspace extends Lookup.Provider {
      *
      * @param instance the instance that is to be pushed to the lookup
      */
-    public void add(Object instance);
+    void add(Object instance);
 
     /**
      * Removes an instance from this workspaces lookup.
      *
      * @param instance the instance that is to be removed from the lookup
      */
-    public void remove(Object instance);
+    void remove(Object instance);
 
     /**
      * Get any instance in the current lookup. All important API in Gephi are
@@ -103,19 +103,19 @@ public interface Workspace extends Lookup.Provider {
      * @return the workspace's lookup
      */
     @Override
-    public Lookup getLookup();
+    Lookup getLookup();
 
     /**
      * Returns the project this workspace belong to
      *
      * @return the workspace's project
      */
-    public Project getProject();
+    Project getProject();
 
     /**
      * Returns the workspace unique identifier
      *
      * @return the workspace id
      */
-    public int getId();
+    int getId();
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceInformation.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceInformation.java
@@ -61,31 +61,31 @@ import java.beans.PropertyChangeListener;
  */
 public interface WorkspaceInformation {
 
-    public static final String EVENT_OPEN = "open";
-    public static final String EVENT_CLOSE = "close";
-    public static final String EVENT_RENAME = "rename";
-    public static final String EVENT_SET_SOURCE = "setSource";
+    String EVENT_OPEN = "open";
+    String EVENT_CLOSE = "close";
+    String EVENT_RENAME = "rename";
+    String EVENT_SET_SOURCE = "setSource";
 
     /**
      * Returns true if the workspace is open.
      *
      * @return true if open, false otherwise
      */
-    public boolean isOpen();
+    boolean isOpen();
 
     /**
      * Returns true if the workspace is closed.
      *
      * @return true if closed, false otherwise
      */
-    public boolean isClosed();
+    boolean isClosed();
 
     /**
      * Returns true if the workspace is invalid.
      *
      * @return true if invalid, false otherwise
      */
-    public boolean isInvalid();
+    boolean isInvalid();
 
     /**
      * Returns the name of the workspace.
@@ -94,33 +94,33 @@ public interface WorkspaceInformation {
      *
      * @return the workspace's name
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns true if the workspace has a source.
      *
      * @return true if has a source, false otherwise
      */
-    public boolean hasSource();
+    boolean hasSource();
 
     /**
      * Returns the workspace's source or null if missing.
      *
      * @return workspace's source or null if missing
      */
-    public String getSource();
+    String getSource();
 
     /**
      * Add change listener.
      *
      * @param listener change listener
      */
-    public void addChangeListener(PropertyChangeListener listener);
+    void addChangeListener(PropertyChangeListener listener);
 
     /**
      * Remove change listener.
      *
      * @param listener change listener
      */
-    public void removeChangeListener(PropertyChangeListener listener);
+    void removeChangeListener(PropertyChangeListener listener);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceListener.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceListener.java
@@ -53,14 +53,14 @@ public interface WorkspaceListener {
      *
      * @param workspace the workspace that was created
      */
-    public void initialize(Workspace workspace);
+    void initialize(Workspace workspace);
 
     /**
      * Notify a workspace has become the selected workspace.
      *
      * @param workspace the workspace that was made current workspace
      */
-    public void select(Workspace workspace);
+    void select(Workspace workspace);
 
     /**
      * Notify another workspace will be selected. The <code>select()</code>
@@ -68,17 +68,17 @@ public interface WorkspaceListener {
      *
      * @param workspace the workspace that is currently the selected workspace
      */
-    public void unselect(Workspace workspace);
+    void unselect(Workspace workspace);
 
     /**
      * Notify a workspace will be closed, all data must be destroyed.
      *
      * @param workspace the workspace that is to be closed
      */
-    public void close(Workspace workspace);
+    void close(Workspace workspace);
 
     /**
      * Notify no more workspace is currently selected, the project is empty.
      */
-    public void disable();
+    void disable();
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceProvider.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceProvider.java
@@ -54,14 +54,14 @@ public interface WorkspaceProvider {
      *
      * @return current workspace or null if missing
      */
-    public Workspace getCurrentWorkspace();
+    Workspace getCurrentWorkspace();
 
     /**
      * Returns true if the project has a current workspace.
      *
      * @return true if has a current workspace, false otherwise
      */
-    public boolean hasCurrentWorkspace();
+    boolean hasCurrentWorkspace();
 
     /**
      * Returns all the workspaces.
@@ -70,7 +70,7 @@ public interface WorkspaceProvider {
      *
      * @return an array of all workspaces
      */
-    public Workspace[] getWorkspaces();
+    Workspace[] getWorkspaces();
 
     /**
      * Retrieve a workspace based on its unique identifier.
@@ -78,5 +78,5 @@ public interface WorkspaceProvider {
      * @param id workspace's unique identifier
      * @return found workspace or null if not found
      */
-    public Workspace getWorkspace(int id);
+    Workspace getWorkspace(int id);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/spi/ProjectPropertiesUI.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/spi/ProjectPropertiesUI.java
@@ -51,9 +51,9 @@ import org.gephi.project.api.Project;
  */
 public interface ProjectPropertiesUI {
 
-    public JPanel getPanel();
+    JPanel getPanel();
 
-    public void setup(Project project);
+    void setup(Project project);
 
-    public void unsetup(Project project);
+    void unsetup(Project project);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspaceBytesPersistenceProvider.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspaceBytesPersistenceProvider.java
@@ -56,7 +56,7 @@ public interface WorkspaceBytesPersistenceProvider extends WorkspacePersistenceP
      * @param stream DataOutputStream stream to write to
      * @param workspace current workspace being serialized
      */
-    public void writeBytes(DataOutputStream stream, Workspace workspace);
+    void writeBytes(DataOutputStream stream, Workspace workspace);
 
     /**
      * This is automatically called when loading a project file.
@@ -64,5 +64,5 @@ public interface WorkspaceBytesPersistenceProvider extends WorkspacePersistenceP
      * @param stream DataInputStream stream to read from
      * @param workspace current workspace being deserialized
      */
-    public void readBytes(DataInputStream stream, Workspace workspace);
+    void readBytes(DataInputStream stream, Workspace workspace);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspaceDuplicateProvider.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspaceDuplicateProvider.java
@@ -53,5 +53,5 @@ import org.gephi.project.api.Workspace;
  */
 public interface WorkspaceDuplicateProvider {
 
-    public void duplicate(Workspace source, Workspace destination);
+    void duplicate(Workspace source, Workspace destination);
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspacePersistenceProvider.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspacePersistenceProvider.java
@@ -82,5 +82,5 @@ public interface WorkspacePersistenceProvider {
      *
      * @return Unique identifier describing your data
      */
-    public String getIdentifier();
+    String getIdentifier();
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspaceXMLPersistenceProvider.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/spi/WorkspaceXMLPersistenceProvider.java
@@ -60,7 +60,7 @@ public interface WorkspaceXMLPersistenceProvider extends WorkspacePersistencePro
      * provider data
      * @param workspace Current workspace being serialized
      */
-    public void writeXML(XMLStreamWriter writer, Workspace workspace);
+    void writeXML(XMLStreamWriter writer, Workspace workspace);
 
     /**
      * This is automatically called when a start element with the tag name
@@ -72,5 +72,5 @@ public interface WorkspaceXMLPersistenceProvider extends WorkspacePersistencePro
      * provider data previously serialized
      * @param workspace Current workspace being deserialized
      */
-    public void readXML(XMLStreamReader reader, Workspace workspace);
+    void readXML(XMLStreamReader reader, Workspace workspace);
 }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/api/StatisticsController.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/api/StatisticsController.java
@@ -68,27 +68,27 @@ public interface StatisticsController {
      * @throws IllegalArgumentException if <code>statistics</code> doesn't
      * implement {@link LongTask}
      */
-    public void execute(Statistics statistics, LongTaskListener listener);
+    void execute(Statistics statistics, LongTaskListener listener);
 
     /**
      * Executes <code>statistics</code> in the current thread.
      * @param statistics    the statistics to execute
      */
-    public void execute(Statistics statistics);
+    void execute(Statistics statistics);
     
     /**
      * Finds the builder from the statistics class.
      * @param statistics    the statistics class
      * @return              the builder, or <code>null</code> if not found
      */
-    public StatisticsBuilder getBuilder(Class<? extends Statistics> statistics);
+    StatisticsBuilder getBuilder(Class<? extends Statistics> statistics);
 
     /**
      * Returns the current <code>StatisticsModel</code>, from the current
      * workspace
      * @return              the current <code>StatisticsModel</code>
      */
-    public StatisticsModel getModel();
+    StatisticsModel getModel();
     
     /**
      * Returns the <code>StatisticsModel</code> for <code>workspace</code>
@@ -96,5 +96,5 @@ public interface StatisticsController {
      * @return              the <code>StatisticsModel</code> associated to
      *                      <code>workspace</code>
      */
-    public StatisticsModel getModel(Workspace workspace);
+    StatisticsModel getModel(Workspace workspace);
 }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/api/StatisticsModel.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/api/StatisticsModel.java
@@ -58,5 +58,5 @@ public interface StatisticsModel {
      * @param statistics        a statistics class
      * @return                  the report or <code>null</code> if not found
      */
-    public String getReport(Class<? extends Statistics> statistics);
+    String getReport(Class<? extends Statistics> statistics);
 }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/DynamicStatistics.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/DynamicStatistics.java
@@ -68,7 +68,7 @@ public interface DynamicStatistics extends Statistics {
      * graph structure and the attribute model the attribute columns.
      * @param graphModel the graph model
      */
-    public void execute(GraphModel graphModel);
+    void execute(GraphModel graphModel);
 
     /**
      * Iteration of the dynamic statistics algorithm on a new interval. The 
@@ -76,48 +76,48 @@ public interface DynamicStatistics extends Statistics {
      * @param window a snapshot of the graph at the current interval
      * @param interval the interval of the current snapshot
      */
-    public void loop(GraphView window, Interval interval);
+    void loop(GraphView window, Interval interval);
 
     /**
      * Called at the end of the process after all loops.
      */
-    public void end();
+    void end();
 
     /**
      * Sets the minimum and maximum bound
      * @param bounds the min and max bounds
      */
-    public void setBounds(Interval bounds);
+    void setBounds(Interval bounds);
 
     /**
      * Sets the window duration
      * @param window the window duration
      */
-    public void setWindow(double window);
+    void setWindow(double window);
 
     /**
      * Sets the tick. The tick is how much the window is moved to the right 
      * at each iteration.
      * @param tick the tick
      */
-    public void setTick(double tick);
+    void setTick(double tick);
 
     /**
      * Returns the window duration
      * @return the window duration
      */
-    public double getWindow();
+    double getWindow();
 
     /**
      * Returns the tick. The tick is how much the window is moved to the right 
      * at each iteration.
      * @return the tick
      */
-    public double getTick();
+    double getTick();
 
     /**
      * Returns the min and max bounds.
      * @return the bounds
      */
-    public Interval getBounds();
+    Interval getBounds();
 }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/Statistics.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/Statistics.java
@@ -61,12 +61,12 @@ public interface Statistics {
      * visualization.
      * @param graphModel The graph model
      */
-    public void execute(GraphModel graphModel);
+    void execute(GraphModel graphModel);
 
     /**
      * Returns an HTML string that displays the statistics result. Can contains
      * complex HTML snippets and images.
      * @return An HTML string that displays the results for this Statistics
      */
-    public String getReport();
+    String getReport();
 }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/StatisticsBuilder.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/StatisticsBuilder.java
@@ -58,17 +58,17 @@ public interface StatisticsBuilder {
      * Returns the name of statistics
      * @return  the name of the statistics
      */
-    public String getName();
+    String getName();
 
     /**
      * Build a new statistics instance and return it
      * @return  a new statistics instance
      */
-    public Statistics getStatistics();
+    Statistics getStatistics();
 
     /**
      * Returns the statistics' class this UI belongs to.
      * @return  the statistics' class this UI belongs to
      */
-    public Class<? extends Statistics> getStatisticsClass();
+    Class<? extends Statistics> getStatisticsClass();
 }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/StatisticsUI.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/StatisticsUI.java
@@ -60,16 +60,16 @@ import org.openide.util.NbBundle;
  */
 public interface StatisticsUI {
 
-    public static final String CATEGORY_NETWORK_OVERVIEW = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.networkOverview");
-    public static final String CATEGORY_NODE_OVERVIEW = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.nodeOverview");
-    public static final String CATEGORY_EDGE_OVERVIEW = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.edgeOverview");
-    public static final String CATEGORY_DYNAMIC = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.dynamic");
+    String CATEGORY_NETWORK_OVERVIEW = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.networkOverview");
+    String CATEGORY_NODE_OVERVIEW = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.nodeOverview");
+    String CATEGORY_EDGE_OVERVIEW = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.edgeOverview");
+    String CATEGORY_DYNAMIC = NbBundle.getMessage(StatisticsUI.class, "StatisticsUI.category.dynamic");
 
     /**
      * Returns a settings panel instance.
      * @return              a settings panel instance
      */
-    public JPanel getSettingsPanel();
+    JPanel getSettingsPanel();
 
     /**
      * Push a statistics instance to the UI to load its settings. Note that this
@@ -77,37 +77,37 @@ public interface StatisticsUI {
      * panel is displayed.
      * @param statistics    the statistics instance that is linked to the UI
      */
-    public void setup(Statistics statistics);
+    void setup(Statistics statistics);
 
     /**
      * Notify the settings panel has been closed and that the settings values
      * can be saved to the statistics instance.
      */
-    public void unsetup();
+    void unsetup();
 
     /**
      * Returns the statistics' class this UI belongs to.
      * @return              the statistics' class this UI belongs to
      */
-    public Class<? extends Statistics> getStatisticsClass();
+    Class<? extends Statistics> getStatisticsClass();
 
     /**
      * Returns this statistics result as a String, if exists
      * @return              this statistics' result string
      */
-    public String getValue();
+    String getValue();
 
     /**
      * Returns this statistics display name
      * @return              this statistics' display name.
      */
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Returns this statistics short description
      * @return              this statistics' short description.
      */
-    public String getShortDescription();
+    String getShortDescription();
 
     /**
      * Returns the category of this metric. Default category can be used, see
@@ -119,13 +119,13 @@ public interface StatisticsUI {
      * Returns a custom String for defining a new category.
      * @return              this statistics' category
      */
-    public String getCategory();
+    String getCategory();
 
     /**
      * Returns a position value, around 1 and 1000, that indicates the position
      * of the Statistics in the UI. Less means upper.
      * @return              this statistics' position value
      */
-    public int getPosition();
+    int getPosition();
 }
 

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineChart.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineChart.java
@@ -62,21 +62,21 @@ public interface TimelineChart {
      *
      * @return the attribute column
      */
-    public String getColumn();
+    String getColumn();
 
     /**
      * Returns the X values of this chart.
      *
      * @return the X values
      */
-    public Number[] getX();
+    Number[] getX();
 
     /**
      * Returns the Y values of this chart.
      *
      * @return the Y values
      */
-    public Number[] getY();
+    Number[] getY();
 
     /**
      * Return the Y value for the given <code>x</code> position. It returns the
@@ -85,33 +85,33 @@ public interface TimelineChart {
      * @param x the point in time
      * @return the Y value
      */
-    public Number getY(Number x);
+    Number getY(Number x);
 
     /**
      * Returns the min Y value .This is the minimum value in the chart.
      *
      * @return the min Y value
      */
-    public Number getMinY();
+    Number getMinY();
 
     /**
      * Returns the max Y value. This is the maximum value in the chart.
      *
      * @return the max Y value
      */
-    public Number getMaxY();
+    Number getMaxY();
 
     /**
      * Returns the min X value .This is the minimum interval in the chart.
      *
      * @return the min X value
      */
-    public Number getMinX();
+    Number getMinX();
 
     /**
      * Returns the max X value. This is the maximum interval in the chart.
      *
      * @return the max X value
      */
-    public Number getMaxX();
+    Number getMaxX();
 }

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineController.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineController.java
@@ -74,14 +74,14 @@ public interface TimelineController {
      * @param workspace the workspace to get the model from
      * @return the timeline model for this workspace
      */
-    public TimelineModel getModel(Workspace workspace);
+    TimelineModel getModel(Workspace workspace);
 
     /**
      * Get the current model from the current workspace
      *
      * @return the current model, or <code>null</code> if no active workspace
      */
-    public TimelineModel getModel();
+    TimelineModel getModel();
 
     /**
      * Sets the timeline custom bounds. Custom bounds still need to be included
@@ -93,14 +93,14 @@ public interface TimelineController {
      * @throws IllegalArgumentException if <code>min<code> is superior or equal than
      * <code>max</code> or out of bounds
      */
-    public void setCustomBounds(double min, double max);
+    void setCustomBounds(double min, double max);
 
     /**
      * Sets the timeline enable status.
      *
      * @param enabled the enabled value to set
      */
-    public void setEnabled(boolean enabled);
+    void setEnabled(boolean enabled);
 
     /**
      * Sets the current timeline interval. This is propagated to the
@@ -112,21 +112,21 @@ public interface TimelineController {
      * @throws IllegalArgumentException if <code>min<code> is superior or equal than
      * <code>max</code> or out of bounds
      */
-    public void setInterval(double from, double to);
+    void setInterval(double from, double to);
     
-    public void setTimeFormat(TimeFormat timeFormat);
+    void setTimeFormat(TimeFormat timeFormat);
     
 
     /**
      * Starts the timeline animation using the current delay, step size and play
      * mode.
      */
-    public void startPlay();
+    void startPlay();
 
     /**
      * Stops the timeline animation.
      */
-    public void stopPlay();
+    void stopPlay();
 
     /**
      * Sets the play delay in milliseconds. Defines the time between each
@@ -134,7 +134,7 @@ public interface TimelineController {
      *
      * @param delay the delay in milliseconds
      */
-    public void setPlaySpeed(int delay);
+    void setPlaySpeed(int delay);
 
     /**
      * Sets the play step. Defines how much the interval is moved at each step
@@ -142,14 +142,14 @@ public interface TimelineController {
      *
      * @param step the step, between 0 and 1
      */
-    public void setPlayStep(double step);
+    void setPlayStep(double step);
 
     /**
      * Sets the play mode. This defines how the interval is moved.
      *
      * @param playMode the play mode
      */
-    public void setPlayMode(TimelineModel.PlayMode playMode);
+    void setPlayMode(TimelineModel.PlayMode playMode);
 
     /**
      * Returns all the possible dynamic attribute columns. This is essentially
@@ -157,7 +157,7 @@ public interface TimelineController {
      *
      * @return all dynamic number columns in the graph table
      */
-    public String[] getDynamicGraphColumns();
+    String[] getDynamicGraphColumns();
 
     /**
      * Select a column to make a {@link TimelineChart} of it. The column must be
@@ -167,19 +167,19 @@ public interface TimelineController {
      * @throws IllegalArgumentException if <code>column</code> is not a graph
      * column
      */
-    public void selectColumn(String column);
+    void selectColumn(String column);
 
     /**
      * Add <code>listener</code> to the list of event listerners.
      *
      * @param listener the listener to add
      */
-    public void addListener(TimelineModelListener listener);
+    void addListener(TimelineModelListener listener);
 
     /**
      * Remove <code>listerner</code> from the list of event listeners.
      *
      * @param listener the listener to remove
      */
-    public void removeListener(TimelineModelListener listener);
+    void removeListener(TimelineModelListener listener);
 }

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModel.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModel.java
@@ -59,7 +59,7 @@ public interface TimelineModel {
     /**
      * Defines how the interval is moved when animating.
      */
-    public enum PlayMode {
+    enum PlayMode {
 
         /**
          * Only one bound of the interval is moved. The interval is therefore resized.
@@ -77,33 +77,33 @@ public interface TimelineModel {
      * @return <code>true</code> if the timeline is enabled, <code>false</code>
      * otherwise
      */
-    public boolean isEnabled();
+    boolean isEnabled();
 
     /**
      * Returns the min value of the time scale. This is the start of the earliest interval
      * in the workspace.
      * @return the min
      */
-    public double getMin();
+    double getMin();
 
     /**
      * Returns the max value of the time scale. This is the end of the latest interval
      * in the workspace.
      * @return the max
      */
-    public double getMax();
+    double getMax();
 
     /**
      * Returns the custom min value. This value can't be inferior than <code>min</code>
      * @return the custom min
      */
-    public double getCustomMin();
+    double getCustomMin();
 
     /**
      * Returns the custom max value. This value can't be superior than <code>max</code>
      * @return the custom max
      */
-    public double getCustomMax();
+    double getCustomMax();
 
     /**
      * Returns <code>true</code> if custom bounds are defined. Returns <code>false</code>
@@ -111,62 +111,62 @@ public interface TimelineModel {
      * @return <code>true</code> if custom bounds are defined, <code>false</code>
      * otherwise.
      */
-    public boolean hasCustomBounds();
+    boolean hasCustomBounds();
 
     /**
      * Returns <code>true</code> if none of the min and max time values are infinity.
      * @return <code>true</code> if the time scale is valid, <code>false</code>
      * otherwise
      */
-    public boolean hasValidBounds();
+    boolean hasValidBounds();
 
     /**
      * Returns the lower bound of the interval.
      * @return the interval start
      */
-    public double getIntervalStart();
+    double getIntervalStart();
 
     /**
      * Returns the upper bound of the interval.
      * @return the interval end
      */
-    public double getIntervalEnd();
+    double getIntervalEnd();
 
     /**
      * Returns the current time format. Default is <code>DOUBLE</code>
      * @return the current tie
      */
-    public TimeFormat getTimeFormat();
+    TimeFormat getTimeFormat();
 
     /**
      * Returns the play delay in milliseconds. Defines the time between each interval
      * shift.
      * @return the play delay 
      */
-    public int getPlayDelay();
+    int getPlayDelay();
 
     /**
      * Returns the play step. Defines how much the interval is moved at each step
      * during animation. Defined in percentage of the total interval.
      * @return the play step
      */
-    public double getPlayStep();
+    double getPlayStep();
 
     /**
      * Returns <code>true</code> if the timeline is playing.
      * @return <code>true</code> is playing, <code>false</code> otherwise
      */
-    public boolean isPlaying();
+    boolean isPlaying();
 
     /**
      * Returns the play mode. This defines how the interval is moved.
      * @return the play mode
      */
-    public PlayMode getPlayMode();
+    PlayMode getPlayMode();
 
     /**
      * Returns the current timeline chart or <code>null</code> if node.
      * @return the timeline chart or <code>null</code>
      */
-    public TimelineChart getChart();
+    TimelineChart getChart();
 }

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModelListener.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/api/TimelineModelListener.java
@@ -49,5 +49,5 @@ package org.gephi.timeline.api;
  */
 public interface TimelineModelListener {
 
-    public void timelineModelChanged(TimelineModelEvent event);
+    void timelineModelChanged(TimelineModelEvent event);
 }

--- a/modules/ToolsAPI/src/main/java/org/gephi/tools/api/ToolController.java
+++ b/modules/ToolsAPI/src/main/java/org/gephi/tools/api/ToolController.java
@@ -61,19 +61,19 @@ public interface ToolController {
      * @param tool the tool that is to be selected or null to only unselect the
      * current tool
      */
-    public void select(Tool tool);
+    void select(Tool tool);
 
     /**
      * Returns the toolbar component, build from tools implementations.
      *
      * @return the toolbar component
      */
-    public JComponent getToolbar();
+    JComponent getToolbar();
 
     /**
      * Returns the properties bar component, that display tools settings.
      *
      * @return the properties bar component
      */
-    public JComponent getPropertiesBar();
+    JComponent getPropertiesBar();
 }

--- a/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/MouseClickEventListener.java
+++ b/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/MouseClickEventListener.java
@@ -60,5 +60,5 @@ public interface MouseClickEventListener extends ToolEventListener {
      * @param position3d Position in the 3D coordinate system, (0,0) is located
      * at the center.
      */
-    public void mouseClick(int[] positionViewport, float[] position3d);
+    void mouseClick(int[] positionViewport, float[] position3d);
 }

--- a/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/NodeClickEventListener.java
+++ b/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/NodeClickEventListener.java
@@ -58,5 +58,5 @@ public interface NodeClickEventListener extends ToolEventListener {
      *
      * @param nodes the clicked nodes
      */
-    public void clickNodes(Node[] nodes);
+    void clickNodes(Node[] nodes);
 }

--- a/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/NodePressAndDraggingEventListener.java
+++ b/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/NodePressAndDraggingEventListener.java
@@ -65,7 +65,7 @@ public interface NodePressAndDraggingEventListener extends ToolEventListener {
      *
      * @param nodes the clicked nodes
      */
-    public void pressNodes(Node[] nodes);
+    void pressNodes(Node[] nodes);
 
     /**
      * Notify mouse is dragging
@@ -73,10 +73,10 @@ public interface NodePressAndDraggingEventListener extends ToolEventListener {
      * @param displacementX distance x
      * @param displacementY distance y
      */
-    public void drag(float displacementX, float displacementY);
+    void drag(float displacementX, float displacementY);
 
     /**
      * Notify mouse has been released.
      */
-    public void released();
+    void released();
 }

--- a/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/NodePressingEventListener.java
+++ b/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/NodePressingEventListener.java
@@ -60,10 +60,10 @@ public interface NodePressingEventListener extends ToolEventListener {
      *
      * @param nodes the pressed nodes array
      */
-    public void pressingNodes(Node[] nodes);
+    void pressingNodes(Node[] nodes);
 
     /**
      * Notify mouse has been released.
      */
-    public void released();
+    void released();
 }

--- a/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/Tool.java
+++ b/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/Tool.java
@@ -66,12 +66,12 @@ public interface Tool {
     /**
      * Notify when this tool is selected.
      */
-    public void select();
+    void select();
 
     /**
      * Notify when this tool is unselected.
      */
-    public void unselect();
+    void unselect();
 
     /**
      * Returns the declared tool listeners for this tool. Tool listeners says
@@ -79,19 +79,19 @@ public interface Tool {
      *
      * @return tool listeners declared for this tool implementation
      */
-    public ToolEventListener[] getListeners();
+    ToolEventListener[] getListeners();
 
     /**
      * Returns <code>ToolUI</code> instance for this tool.
      *
      * @return the user interface attributes for this tool
      */
-    public ToolUI getUI();
+    ToolUI getUI();
 
     /**
      * Returns the tool type of selection interaction.
      *
      * @return the tool type of selection interaction
      */
-    public ToolSelectionType getSelectionType();
+    ToolSelectionType getSelectionType();
 }

--- a/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/ToolUI.java
+++ b/modules/ToolsAPI/src/main/java/org/gephi/tools/spi/ToolUI.java
@@ -60,28 +60,28 @@ public interface ToolUI {
      * @param tool the tool instance
      * @return a <code>JPanel</code> for the the tool's properties bar
      */
-    public JPanel getPropertiesBar(Tool tool);
+    JPanel getPropertiesBar(Tool tool);
 
     /**
      * Returns the tool icon, for the toobar.
      *
      * @return tool's icon
      */
-    public Icon getIcon();
+    Icon getIcon();
 
     /**
      * Returns the tool's name.
      *
      * @return tool's name
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns the tool's description.
      *
      * @return tool's description
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * Returns the tool's relative position.
@@ -90,5 +90,5 @@ public interface ToolUI {
      *
      * @return A number between 0 and 200
      */
-    public int getPosition();
+    int getPosition();
 }

--- a/modules/ToolsPlugin/src/main/java/org/gephi/ui/tools/plugin/edit/EditWindowUtils.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/ui/tools/plugin/edit/EditWindowUtils.java
@@ -49,47 +49,47 @@ public class EditWindowUtils {
 
     interface AttributeValueWrapper {
 
-        public Byte getValueByte();
+        Byte getValueByte();
 
-        public void setValueByte(Byte object);
+        void setValueByte(Byte object);
 
-        public Short getValueShort();
+        Short getValueShort();
 
-        public void setValueShort(Short object);
+        void setValueShort(Short object);
 
-        public Character getValueCharacter();
+        Character getValueCharacter();
 
-        public void setValueCharacter(Character object);
+        void setValueCharacter(Character object);
 
-        public String getValueString();
+        String getValueString();
 
-        public void setValueString(String object);
+        void setValueString(String object);
 
-        public Double getValueDouble();
+        Double getValueDouble();
 
-        public void setValueDouble(Double object);
+        void setValueDouble(Double object);
 
-        public Float getValueFloat();
+        Float getValueFloat();
 
-        public void setValueFloat(Float object);
+        void setValueFloat(Float object);
 
-        public Integer getValueInteger();
+        Integer getValueInteger();
 
-        public void setValueInteger(Integer object);
+        void setValueInteger(Integer object);
 
-        public Boolean getValueBoolean();
+        Boolean getValueBoolean();
 
-        public void setValueBoolean(Boolean object);
+        void setValueBoolean(Boolean object);
 
-        public Long getValueLong();
+        Long getValueLong();
 
-        public void setValueLong(Long object);
+        void setValueLong(Long object);
 
         /**
          * **** Other types are not supported by property editors by default so they are used and parsed as Strings *****
          */
-        public String getValueAsString();
+        String getValueAsString();
 
-        public void setValueAsString(String value);
+        void setValueAsString(String value);
     }
 }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/ColumnSelectionPanel.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/ColumnSelectionPanel.java
@@ -133,14 +133,14 @@ public class ColumnSelectionPanel extends JPanel {
         }
     }
 
-    public static interface ColumnSelectionModel {
+    public interface ColumnSelectionModel {
 
-        public boolean isEnabled();
+        boolean isEnabled();
 
-        public boolean isSelected();
+        boolean isSelected();
 
-        public void setSelected(boolean selected);
+        void setSelected(boolean selected);
 
-        public String getName();
+        String getName();
     }
 }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/DecoratedIcon.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/DecoratedIcon.java
@@ -86,8 +86,8 @@ public class DecoratedIcon implements Icon {
         return orig.getIconHeight();
     }
 
-    public static interface DecorationController {
+    public interface DecorationController {
 
-        public boolean isDecorated();
+        boolean isDecorated();
     }
 }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/splineeditor/equation/Equation.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/splineeditor/equation/Equation.java
@@ -43,5 +43,5 @@ package org.gephi.ui.components.splineeditor.equation;
 
 public interface Equation {
 
-    public double compute(double variable);
+    double compute(double variable);
 }

--- a/modules/ValidationAPI/src/main/java/org/gephi/lib/validation/ValidationClient.java
+++ b/modules/ValidationAPI/src/main/java/org/gephi/lib/validation/ValidationClient.java
@@ -50,5 +50,5 @@ import org.netbeans.validation.api.ui.ValidationGroup;
  */
 public interface ValidationClient {
 
-    public void validate(ValidationGroup group);
+    void validate(ValidationGroup group);
 }

--- a/modules/VisualizationAPI/src/main/java/org/gephi/visualization/api/VisualizationController.java
+++ b/modules/VisualizationAPI/src/main/java/org/gephi/visualization/api/VisualizationController.java
@@ -51,11 +51,11 @@ import org.gephi.graph.api.Node;
  */
 public interface VisualizationController {
 
-    public void selectNodes(Node[] nodes);
+    void selectNodes(Node[] nodes);
 
-    public void selectEdges(Edge[] edges);
+    void selectEdges(Edge[] edges);
 
-    public Column[] getEdgeTextColumns();
+    Column[] getEdgeTextColumns();
 
-    public Column[] getNodeTextColumns();
+    Column[] getNodeTextColumns();
 }

--- a/modules/VisualizationAPI/src/main/java/org/gephi/visualization/spi/GraphContextMenuItem.java
+++ b/modules/VisualizationAPI/src/main/java/org/gephi/visualization/spi/GraphContextMenuItem.java
@@ -89,5 +89,5 @@ public interface GraphContextMenuItem extends ContextMenuItemManipulator {
      * @param graph graph
      * @param nodes All selected nodes
      */
-    public void setup(Graph graph, Node[] nodes);
+    void setup(Graph graph, Node[] nodes);
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/VizArchitecture.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/VizArchitecture.java
@@ -47,5 +47,5 @@ package org.gephi.visualization;
  */
 public interface VizArchitecture {
 
-    public void initArchitecture();
+    void initArchitecture();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/api/selection/SelectionArea.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/api/selection/SelectionArea.java
@@ -52,15 +52,15 @@ import org.gephi.visualization.model.node.NodeModel;
  */
 public interface SelectionArea {
 
-    public float[] getSelectionAreaRectancle();
+    float[] getSelectionAreaRectancle();
 
-    public float[] getSelectionAreaCenter();
+    float[] getSelectionAreaCenter();
 
-    public boolean mouseTest(Vecf distanceFromMouse, NodeModel nodeModel);
+    boolean mouseTest(Vecf distanceFromMouse, NodeModel nodeModel);
 
-    public void drawArea(GL2 gl, GLU glu);
+    void drawArea(GL2 gl, GLU glu);
 
-    public boolean isEnabled();
+    boolean isEnabled();
 
-    public boolean blockSelection();
+    boolean blockSelection();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/api/selection/SelectionType.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/api/selection/SelectionType.java
@@ -47,11 +47,11 @@ package org.gephi.visualization.api.selection;
  */
 public interface SelectionType {
 
-    public SelectionArea getSelectionArea();
+    SelectionArea getSelectionArea();
 
-    public void setSelectionArea(SelectionArea selectionArea);
+    void setSelectionArea(SelectionArea selectionArea);
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/GraphDrawable.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/GraphDrawable.java
@@ -56,47 +56,47 @@ import org.gephi.visualization.opengl.GraphicalConfiguration;
  */
 public interface GraphDrawable {
 
-    public Component getGraphComponent();
+    Component getGraphComponent();
 
-    public float getGlobalScale();
+    float getGlobalScale();
 
-    public int getViewportHeight();
+    int getViewportHeight();
 
-    public int getViewportWidth();
+    int getViewportWidth();
 
-    public float[] getCameraTarget();
+    float[] getCameraTarget();
 
-    public float[] getCameraLocation();
+    float[] getCameraLocation();
 
-    public void setCameraLocation(float[] cameraLocation);
+    void setCameraLocation(float[] cameraLocation);
 
-    public void setCameraTarget(float[] cameraTarget);
+    void setCameraTarget(float[] cameraTarget);
 
-    public Vec3f getCameraVector();
+    Vec3f getCameraVector();
 
-    public double getDraggingMarkerX();
+    double getDraggingMarkerX();
 
-    public double getDraggingMarkerY();
+    double getDraggingMarkerY();
 
-    public FloatBuffer getProjectionMatrix();
+    FloatBuffer getProjectionMatrix();
 
-    public IntBuffer getViewport();
+    IntBuffer getViewport();
 
-    public double[] myGluProject(float x, float y);
+    double[] myGluProject(float x, float y);
 
-    public float[] myGluProject(float x, float y, float z);
+    float[] myGluProject(float x, float y, float z);
 
-    public void display();
+    void display();
 
-    public void setCameraPosition(GL2 gl, GLU glu);
+    void setCameraPosition(GL2 gl, GLU glu);
 
-    public void initConfig(GL2 gl);
+    void initConfig(GL2 gl);
 
-    public GraphicalConfiguration getGraphicalConfiguration();
+    GraphicalConfiguration getGraphicalConfiguration();
 
-    public void destroy();
+    void destroy();
 
-    public Point getLocationOnScreen();
+    Point getLocationOnScreen();
 
-    public void reinitWindow();
+    void reinitWindow();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/GraphIO.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/GraphIO.java
@@ -50,27 +50,27 @@ import java.awt.event.KeyListener;
  */
 public interface GraphIO extends MouseListener, KeyListener {
 
-    public float[] getMousePosition();
+    float[] getMousePosition();
 
-    public float[] getMousePosition3d();
+    float[] getMousePosition3d();
 
-    public float[] getMouseDrag();
+    float[] getMouseDrag();
 
-    public float[] getMouseDrag3d();
+    float[] getMouseDrag3d();
 
-    public void startMouseListening();
+    void startMouseListening();
 
-    public void stopMouseListening();
+    void stopMouseListening();
 
-    public void trigger();
+    void trigger();
 
-    public void setCameraDistance(float distance);
+    void setCameraDistance(float distance);
 
-    public void centerOnZero();
+    void centerOnZero();
 
-    public void centerOnGraph();
+    void centerOnGraph();
 
-    public void centerOnCoordinate(float x, float y, float z);
+    void centerOnCoordinate(float x, float y, float z);
 
-    public boolean isDragging();
+    boolean isDragging();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/PropertiesBarAddon.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/PropertiesBarAddon.java
@@ -49,5 +49,5 @@ import javax.swing.JComponent;
  */
 public interface PropertiesBarAddon {
 
-    public JComponent getComponent();
+    JComponent getComponent();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/Scheduler.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/Scheduler.java
@@ -50,32 +50,32 @@ import com.jogamp.opengl.glu.GLU;
  */
 public interface Scheduler {
 
-    public void start();
+    void start();
 
-    public void stop();
+    void stop();
 
-    public boolean isAnimating();
+    boolean isAnimating();
 
-    public void updatePosition();
+    void updatePosition();
 
-    public void updateWorld();
+    void updateWorld();
 
-    public void display(GL2 gl, GLU glu);
+    void display(GL2 gl, GLU glu);
 
-    public void requireUpdateVisible();
+    void requireUpdateVisible();
 
-    public void requireUpdateSelection();
+    void requireUpdateSelection();
 
-    public void requireStartDrag();
+    void requireStartDrag();
 
-    public void requireDrag();
+    void requireDrag();
 
-    public void requireStopDrag();
+    void requireStopDrag();
 
 //    public void requireUpdatePosition();
-    public void requireMouseClick();
+void requireMouseClick();
 
-    public void setFps(float maxFps);
+    void setFps(float maxFps);
 
-    public float getFps();
+    float getFps();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/VizEventListener.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/VizEventListener.java
@@ -49,7 +49,7 @@ import java.util.EventListener;
  */
 public interface VizEventListener extends EventListener {
 
-    public void handleEvent(VizEvent event);
+    void handleEvent(VizEvent event);
 
-    public VizEvent.Type getType();
+    VizEvent.Type getType();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/VizEventManager.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/apiimpl/VizEventManager.java
@@ -49,37 +49,37 @@ import org.gephi.visualization.VizArchitecture;
  */
 public interface VizEventManager extends VizArchitecture {
 
-    public void startDrag();
+    void startDrag();
 
-    public void drag();
+    void drag();
 
-    public void stopDrag();
+    void stopDrag();
 
-    public void mouseLeftPress();
+    void mouseLeftPress();
 
-    public void mouseRightPress();
+    void mouseRightPress();
 
-    public void mouseMiddlePress();
+    void mouseMiddlePress();
 
-    public void mouseLeftClick();
+    void mouseLeftClick();
 
-    public void mouseRightClick();
+    void mouseRightClick();
 
-    public void mouseMiddleClick();
+    void mouseMiddleClick();
 
-    public void mouseMove();
+    void mouseMove();
 
-    public void mouseLeftPressing();
+    void mouseLeftPressing();
 
-    public void mouseReleased();
+    void mouseReleased();
 
-    public void addListener(VizEventListener listener);
+    void addListener(VizEventListener listener);
 
-    public void addListener(VizEventListener[] listeners);
+    void addListener(VizEventListener[] listeners);
 
-    public void removeListener(VizEventListener listener);
+    void removeListener(VizEventListener listener);
 
-    public void removeListener(VizEventListener[] listeners);
+    void removeListener(VizEventListener[] listeners);
 
-    public boolean hasListeners(VizEvent.Type type);
+    boolean hasListeners(VizEvent.Type type);
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/component/VizToolbarGroup.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/component/VizToolbarGroup.java
@@ -49,13 +49,13 @@ import javax.swing.JComponent;
  */
 public interface VizToolbarGroup {
 
-    public String getName();
+    String getName();
 
-    public JComponent[] getToolbarComponents();
+    JComponent[] getToolbarComponents();
 
-    public JComponent getExtendedComponent();
+    JComponent getExtendedComponent();
 
-    public boolean hasToolbar();
+    boolean hasToolbar();
 
-    public boolean hasExtended();
+    boolean hasExtended();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/model/Model.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/model/Model.java
@@ -10,5 +10,5 @@ import org.gephi.visualization.VizModel;
  */
 public interface Model {
 
-    public void display(GL2 gl, GLU glu, VizModel model);
+    void display(GL2 gl, GLU glu, VizModel model);
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/model/TextModel.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/model/TextModel.java
@@ -12,27 +12,27 @@ import org.gephi.graph.api.ElementProperties;
  */
 public interface TextModel {
 
-    public boolean hasCustomTextColor();
+    boolean hasCustomTextColor();
 
-    public void setText(String text);
+    void setText(String text);
 
-    public float getTextWidth();
+    float getTextWidth();
 
-    public float getTextHeight();
+    float getTextHeight();
 
-    public String getText();
+    String getText();
 
-    public float getTextSize();
+    float getTextSize();
 
-    public float getTextR();
+    float getTextR();
 
-    public float getTextG();
+    float getTextG();
 
-    public float getTextB();
+    float getTextB();
 
-    public float getTextAlpha();
+    float getTextAlpha();
 
-    public boolean isTextVisible();
+    boolean isTextVisible();
 
-    public ElementProperties getElementProperties();
+    ElementProperties getElementProperties();
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/text/ColorMode.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/text/ColorMode.java
@@ -52,15 +52,15 @@ import org.gephi.visualization.text.TextManager.Renderer;
  */
 public interface ColorMode {
 
-    public String getName();
+    String getName();
 
-    public ImageIcon getIcon();
+    ImageIcon getIcon();
 
-    public void defaultNodeColor(Renderer renderer);
+    void defaultNodeColor(Renderer renderer);
 
-    public void defaultEdgeColor(Renderer renderer);
+    void defaultEdgeColor(Renderer renderer);
 
-    public void textNodeColor(Renderer renderer, NodeModel nodeModel);
+    void textNodeColor(Renderer renderer, NodeModel nodeModel);
 
-    public void textEdgeColor(Renderer renderer, EdgeModel edgeModel);
+    void textEdgeColor(Renderer renderer, EdgeModel edgeModel);
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/text/SizeMode.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/text/SizeMode.java
@@ -50,13 +50,13 @@ import org.gephi.visualization.model.node.NodeModel;
  */
 public interface SizeMode {
 
-    public String getName();
+    String getName();
 
-    public ImageIcon getIcon();
+    ImageIcon getIcon();
 
-    public void init();
+    void init();
 
-    public float getSizeFactor2d(float sizeFactor, NodeModel model);
+    float getSizeFactor2d(float sizeFactor, NodeModel model);
 
-    public float getSizeFactor3d(float sizeFactor, NodeModel model);
+    float getSizeFactor3d(float sizeFactor, NodeModel model);
 }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/text/TextManager.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/text/TextManager.java
@@ -253,29 +253,29 @@ public class TextManager implements VizArchitecture {
     }
 
     //-------------------------------------------------------------------------------------------------
-    public static interface Renderer {
+    public interface Renderer {
 
-        public void initRenderer(Font font);
+        void initRenderer(Font font);
 
-        public void reinitRenderer();
+        void reinitRenderer();
 
-        public void disposeRenderer();
+        void disposeRenderer();
 
-        public void beginRendering();
+        void beginRendering();
 
-        public void endRendering();
+        void endRendering();
 
-        public void drawTextNode(NodeModel model);
+        void drawTextNode(NodeModel model);
 
-        public void drawTextEdge(EdgeModel model);
+        void drawTextEdge(EdgeModel model);
 
-        public Font getFont();
+        Font getFont();
 
-        public void setFont(Font font);
+        void setFont(Font font);
 
-        public void setColor(float r, float g, float b, float a);
+        void setColor(float r, float g, float b, float a);
 
-        public TextRenderer getJOGLRenderer();
+        TextRenderer getJOGLRenderer();
     }
 
     private class Renderer3D implements Renderer {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S2333 - Redundant modifiers should not be used
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2333

Please let me know if you have any questions.

Kirill Vlasov
