### PR TITLE
Fixing squid:S1161 - @Override annotation should be used where necessary

### DIFF
--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/columns/merge/ui/CreateTimeIntervalUI.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/columns/merge/ui/CreateTimeIntervalUI.java
@@ -334,12 +334,14 @@ public class CreateTimeIntervalUI extends javax.swing.JPanel implements Manipula
         startColumnLabel.setText(org.openide.util.NbBundle.getMessage(CreateTimeIntervalUI.class, "CreateTimeIntervalUI.startColumnLabel.text")); // NOI18N
 
         startColumnComboBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 startColumnComboBoxActionPerformed(evt);
             }
         });
 
         endColumnComboBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 endColumnComboBoxActionPerformed(evt);
             }
@@ -351,6 +353,7 @@ public class CreateTimeIntervalUI extends javax.swing.JPanel implements Manipula
         parseNumbersRadioButton.setSelected(true);
         parseNumbersRadioButton.setText(org.openide.util.NbBundle.getMessage(CreateTimeIntervalUI.class, "CreateTimeIntervalUI.parseNumbersRadioButton.text")); // NOI18N
         parseNumbersRadioButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 parseNumbersRadioButtonActionPerformed(evt);
             }
@@ -362,6 +365,7 @@ public class CreateTimeIntervalUI extends javax.swing.JPanel implements Manipula
         buttonGroup.add(parseDatesRadioButton);
         parseDatesRadioButton.setText(org.openide.util.NbBundle.getMessage(CreateTimeIntervalUI.class, "CreateTimeIntervalUI.parseDatesRadioButton.text")); // NOI18N
         parseDatesRadioButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 parseDatesRadioButtonActionPerformed(evt);
             }

--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/columns/ui/ColumnValuesFrequencyUI.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/columns/ui/ColumnValuesFrequencyUI.java
@@ -124,6 +124,7 @@ public class ColumnValuesFrequencyUI extends javax.swing.JPanel implements Attri
         configurePieChartButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/datalab/plugin/manipulators/resources/category.png"))); // NOI18N
         configurePieChartButton.setText(org.openide.util.NbBundle.getMessage(ColumnValuesFrequencyUI.class, "ColumnValuesFrequencyUI.configurePieChartButton.text")); // NOI18N
         configurePieChartButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 configurePieChartButtonActionPerformed(evt);
             }
@@ -132,6 +133,7 @@ public class ColumnValuesFrequencyUI extends javax.swing.JPanel implements Attri
         showReportButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/datalab/plugin/manipulators/resources/application-block.png"))); // NOI18N
         showReportButton.setText(org.openide.util.NbBundle.getMessage(ColumnValuesFrequencyUI.class, "ColumnValuesFrequencyUI.showReportButton.text")); // NOI18N
         showReportButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 showReportButtonActionPerformed(evt);
             }

--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/columns/ui/ConvertColumnToDynamicUI.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/columns/ui/ConvertColumnToDynamicUI.java
@@ -187,6 +187,7 @@ public class ConvertColumnToDynamicUI extends javax.swing.JPanel implements Attr
         replaceColumnCheckbox.setToolTipText(org.openide.util.NbBundle.getMessage(ConvertColumnToDynamicUI.class, "ConvertColumnToDynamicUI.replaceColumnCheckbox.toolTipText")); // NOI18N
         replaceColumnCheckbox.setHorizontalTextPosition(javax.swing.SwingConstants.LEADING);
         replaceColumnCheckbox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 replaceColumnCheckboxActionPerformed(evt);
             }

--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/AddEdgeToGraphUI.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/AddEdgeToGraphUI.java
@@ -203,6 +203,7 @@ public class AddEdgeToGraphUI extends javax.swing.JPanel implements ManipulatorU
         directedUndirectedRadioButtonGroup.add(directedRadioButton);
         directedRadioButton.setText(org.openide.util.NbBundle.getMessage(AddEdgeToGraphUI.class, "AddEdgeToGraphUI.directedRadioButton.text")); // NOI18N
         directedRadioButton.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 directedRadioButtonItemStateChanged(evt);
             }
@@ -211,6 +212,7 @@ public class AddEdgeToGraphUI extends javax.swing.JPanel implements ManipulatorU
         directedUndirectedRadioButtonGroup.add(undirectedRadioButton);
         undirectedRadioButton.setText(org.openide.util.NbBundle.getMessage(AddEdgeToGraphUI.class, "AddEdgeToGraphUI.undirectedRadioButton.text")); // NOI18N
         undirectedRadioButton.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 undirectedRadioButtonItemStateChanged(evt);
             }
@@ -219,6 +221,7 @@ public class AddEdgeToGraphUI extends javax.swing.JPanel implements ManipulatorU
         descriptionLabel.setText(org.openide.util.NbBundle.getMessage(AddEdgeToGraphUI.class, "AddEdgeToGraphUI.descriptionLabel.text")); // NOI18N
 
         sourceNodesComboBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 sourceNodesComboBoxItemStateChanged(evt);
             }
@@ -232,6 +235,7 @@ public class AddEdgeToGraphUI extends javax.swing.JPanel implements ManipulatorU
 
         edgeTypeComboBox.setEditable(true);
         edgeTypeComboBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 edgeTypeComboBoxActionPerformed(evt);
             }

--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/ImportCSVUIVisualPanel1.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/ImportCSVUIVisualPanel1.java
@@ -426,6 +426,7 @@ public class ImportCSVUIVisualPanel1 extends javax.swing.JPanel {
 
         fileButton.setText(org.openide.util.NbBundle.getMessage(ImportCSVUIVisualPanel1.class, "ImportCSVUIVisualPanel1.fileButton.text")); // NOI18N
         fileButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 fileButtonActionPerformed(evt);
             }
@@ -435,6 +436,7 @@ public class ImportCSVUIVisualPanel1 extends javax.swing.JPanel {
         separatorLabel.setText(org.openide.util.NbBundle.getMessage(ImportCSVUIVisualPanel1.class, "ImportCSVUIVisualPanel1.separatorLabel.text")); // NOI18N
 
         separatorComboBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 separatorComboBoxItemStateChanged(evt);
             }
@@ -444,6 +446,7 @@ public class ImportCSVUIVisualPanel1 extends javax.swing.JPanel {
         tableLabel.setText(org.openide.util.NbBundle.getMessage(ImportCSVUIVisualPanel1.class, "ImportCSVUIVisualPanel1.tableLabel.text")); // NOI18N
 
         tableComboBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 tableComboBoxItemStateChanged(evt);
             }
@@ -457,6 +460,7 @@ public class ImportCSVUIVisualPanel1 extends javax.swing.JPanel {
         charsetLabel.setText(org.openide.util.NbBundle.getMessage(ImportCSVUIVisualPanel1.class, "ImportCSVUIVisualPanel1.charsetLabel.text")); // NOI18N
 
         charsetComboBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 charsetComboBoxItemStateChanged(evt);
             }

--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/SearchReplaceUI.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/general/ui/SearchReplaceUI.java
@@ -329,6 +329,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
 
         matchWholeValueCheckBox.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.matchWholeValueCheckBox.text")); // NOI18N
         matchWholeValueCheckBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 matchWholeValueCheckBoxItemStateChanged(evt);
             }
@@ -338,6 +339,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
         normalSearchModeRadioButton.setSelected(true);
         normalSearchModeRadioButton.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.normalSearchModeRadioButton.text")); // NOI18N
         normalSearchModeRadioButton.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 normalSearchModeRadioButtonItemStateChanged(evt);
             }
@@ -346,6 +348,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
         searchModeButtonGroup.add(regexSearchModeRadioButton);
         regexSearchModeRadioButton.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.regexSearchModeRadioButton.text")); // NOI18N
         regexSearchModeRadioButton.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 regexSearchModeRadioButtonItemStateChanged(evt);
             }
@@ -353,6 +356,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
 
         caseSensitiveCheckBox.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.caseSensitiveCheckBox.text")); // NOI18N
         caseSensitiveCheckBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 caseSensitiveCheckBoxItemStateChanged(evt);
             }
@@ -360,6 +364,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
 
         findNextButton.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.findNextButton.text")); // NOI18N
         findNextButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 findNextButtonActionPerformed(evt);
             }
@@ -367,6 +372,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
 
         replaceButton.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.replaceButton.text")); // NOI18N
         replaceButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 replaceButtonActionPerformed(evt);
             }
@@ -374,6 +380,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
 
         replaceAllButton.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.replaceAllButton.text")); // NOI18N
         replaceAllButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 replaceAllButtonActionPerformed(evt);
             }
@@ -381,6 +388,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
 
         searchText.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.searchText.text")); // NOI18N
         searchText.addKeyListener(new java.awt.event.KeyAdapter() {
+            @Override
             public void keyPressed(java.awt.event.KeyEvent evt) {
                 searchTextKeyPressed(evt);
             }
@@ -396,6 +404,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
 
         regexReplaceCheckBox.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.regexReplaceCheckBox.text")); // NOI18N
         regexReplaceCheckBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 regexReplaceCheckBoxItemStateChanged(evt);
             }
@@ -404,6 +413,7 @@ public final class SearchReplaceUI extends javax.swing.JPanel {
         columnsToSearchLabel.setText(org.openide.util.NbBundle.getMessage(SearchReplaceUI.class, "SearchReplaceUI.columnsToSearchLabel.text")); // NOI18N
 
         columnsToSearchComboBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 columnsToSearchComboBoxItemStateChanged(evt);
             }

--- a/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/ui/GeneralNumberListStatisticsReportUI.java
+++ b/modules/DataLaboratoryPlugin/src/main/java/org/gephi/datalab/plugin/manipulators/ui/GeneralNumberListStatisticsReportUI.java
@@ -180,6 +180,7 @@ public class GeneralNumberListStatisticsReportUI extends javax.swing.JPanel impl
         configureBoxPlotButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/datalab/plugin/manipulators/resources/wooden-box.png"))); // NOI18N
         configureBoxPlotButton.setText(org.openide.util.NbBundle.getMessage(GeneralNumberListStatisticsReportUI.class, "GeneralNumberListStatisticsReportUI.configureBoxPlotButton.text")); // NOI18N
         configureBoxPlotButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 configureBoxPlotButtonActionPerformed(evt);
             }
@@ -188,6 +189,7 @@ public class GeneralNumberListStatisticsReportUI extends javax.swing.JPanel impl
         configureScatterPlotButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/datalab/plugin/manipulators/resources/chart-up.png"))); // NOI18N
         configureScatterPlotButton.setText(org.openide.util.NbBundle.getMessage(GeneralNumberListStatisticsReportUI.class, "GeneralNumberListStatisticsReportUI.configureScatterPlotButton.text_1")); // NOI18N
         configureScatterPlotButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 configureScatterPlotButtonActionPerformed(evt);
             }
@@ -196,6 +198,7 @@ public class GeneralNumberListStatisticsReportUI extends javax.swing.JPanel impl
         showReportButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/datalab/plugin/manipulators/resources/application-block.png"))); // NOI18N
         showReportButton.setText(org.openide.util.NbBundle.getMessage(GeneralNumberListStatisticsReportUI.class, "GeneralNumberListStatisticsReportUI.showReportButton.text")); // NOI18N
         showReportButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 showReportButtonActionPerformed(evt);
             }
@@ -203,6 +206,7 @@ public class GeneralNumberListStatisticsReportUI extends javax.swing.JPanel impl
 
         useLinesCheckBox.setText(org.openide.util.NbBundle.getMessage(GeneralNumberListStatisticsReportUI.class, "GeneralNumberListStatisticsReportUI.useLinesCheckBox.text")); // NOI18N
         useLinesCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 useLinesCheckBoxActionPerformed(evt);
             }
@@ -210,6 +214,7 @@ public class GeneralNumberListStatisticsReportUI extends javax.swing.JPanel impl
 
         useLinearRegression.setText(org.openide.util.NbBundle.getMessage(GeneralNumberListStatisticsReportUI.class, "GeneralNumberListStatisticsReportUI.useLinearRegression.text")); // NOI18N
         useLinearRegression.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 useLinearRegressionActionPerformed(evt);
             }
@@ -218,6 +223,7 @@ public class GeneralNumberListStatisticsReportUI extends javax.swing.JPanel impl
         configureHistogramButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/datalab/plugin/manipulators/resources/chart.png"))); // NOI18N
         configureHistogramButton.setText(org.openide.util.NbBundle.getMessage(GeneralNumberListStatisticsReportUI.class, "GeneralNumberListStatisticsReportUI.configureHistogramButton.text")); // NOI18N
         configureHistogramButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 configureHistogramButtonActionPerformed(evt);
             }
@@ -226,6 +232,7 @@ public class GeneralNumberListStatisticsReportUI extends javax.swing.JPanel impl
         divisionsLabel.setText(org.openide.util.NbBundle.getMessage(GeneralNumberListStatisticsReportUI.class, "GeneralNumberListStatisticsReportUI.divisionsLabel.text")); // NOI18N
 
         divisionsComboBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 divisionsComboBoxItemStateChanged(evt);
             }

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/Installer.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/Installer.java
@@ -97,6 +97,7 @@ public class Installer extends ModuleInstall {
 
         //Check for new major release:
         WindowManager.getDefault().invokeWhenUIReady(new Runnable() {
+            @Override
             public void run() {
                 new Thread() {
                     @Override
@@ -114,6 +115,7 @@ public class Installer extends ModuleInstall {
     private void initGephi() {
         final ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
         WindowManager.getDefault().invokeWhenUIReady(new Runnable() {
+            @Override
             public void run() {
                 pc.startup();
                 DragNDropFrameAdapter.register();

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/MemoryStarvationManager.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/MemoryStarvationManager.java
@@ -112,6 +112,7 @@ public class MemoryStarvationManager implements NotificationListener {
         }
     }
 
+    @Override
     public void handleNotification(Notification n, Object o) {
         if (messageDelivered) {
             return;

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/CloseProject.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/CloseProject.java
@@ -50,6 +50,7 @@ import org.openide.util.actions.SystemAction;
 
 public final class CloseProject extends SystemAction {
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         Lookup.getDefault().lookup(ProjectControllerUI.class).closeProject();
     }

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/DeleteWorkspace.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/DeleteWorkspace.java
@@ -50,6 +50,7 @@ import org.openide.util.actions.SystemAction;
 
 public class DeleteWorkspace extends SystemAction {
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         Lookup.getDefault().lookup(ProjectControllerUI.class).deleteWorkspace();
     }

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/NewProject.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/NewProject.java
@@ -50,6 +50,7 @@ import org.openide.util.actions.SystemAction;
 
 public final class NewProject extends SystemAction {
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         Lookup.getDefault().lookup(ProjectControllerUI.class).newProject();
     }

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/NewWorkspace.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/NewWorkspace.java
@@ -50,6 +50,7 @@ import org.openide.util.actions.SystemAction;
 
 public class NewWorkspace extends SystemAction {
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         Lookup.getDefault().lookup(ProjectControllerUI.class).newWorkspace();
     }

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/RenameWorkspace.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/actions/RenameWorkspace.java
@@ -58,6 +58,7 @@ import org.openide.util.actions.SystemAction;
  */
 public class RenameWorkspace extends SystemAction {
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         String name = "";
         ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/multilingual/LanguageAction.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/multilingual/LanguageAction.java
@@ -119,6 +119,7 @@ public final class LanguageAction extends CallableSystemAction {
         for (final Language lang : Language.values()) {
             JMenuItem menuItem = new JMenuItem(new AbstractAction(lang.getName()) {
 
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     String msg = NbBundle.getMessage(LanguageAction.class, "ChangeLang.Confirm.message" + (Utilities.isMac() || Utilities.isUnix() ? ".mac" : ""));
                     String title = NbBundle.getMessage(LanguageAction.class, "ChangeLang.Confirm.title");

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
@@ -90,6 +90,7 @@ public class ReportController {
     public void sendReport(final Report report) {
         Thread thread = new Thread(new Runnable() {
 
+            @Override
             public void run() {
                 ProgressHandle handle = ProgressHandleFactory.createHandle(NbBundle.getMessage(ReportController.class, "ReportController.status.sending"));
                 try {

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportPanel.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportPanel.java
@@ -64,6 +64,7 @@ public class ReportPanel extends javax.swing.JPanel {
         //Bind
         followCheckBox.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 labelEmail.setEnabled(followCheckBox.isSelected());
                 emailTextField.setEnabled(followCheckBox.isSelected());
@@ -75,6 +76,7 @@ public class ReportPanel extends javax.swing.JPanel {
         helpLabel.setEnabled(followCheckBox.isSelected());
         viewDataButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 //Set
                 ReportPanel.this.report.setUserDescription(problemArea.getText());

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReporterHandler.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReporterHandler.java
@@ -92,12 +92,14 @@ public class ReporterHandler extends java.util.logging.Handler implements Callab
         throwable = null;
     }
 
+    @Override
     public JButton call() throws Exception {
         JButton btn = new JButton(NbBundle.getMessage(ReporterHandler.class, "ReportHandler.button"));
         btn.addActionListener(this);
         return btn;
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         Report report = new Report();
         report.setThrowable(throwable);

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/ConfigurationPanel.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/ConfigurationPanel.java
@@ -312,6 +312,7 @@ public class ConfigurationPanel extends javax.swing.JPanel {
 
         onlyVisibleCheckBox.setText(org.openide.util.NbBundle.getMessage(ConfigurationPanel.class, "ConfigurationPanel.onlyVisibleCheckBox.text")); // NOI18N
         onlyVisibleCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 onlyVisibleCheckBoxActionPerformed(evt);
             }
@@ -319,6 +320,7 @@ public class ConfigurationPanel extends javax.swing.JPanel {
 
         useSparklinesCheckBox.setText(org.openide.util.NbBundle.getMessage(ConfigurationPanel.class, "ConfigurationPanel.useSparklinesCheckBox.text")); // NOI18N
         useSparklinesCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 useSparklinesCheckBoxActionPerformed(evt);
             }
@@ -326,6 +328,7 @@ public class ConfigurationPanel extends javax.swing.JPanel {
 
         showEdgesNodesLabelsCheckBox.setText(org.openide.util.NbBundle.getMessage(ConfigurationPanel.class, "ConfigurationPanel.showEdgesNodesLabelsCheckBox.text")); // NOI18N
         showEdgesNodesLabelsCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 showEdgesNodesLabelsCheckBoxActionPerformed(evt);
             }
@@ -333,6 +336,7 @@ public class ConfigurationPanel extends javax.swing.JPanel {
 
         timeIntervalsGraphicsCheckBox.setText(org.openide.util.NbBundle.getMessage(ConfigurationPanel.class, "ConfigurationPanel.timeIntervalsGraphicsCheckBox.text")); // NOI18N
         timeIntervalsGraphicsCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 timeIntervalsGraphicsCheckBoxActionPerformed(evt);
             }

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
@@ -1367,6 +1367,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
         nodesButton.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
         nodesButton.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         nodesButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 nodesButtonActionPerformed(evt);
             }
@@ -1379,6 +1380,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
         edgesButton.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
         edgesButton.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         edgesButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 edgesButtonActionPerformed(evt);
             }
@@ -1393,6 +1395,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
         configurationButton.setHorizontalTextPosition(javax.swing.SwingConstants.RIGHT);
         configurationButton.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         configurationButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 configurationButtonActionPerformed(evt);
             }
@@ -1424,6 +1427,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
         availableColumnsButton.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
         availableColumnsButton.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         availableColumnsButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 availableColumnsButtonActionPerformed(evt);
             }
@@ -1461,6 +1465,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
 
         org.openide.awt.Mnemonics.setLocalizedText(refreshButton, org.openide.util.NbBundle.getMessage(DataTableTopComponent.class, "DataTableTopComponent.refreshButton.text")); // NOI18N
         refreshButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 refreshButtonActionPerformed(evt);
             }

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/general/actions/MergeColumnsUI.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/general/actions/MergeColumnsUI.java
@@ -340,6 +340,7 @@ public class MergeColumnsUI extends javax.swing.JPanel {
         infoLabel = new javax.swing.JLabel();
 
         columnsToMergeList.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 columnsToMergeListMouseClicked(evt);
             }
@@ -352,6 +353,7 @@ public class MergeColumnsUI extends javax.swing.JPanel {
         addColumnButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/desktop/datalab/resources/arrow.png"))); // NOI18N
         addColumnButton.setText(org.openide.util.NbBundle.getMessage(MergeColumnsUI.class, "MergeColumnsUI.addColumnButton.text")); // NOI18N
         addColumnButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 addColumnButtonActionPerformed(evt);
             }
@@ -360,12 +362,14 @@ public class MergeColumnsUI extends javax.swing.JPanel {
         removeColumnButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/desktop/datalab/resources/arrow-180.png"))); // NOI18N
         removeColumnButton.setText(org.openide.util.NbBundle.getMessage(MergeColumnsUI.class, "MergeColumnsUI.removeColumnButton.text")); // NOI18N
         removeColumnButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 removeColumnButtonActionPerformed(evt);
             }
         });
 
         availableColumnsList.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 availableColumnsListMouseClicked(evt);
             }
@@ -382,6 +386,7 @@ public class MergeColumnsUI extends javax.swing.JPanel {
         availableStrategiesLabel.setText(org.openide.util.NbBundle.getMessage(MergeColumnsUI.class, "MergeColumnsUI.availableStrategiesLabel.text")); // NOI18N
 
         availableStrategiesComboBox.addItemListener(new java.awt.event.ItemListener() {
+            @Override
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 availableStrategiesComboBoxItemStateChanged(evt);
             }

--- a/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/DesktopExportController.java
+++ b/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/DesktopExportController.java
@@ -72,6 +72,7 @@ public class DesktopExportController implements ExportControllerUI {
         controller = Lookup.getDefault().lookup(ExportController.class);
         errorHandler = new LongTaskErrorHandler() {
 
+            @Override
             public void fatalError(Throwable t) {
                 t.printStackTrace();
                 String message = t.getCause().getMessage();
@@ -86,6 +87,7 @@ public class DesktopExportController implements ExportControllerUI {
         executor = new LongTaskExecutor(true, "Exporter", 10);
     }
 
+    @Override
     public void exportFile(final FileObject fileObject, final Exporter exporter) {
         if (exporter == null) {
             throw new RuntimeException(NbBundle.getMessage(getClass(), "error_no_matching_file_exporter"));
@@ -99,6 +101,7 @@ public class DesktopExportController implements ExportControllerUI {
         String taskmsg = NbBundle.getMessage(DesktopExportController.class, "DesktopExportController.exportTaskName", fileObject.getNameExt());
         executor.execute(task, new Runnable() {
 
+            @Override
             public void run() {
                 try {
                     controller.exportFile(FileUtil.toFile(fileObject), exporter);
@@ -110,6 +113,7 @@ public class DesktopExportController implements ExportControllerUI {
         }, taskmsg, errorHandler);
     }
 
+    @Override
     public ExportController getExportController() {
         return controller;
     }

--- a/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/Export.java
+++ b/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/Export.java
@@ -67,19 +67,24 @@ public class Export extends CallableSystemAction {
 
         Lookup.getDefault().lookup(ProjectController.class).addWorkspaceListener(new WorkspaceListener() {
 
+            @Override
             public void initialize(Workspace workspace) {
             }
 
+            @Override
             public void select(Workspace workspace) {
                 menu.setEnabled(true);
             }
 
+            @Override
             public void unselect(Workspace workspace) {
             }
 
+            @Override
             public void close(Workspace workspace) {
             }
 
+            @Override
             public void disable() {
                 menu.setEnabled(false);
             }
@@ -109,6 +114,7 @@ public class Export extends CallableSystemAction {
             String menuName = ui.getName();
             JMenuItem menuItem = new JMenuItem(new AbstractAction(menuName) {
 
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     ui.action();
                 }

--- a/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/api/GraphFileExporterUI.java
+++ b/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/api/GraphFileExporterUI.java
@@ -90,14 +90,17 @@ public final class GraphFileExporterUI implements ExporterClassUI {
     private boolean visibleOnlyGraph = false;
     private JDialog dialog;
 
+    @Override
     public String getName() {
         return NbBundle.getMessage(GraphFileExporterUI.class, "GraphFileExporterUI_title");
     }
 
+    @Override
     public boolean isEnable() {
         return true;
     }
 
+    @Override
     public void action() {
         final String LAST_PATH = "GraphFileExporterUI_Last_Path";
         final String LAST_PATH_DEFAULT = "GraphFileExporterUI_Last_Path_Default";
@@ -118,6 +121,7 @@ public final class GraphFileExporterUI implements ExporterClassUI {
         optionsPanel.add(optionsButton);
         optionsButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 ExporterUI exporterUI = exportController.getExportController().getUI(selectedExporter);
                 if (exporterUI != null) {
@@ -169,6 +173,7 @@ public final class GraphFileExporterUI implements ExporterClassUI {
         chooser.setDialogTitle(NbBundle.getMessage(GraphFileExporterUI.class, "GraphFileExporterUI_filechooser_title"));
         chooser.addPropertyChangeListener(JFileChooser.FILE_FILTER_CHANGED_PROPERTY, new PropertyChangeListener() {
 
+            @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 DialogFileFilter fileFilter = (DialogFileFilter) evt.getNewValue();
 
@@ -198,6 +203,7 @@ public final class GraphFileExporterUI implements ExporterClassUI {
         });
         chooser.addPropertyChangeListener(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY, new PropertyChangeListener() {
 
+            @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 if (evt.getNewValue() != null) {
                     selectedFile = (File) evt.getNewValue();

--- a/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/api/TopDialog.java
+++ b/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/api/TopDialog.java
@@ -118,6 +118,7 @@ class TopDialog extends JDialog {
 
         Action cancelAction = new AbstractAction() {
 
+            @Override
             public void actionPerformed(ActionEvent ev) {
                 cancel();
             }
@@ -127,6 +128,7 @@ class TopDialog extends JDialog {
         addWindowListener(
                 new WindowAdapter() {
 
+                    @Override
                     public void windowClosing(WindowEvent ev) {
                         if (!haveFinalValue) {
                             TopDialog.this.nd.setValue(NotifyDescriptor.CLOSED_OPTION);
@@ -288,6 +290,7 @@ class TopDialog extends JDialog {
     private ActionListener makeListener(final Object option) {
         return new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 //System.err.println("actionPerformed: " + option);
                 nd.setValue(option);

--- a/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/api/VectorialFileExporterUI.java
+++ b/modules/DesktopExport/src/main/java/org/gephi/desktop/io/export/api/VectorialFileExporterUI.java
@@ -88,14 +88,17 @@ public final class VectorialFileExporterUI implements ExporterClassUI {
     private File selectedFile;
     private JDialog dialog;
 
+    @Override
     public String getName() {
         return NbBundle.getMessage(VectorialFileExporterUI.class, "VectorialFileExporterUI_title");
     }
 
+    @Override
     public boolean isEnable() {
         return true;
     }
 
+    @Override
     public void action() {
         final String LAST_PATH = "VectorialFileExporterUI_Last_Path";
         final String LAST_PATH_DEFAULT = "VectorialFileExporterUI_Last_Path_Default";
@@ -116,6 +119,7 @@ public final class VectorialFileExporterUI implements ExporterClassUI {
         optionsPanel.add(optionsButton);
         optionsButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 ExporterUI exporterUI = exportController.getExportController().getUI(selectedExporter);
                 if (exporterUI != null) {
@@ -161,6 +165,7 @@ public final class VectorialFileExporterUI implements ExporterClassUI {
         chooser.setDialogTitle(NbBundle.getMessage(VectorialFileExporterUI.class, "VectorialFileExporterUI_filechooser_title"));
         chooser.addPropertyChangeListener(JFileChooser.FILE_FILTER_CHANGED_PROPERTY, new PropertyChangeListener() {
 
+            @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 DialogFileFilter fileFilter = (DialogFileFilter) evt.getNewValue();
 
@@ -190,6 +195,7 @@ public final class VectorialFileExporterUI implements ExporterClassUI {
         });
         chooser.addPropertyChangeListener(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY, new PropertyChangeListener() {
 
+            @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 if (evt.getNewValue() != null) {
                     selectedFile = (File) evt.getNewValue();

--- a/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/CategoryChildFactory.java
+++ b/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/CategoryChildFactory.java
@@ -69,6 +69,7 @@ public class CategoryChildFactory extends ChildFactory<Object> {
         Object[] children = utils.getChildren(category);
         Arrays.sort(children, new Comparator() {
 
+            @Override
             public int compare(Object o1, Object o2) {
                 String s1;
                 String s2;

--- a/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/FilterBuilderNode.java
+++ b/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/FilterBuilderNode.java
@@ -109,15 +109,18 @@ public class FilterBuilderNode extends AbstractNode {
 
     private class FilterTransferable implements Transferable {
 
+        @Override
         public DataFlavor[] getTransferDataFlavors() {
             return new DataFlavor[]{DATA_FLAVOR};
         }
 
+        @Override
         public boolean isDataFlavorSupported(DataFlavor flavor) {
             return flavor == DATA_FLAVOR;
 
         }
 
+        @Override
         public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
             if (flavor == DATA_FLAVOR) {
                 return filterBuilder;

--- a/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/FiltersExplorer.java
+++ b/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/FiltersExplorer.java
@@ -224,6 +224,7 @@ public class FiltersExplorer extends BeanTreeView {
     private void updateEnabled(final boolean enabled) {
         SwingUtilities.invokeLater(new Runnable() {
 
+            @Override
             public void run() {
                 setRootVisible(enabled);
                 setEnabled(enabled);

--- a/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/SavedQueryNode.java
+++ b/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/library/SavedQueryNode.java
@@ -113,6 +113,7 @@ public class SavedQueryNode extends AbstractNode {
             super(NbBundle.getMessage(SavedQueryNode.class, "SavedQueryNode.actions.remove"));
         }
 
+        @Override
         public void actionPerformed(ActionEvent e) {
             FilterController filterController = Lookup.getDefault().lookup(FilterController.class);
             FilterLibrary filterLibrary = filterController.getModel().getLibrary();

--- a/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/query/QueryExplorer.java
+++ b/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/query/QueryExplorer.java
@@ -93,6 +93,7 @@ public class QueryExplorer extends BeanTreeView implements PropertyChangeListene
             model.addChangeListener(this);
             SwingUtilities.invokeLater(new Runnable() {
 
+                @Override
                 public void run() {
                     manager.setRootContext(new RootNode(new QueryChildren(model.getQueries())));
                 }
@@ -100,6 +101,7 @@ public class QueryExplorer extends BeanTreeView implements PropertyChangeListene
         } else {
             SwingUtilities.invokeLater(new Runnable() {
 
+                @Override
                 public void run() {
                     manager.setRootContext(new AbstractNode(Children.LEAF) {
 
@@ -119,6 +121,7 @@ public class QueryExplorer extends BeanTreeView implements PropertyChangeListene
         }
     }
 
+    @Override
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(ExplorerManager.PROP_SELECTED_NODES)) {
             if (uiModel == null) {
@@ -144,6 +147,7 @@ public class QueryExplorer extends BeanTreeView implements PropertyChangeListene
                 final Query query = queryNode.getQuery();
                 new Thread(new Runnable() {
 
+                    @Override
                     public void run() {
                         uiModel.setSelectedQuery(query);
                         model.removeChangeListener(QueryExplorer.this);
@@ -155,10 +159,12 @@ public class QueryExplorer extends BeanTreeView implements PropertyChangeListene
         }
     }
 
+    @Override
     public void stateChanged(ChangeEvent e) {
         //System.out.println("model updated");
         SwingUtilities.invokeLater(new Runnable() {
 
+            @Override
             public void run() {
                 //uiModel.setSelectedQuery(model.getCurrentQuery());
                 saveExpandStatus(QueryExplorer.this.manager.getRootContext());
@@ -171,6 +177,7 @@ public class QueryExplorer extends BeanTreeView implements PropertyChangeListene
     private void updateEnabled(final boolean enabled) {
         SwingUtilities.invokeLater(new Runnable() {
 
+            @Override
             public void run() {
                 setRootVisible(enabled);
                 setEnabled(enabled);

--- a/modules/DesktopGenerate/src/main/java/org/gephi/desktop/generate/Generate.java
+++ b/modules/DesktopGenerate/src/main/java/org/gephi/desktop/generate/Generate.java
@@ -83,6 +83,7 @@ public class Generate extends CallableSystemAction {
                 String menuName = gen.getName() + "...";
                 JMenuItem menuItem = new JMenuItem(new AbstractAction(menuName) {
 
+                    @Override
                     public void actionPerformed(ActionEvent e) {
                         generatorController.generate(gen);
                     }

--- a/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPanel.java
+++ b/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPanel.java
@@ -353,6 +353,7 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
         runButton.setIconTextGap(5);
         runButton.setMargin(new java.awt.Insets(2, 7, 2, 14));
         runButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 runButtonActionPerformed(evt);
             }
@@ -376,6 +377,7 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
 
         resetButton.setText(org.openide.util.NbBundle.getMessage(LayoutPanel.class, "LayoutPanel.resetButton.text")); // NOI18N
         resetButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 resetButtonActionPerformed(evt);
             }

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewSettingsTopComponent.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewSettingsTopComponent.java
@@ -382,6 +382,7 @@ public final class PreviewSettingsTopComponent extends TopComponent implements P
         saveButton.setFocusable(false);
         saveButton.setHorizontalAlignment(javax.swing.SwingConstants.RIGHT);
         saveButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 saveButtonActionPerformed(evt);
             }
@@ -417,6 +418,7 @@ public final class PreviewSettingsTopComponent extends TopComponent implements P
         refreshButton.setEnabled(false);
         refreshButton.setMargin(new java.awt.Insets(10, 14, 10, 14));
         refreshButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 refreshButtonActionPerformed(evt);
             }

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewTopComponent.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewTopComponent.java
@@ -298,6 +298,7 @@ public final class PreviewTopComponent extends TopComponent implements PropertyC
 
         org.openide.awt.Mnemonics.setLocalizedText(refreshButton, org.openide.util.NbBundle.getMessage(PreviewTopComponent.class, "PreviewTopComponent.refreshButton.text")); // NOI18N
         refreshButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 refreshButtonActionPerformed(evt);
             }

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/RendererManager.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/RendererManager.java
@@ -297,6 +297,7 @@ public class RendererManager extends javax.swing.JPanel implements PropertyChang
         restoreOrderButton.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
         restoreOrderButton.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         restoreOrderButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 restoreOrderButtonActionPerformed(evt);
             }
@@ -309,6 +310,7 @@ public class RendererManager extends javax.swing.JPanel implements PropertyChang
         selectAllButton.setFocusable(false);
         selectAllButton.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         selectAllButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 selectAllButtonActionPerformed(evt);
             }
@@ -320,6 +322,7 @@ public class RendererManager extends javax.swing.JPanel implements PropertyChang
         unselectAllButon.setFocusable(false);
         unselectAllButon.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         unselectAllButon.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 unselectAllButonActionPerformed(evt);
             }

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -107,6 +107,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         //Project IO executor
         longTaskExecutor = new LongTaskExecutor(true, "Project IO");
         longTaskExecutor.setDefaultErrorHandler(new LongTaskErrorHandler() {
+            @Override
             public void fatalError(Throwable t) {
                 unlockProjectActions();
 //                String txt = NbBundle.getMessage(ProjectControllerUIImpl.class, "ProjectControllerUI.error.open");
@@ -121,6 +122,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
             }
         });
         longTaskExecutor.setLongTaskListener(new LongTaskListener() {
+            @Override
             public void taskFinished(LongTask task) {
                 unlockProjectActions();
             }
@@ -133,6 +135,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         final Runnable saveTask = controller.saveProject(project, file);
         final String fileName = file.getName();
         Runnable saveRunnable = new Runnable() {
+            @Override
             public void run() {
                 saveTask.run();
                 //Status line
@@ -150,6 +153,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         mostRecentFiles.addFile(file.getAbsolutePath());
     }
 
+    @Override
     public void saveProject() {
         Project project = controller.getCurrentProject();
         if (project.getLookup().lookup(ProjectInformation.class).hasFile()) {
@@ -160,6 +164,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         }
     }
 
+    @Override
     public void saveAsProject() {
         final String LAST_PATH = "SaveAsProject_Last_Path";
         final String LAST_PATH_DEFAULT = "SaveAsProject_Last_Path_Default";
@@ -210,6 +215,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
 
                 //Modifying Title bar
                 SwingUtilities.invokeLater(new Runnable() {
+                    @Override
                     public void run() {
                         JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                         String title = frame.getTitle();
@@ -258,6 +264,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
 
             //Title bar
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                     String title = frame.getTitle();
@@ -269,6 +276,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         return true;
     }
 
+    @Override
     public void openProject(File file) {
         if (controller.getCurrentProject() != null) {
             if (!closeCurrentProject()) {
@@ -284,9 +292,11 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         final Runnable loadTask = controller.openProject(file);
         final String fileName = file.getName();
         Runnable loadRunnable = new Runnable() {
+            @Override
             public void run() {
                 loadTask.run();
                 SwingUtilities.invokeLater(new Runnable() {
+                    @Override
                     public void run() {
                         JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                         String title = frame.getTitle() + " - " + fileName;
@@ -308,11 +318,13 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         mostRecentFiles.addFile(file.getAbsolutePath());
     }
 
+    @Override
     public void renameProject(final String name) {
         controller.renameProject(controller.getCurrentProject(), name);
 
         //Title bar
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                 String title = frame.getTitle();
@@ -323,42 +335,52 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         });
     }
 
+    @Override
     public boolean canCloseProject() {
         return closeProject;
     }
 
+    @Override
     public boolean canDeleteWorkspace() {
         return deleteWorkspace;
     }
 
+    @Override
     public boolean canNewProject() {
         return newProject;
     }
 
+    @Override
     public boolean canNewWorkspace() {
         return newWorkspace;
     }
 
+    @Override
     public boolean canDuplicateWorkspace() {
         return duplicateWorkspace;
     }
 
+    @Override
     public boolean canRenameWorkspace() {
         return renameWorkspace;
     }
 
+    @Override
     public boolean canOpenFile() {
         return openFile;
     }
 
+    @Override
     public boolean canSave() {
         return saveProject;
     }
 
+    @Override
     public boolean canSaveAs() {
         return saveAsProject;
     }
 
+    @Override
     public boolean canProjectProperties() {
         return projectProperties;
     }
@@ -394,6 +416,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         openFile = true;
     }
 
+    @Override
     public void projectProperties() {
         Project project = controller.getCurrentProject();
         ProjectPropertiesUI ui = Lookup.getDefault().lookup(ProjectPropertiesUI.class);
@@ -408,6 +431,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         }
     }
 
+    @Override
     public void openFile() {
         final String LAST_PATH = "OpenFile_Last_Path";
         final String LAST_PATH_DEFAULT = "OpenFile_Last_Path_Default";
@@ -489,12 +513,14 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         }
     }
 
+    @Override
     public Project newProject() {
         if (closeCurrentProject()) {
             controller.newProject();
             final Project project = controller.getCurrentProject();
 
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                     String title = frame.getTitle() + " - " + project.getLookup().lookup(ProjectInformation.class).getName();
@@ -508,16 +534,19 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         return null;
     }
 
+    @Override
     public void closeProject() {
         if (closeCurrentProject()) {
             controller.closeCurrentProject();
         }
     }
 
+    @Override
     public Workspace newWorkspace() {
         return controller.newWorkspace(controller.getCurrentProject());
     }
 
+    @Override
     public void deleteWorkspace() {
         if (controller.getCurrentProject().getLookup().lookup(WorkspaceProvider.class).getWorkspaces().length == 1) {
             //Close project
@@ -533,6 +562,7 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
 
             //Title bar
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                     String title = frame.getTitle();
@@ -544,10 +574,12 @@ public class ProjectControllerUIImpl implements ProjectControllerUI {
         controller.deleteWorkspace(controller.getCurrentWorkspace());
     }
 
+    @Override
     public void renameWorkspace(String name) {
         controller.renameWorkspace(controller.getCurrentWorkspace(), name);
     }
 
+    @Override
     public Workspace duplicateWorkspace() {
         return controller.duplicateWorkspace(controller.getCurrentWorkspace());
     }

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/AvailableStatisticsChooser.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/AvailableStatisticsChooser.java
@@ -77,6 +77,7 @@ public class AvailableStatisticsChooser extends javax.swing.JPanel {
         //Sort categories by position
         Arrays.sort(categories, new Comparator() {
 
+            @Override
             public int compare(Object o1, Object o2) {
                 Integer p1 = ((StatisticsCategory) o1).getPosition();
                 Integer p2 = ((StatisticsCategory) o2).getPosition();
@@ -104,6 +105,7 @@ public class AvailableStatisticsChooser extends javax.swing.JPanel {
             //Sort it by position
             Collections.sort(uis, new Comparator() {
 
+                @Override
                 public int compare(Object o1, Object o2) {
                     Integer p1 = ((StatisticsUI) o1).getPosition();
                     Integer p2 = ((StatisticsUI) o2).getPosition();

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/DynamicSettingsPanel.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/DynamicSettingsPanel.java
@@ -430,6 +430,7 @@ public class DynamicSettingsPanel extends javax.swing.JPanel {
             this.combo = comboBoxModel;
         }
 
+        @Override
         public boolean validate(Problems prblms, String string, String t) {
             Integer i = 0;
             try {
@@ -458,6 +459,7 @@ public class DynamicSettingsPanel extends javax.swing.JPanel {
             this.dates = dates;
         }
 
+        @Override
         public boolean validate(Problems prblms, String string, String t) {
             if (dates) {
                 Integer tick = 0;

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
@@ -107,6 +107,7 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
         }
     }
 
+    @Override
     public void execute(final Statistics statistics) {
         StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
         final StatisticsUI[] uis = getUI(statistics);
@@ -118,6 +119,7 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
 
         controller.execute(statistics, new LongTaskListener() {
 
+            @Override
             public void taskFinished(LongTask task) {
                 model.setRunning(statistics, false);
                 for (StatisticsUI s : uis) {
@@ -128,6 +130,7 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
         });
     }
 
+    @Override
     public void execute(final Statistics statistics, final LongTaskListener listener) {
         StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
         final StatisticsUI[] uis = getUI(statistics);
@@ -139,6 +142,7 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
 
         controller.execute(statistics, new LongTaskListener() {
 
+            @Override
             public void taskFinished(LongTask task) {
                 model.setRunning(statistics, false);
                 for (StatisticsUI s : uis) {
@@ -163,6 +167,7 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
         return list.toArray(new StatisticsUI[0]);
     }
 
+    @Override
     public void setStatisticsUIVisible(StatisticsUI ui, boolean visible) {
         if (model != null) {
             model.setVisible(ui, visible);

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsFrontEnd.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsFrontEnd.java
@@ -95,6 +95,7 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
 
         runButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 if (runButton.getText().equals(RUN)) {
                     run();
@@ -106,6 +107,7 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
 
         reportButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 showReport();
             }
@@ -183,6 +185,7 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
         if (currentStatistics != null) {
             LongTaskListener listener = new LongTaskListener() {
 
+                @Override
                 public void taskFinished(LongTask task) {
                     showReport();
                 }
@@ -199,6 +202,7 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
                     ValidationPanel vp = (ValidationPanel) dynamicSettingsPanel;
                     vp.addChangeListener(new ChangeListener() {
 
+                        @Override
                         public void stateChanged(ChangeEvent e) {
                             dd.setValid(!((ValidationPanel) e.getSource()).isProblem());
                         }
@@ -219,6 +223,7 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
                         ValidationPanel vp = (ValidationPanel) settingsPanel;
                         vp.addChangeListener(new ChangeListener() {
 
+                            @Override
                             public void stateChanged(ChangeEvent e) {
                                 dd.setValid(!((ValidationPanel) e.getSource()).isProblem());
                             }
@@ -248,6 +253,7 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
         if (report != null) {
             SwingUtilities.invokeLater(new Runnable() {
 
+                @Override
                 public void run() {
                     SimpleHTMLReport dialog = new SimpleHTMLReport(WindowManager.getDefault().getMainWindow(), report);
                 }

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
@@ -89,19 +89,23 @@ public class StatisticsModelUIImpl implements StatisticsModelUI {
         fireChangeEvent();
     }
 
+    @Override
     public String getResult(StatisticsUI statisticsUI) {
         return resultMap.get(statisticsUI);
     }
 
+    @Override
     public String getReport(Class<? extends Statistics> statistics) {
         StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
         return controller.getModel(workspace).getReport(statistics);
     }
 
+    @Override
     public boolean isStatisticsUIVisible(StatisticsUI statisticsUI) {
         return !invisibleList.contains(statisticsUI);
     }
 
+    @Override
     public boolean isRunning(StatisticsUI statisticsUI) {
         for (Statistics s : runningList.toArray(new Statistics[0])) {
             if (statisticsUI.getStatisticsClass().equals(s.getClass())) {
@@ -122,6 +126,7 @@ public class StatisticsModelUIImpl implements StatisticsModelUI {
         }
     }
 
+    @Override
     public Statistics getRunning(StatisticsUI statisticsUI) {
         for (Statistics s : runningList.toArray(new Statistics[0])) {
             if (statisticsUI.getStatisticsClass().equals(s)) {
@@ -142,12 +147,14 @@ public class StatisticsModelUIImpl implements StatisticsModelUI {
         }
     }
 
+    @Override
     public void addChangeListener(ChangeListener changeListener) {
         if (!listeners.contains(changeListener)) {
             listeners.add(changeListener);
         }
     }
 
+    @Override
     public void removeChangeListener(ChangeListener changeListener) {
         listeners.remove(changeListener);
     }

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsPanel.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsPanel.java
@@ -107,6 +107,7 @@ public class StatisticsPanel extends JPanel {
                 //Sort it by position
                 Collections.sort(uis, new Comparator() {
 
+                    @Override
                     public int compare(Object o1, Object o2) {
                         Integer p1 = ((UIFrontEnd) o1).getStatisticsUI().getPosition();
                         Integer p2 = ((UIFrontEnd) o2).getStatisticsUI().getPosition();
@@ -146,6 +147,7 @@ public class StatisticsPanel extends JPanel {
                 //Sort it by position
                 Collections.sort(uis, new Comparator() {
 
+                    @Override
                     public int compare(Object o1, Object o2) {
                         Integer p1 = ((StatisticsUI) o1).getPosition();
                         Integer p2 = ((StatisticsUI) o2).getPosition();

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsTopComponent.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsTopComponent.java
@@ -95,9 +95,11 @@ public final class StatisticsTopComponent extends TopComponent implements Change
         ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
         pc.addWorkspaceListener(new WorkspaceListener() {
 
+            @Override
             public void initialize(Workspace workspace) {
             }
 
+            @Override
             public void select(Workspace workspace) {
                 StatisticsModelUIImpl model = workspace.getLookup().lookup(StatisticsModelUIImpl.class);
                 if (model == null) {
@@ -107,12 +109,15 @@ public final class StatisticsTopComponent extends TopComponent implements Change
                 refreshModel(model);
             }
 
+            @Override
             public void unselect(Workspace workspace) {
             }
 
+            @Override
             public void close(Workspace workspace) {
             }
 
+            @Override
             public void disable() {
                 refreshModel(null);
             }
@@ -132,6 +137,7 @@ public final class StatisticsTopComponent extends TopComponent implements Change
         //Settings
         settingsButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 AvailableStatisticsChooser chooser = new AvailableStatisticsChooser();
                 chooser.setup(model, ((StatisticsPanel) statisticsPanel).getCategories());
@@ -156,6 +162,7 @@ public final class StatisticsTopComponent extends TopComponent implements Change
         ((StatisticsPanel) statisticsPanel).refreshModel(model);
     }
 
+    @Override
     public void stateChanged(ChangeEvent e) {
         refreshModel(model);
     }

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
@@ -73,6 +73,7 @@ public class CustomBoundsDialog extends javax.swing.JPanel {
 
         resetDefaultsDate.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 setDefaults();
             }
@@ -186,6 +187,7 @@ public class CustomBoundsDialog extends javax.swing.JPanel {
             this.max = max;
         }
 
+        @Override
         public boolean validate(Problems prblms, String string, String t) {
             double thisDate;
             double otherDate;
@@ -247,6 +249,7 @@ public class CustomBoundsDialog extends javax.swing.JPanel {
 
     private class FormatValidator implements Validator<String> {
 
+        @Override
         public boolean validate(Problems prblms, String string, String t) {
             if (model.getTimeFormat().equals(TimeFormat.DATE)) {
                 try {

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineDrawer.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineDrawer.java
@@ -341,11 +341,13 @@ public class TimelineDrawer extends JPanel implements MouseListener, MouseMotion
 
     }
 
+    @Override
     public void mouseClicked(MouseEvent e) {
         latestMousePositionX = e.getX();
         currentMousePositionX = latestMousePositionX;
     }
 
+    @Override
     public void mousePressed(MouseEvent e) {
         if (model == null) {
             return;
@@ -392,6 +394,7 @@ public class TimelineDrawer extends JPanel implements MouseListener, MouseMotion
 //        }        
     }
 
+    @Override
     public void mouseEntered(MouseEvent e) {
         //throw new UnsupportedOperationException("Not supported yet.");
         if (currentState == TimelineState.IDLE) {
@@ -401,6 +404,7 @@ public class TimelineDrawer extends JPanel implements MouseListener, MouseMotion
         mouseInside = true;
     }
 
+    @Override
     public void mouseExited(MouseEvent e) {
         //throw new UnsupportedOperationException("Not supported yet.");
         if (currentState == TimelineState.IDLE) {
@@ -413,6 +417,7 @@ public class TimelineDrawer extends JPanel implements MouseListener, MouseMotion
         repaint();
     }
 
+    @Override
     public void mouseReleased(MouseEvent evt) {
 
         latestMousePositionX = evt.getX();
@@ -422,6 +427,7 @@ public class TimelineDrawer extends JPanel implements MouseListener, MouseMotion
         this.getParent().repaint(); // so it will repaint upper and bottom panes
     }
 
+    @Override
     public void mouseMoved(MouseEvent evt) {
         if (model == null) {
             return;
@@ -489,6 +495,7 @@ public class TimelineDrawer extends JPanel implements MouseListener, MouseMotion
 
     }
 
+    @Override
     public void mouseDragged(MouseEvent evt) {
 
         if (model == null) {

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineTopComponent.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineTopComponent.java
@@ -110,6 +110,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
         //Close button
         closeButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 controller.setEnabled(false);
                 setTimeLineVisible(false);
@@ -118,6 +119,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
 
         disableButon.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 controller.setEnabled(false);
             }
@@ -126,6 +128,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
         //Enable button
         enableTimelineButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 if (model != null) {
                     controller.setEnabled(true);
@@ -135,6 +138,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
 
         columnsButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 //Create popup
                 JPopupMenu menu = new JPopupMenu();
@@ -150,6 +154,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                     JRadioButtonMenuItem item = new JRadioButtonMenuItem(col, selected);
                     item.addActionListener(new ActionListener() {
 
+                        @Override
                         public void actionPerformed(ActionEvent e) {
                             controller.selectColumn(col);
                         }
@@ -170,6 +175,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                     JMenuItem disableItem = new JMenuItem(NbBundle.getMessage(TimelineTopComponent.class, "TimelineTopComponent.charts.disable"));
                     disableItem.addActionListener(new ActionListener() {
 
+                        @Override
                         public void actionPerformed(ActionEvent e) {
                             controller.selectColumn(null);
                         }
@@ -187,6 +193,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
 
         settingsButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 //Create popup
                 JPopupMenu menu = new JPopupMenu();
@@ -197,6 +204,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                         ImageUtilities.image2Icon(customBoundsIcon));
                 customBoundsItem.addActionListener(new ActionListener() {
 
+                    @Override
                     public void actionPerformed(ActionEvent e) {
                         CustomBoundsDialog d = new CustomBoundsDialog();
                         d.setup(model);
@@ -205,6 +213,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                         final DialogDescriptor descriptor = new DialogDescriptor(validationPanel, title);
                         validationPanel.addChangeListener(new ChangeListener() {
 
+                            @Override
                             public void stateChanged(ChangeEvent e) {
                                 descriptor.setValid(!((ValidationPanel) e.getSource()).isProblem());
                             }
@@ -223,6 +232,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                         ImageUtilities.image2Icon(animationIcon));
                 animationItem.addActionListener(new ActionListener() {
 
+                    @Override
                     public void actionPerformed(ActionEvent e) {
                         PlaySettingsDialog d = new PlaySettingsDialog();
                         d.setup(model);
@@ -242,6 +252,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                         ImageUtilities.image2Icon(dateFormatIcon));
                 dateFormatItem.addActionListener(new ActionListener() {
 
+                    @Override
                     public void actionPerformed(ActionEvent e) {
                         TimeFormatDialog d = new TimeFormatDialog();
                         d.setup(model);
@@ -261,6 +272,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
 
         playButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 if (model != null) {
                     if (model.isPlaying() && !playButton.isSelected()) {
@@ -278,6 +290,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
         if (model != null) {
             SwingUtilities.invokeLater(new Runnable() {
 
+                @Override
                 public void run() {
                     drawer.setModel(TimelineTopComponent.this.model);
                     enableTimeline(TimelineTopComponent.this.model);
@@ -286,6 +299,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
         } else {
             SwingUtilities.invokeLater(new Runnable() {
 
+                @Override
                 public void run() {
                     drawer.setModel(TimelineTopComponent.this.model);
                     enableTimeline(null);
@@ -294,6 +308,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
         }
     }
 
+    @Override
     public void timelineModelChanged(TimelineModelEvent event) {
         if (event.getEventType().equals(TimelineModelEvent.EventType.MODEL)) {
             setup(event.getSource());
@@ -330,6 +345,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
     private void setPlaying(final boolean playing) {
         SwingUtilities.invokeLater(new Runnable() {
 
+            @Override
             public void run() {
                 playButton.setSelected(playing);
             }
@@ -338,6 +354,7 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
 
     public void setTimeLineVisible(final boolean visible) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 if (visible != TimelineTopComponent.this.isVisible()) {
 

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineWindowAction.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineWindowAction.java
@@ -47,6 +47,7 @@ import org.openide.util.Lookup;
 
 public final class TimelineWindowAction implements ActionListener {
     
+    @Override
     public void actionPerformed(ActionEvent e) {
         BottomComponentImpl bottomComponent = Lookup.getDefault().lookup(BottomComponentImpl.class);
         if (bottomComponent != null) {

--- a/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DelegatingChooserUI.java
+++ b/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DelegatingChooserUI.java
@@ -108,6 +108,7 @@ public class DelegatingChooserUI extends ComponentUI {
             fc.addPropertyChangeListener(
                     JFileChooser.FILE_SELECTION_MODE_CHANGED_PROPERTY,
                     new PropertyChangeListener () {
+                        @Override
                         public void propertyChange(PropertyChangeEvent evt) {
                             JFileChooser fileChooser = (JFileChooser)evt.getSource();
                             fileChooser.updateUI();

--- a/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DirectoryCellEditor.java
+++ b/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DirectoryCellEditor.java
@@ -72,10 +72,12 @@ class DirectoryCellEditor extends DefaultCellEditor {
         this.fileChooser = fileChooser;
     }
     
+    @Override
     public boolean isCellEditable(EventObject event) {
         return ((event instanceof MouseEvent) ? false : true);
     }
     
+    @Override
     public Component getTreeCellEditorComponent(JTree tree, Object value, boolean isSelected, boolean expanded, boolean leaf, int row) {
         Component c = super.getTreeCellEditorComponent(tree, value, isSelected, expanded, leaf, row);
         DirectoryNode node = (DirectoryNode)value;

--- a/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
+++ b/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
@@ -219,15 +219,18 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         }
     }
     
+    @Override
     public void installUI(JComponent c) {
         super.installUI(c);
     }
     
+    @Override
     public void uninstallComponents(JFileChooser fc) {
         fc.removeAll();
         super.uninstallComponents(fc);
     }
     
+    @Override
     public void installComponents(JFileChooser fc) {
         fileChooser = fc;
         
@@ -396,18 +399,22 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         fileAndFilterPanel.setLayout(new BoxLayout(fileAndFilterPanel, BoxLayout.Y_AXIS));
         
         filenameTextField = new JTextField(24) {
+            @Override
             public Dimension getMaximumSize() {
                 return new Dimension(Short.MAX_VALUE, super.getPreferredSize().height);
             }
         };
         
         filenameTextField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
             public void insertUpdate(DocumentEvent e) {
                 updateCompletions();
             }
+            @Override
             public void removeUpdate(DocumentEvent e) {
                 updateCompletions();
             }
+            @Override
             public void changedUpdate(DocumentEvent e) {}
         });
         
@@ -416,6 +423,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         fnl.setLabelFor(filenameTextField);
         filenameTextField.addFocusListener(
                 new FocusAdapter() {
+            @Override
             public void focusGained(FocusEvent e) {
                 if (!getFileChooser().isMultiSelectionEnabled()) {
                     tree.clearSelection();
@@ -451,6 +459,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.Y_AXIS));
         
         approveButton = new JButton(getApproveButtonText(fc)) {
+            @Override
             public Dimension getMaximumSize() {
                 return approveButton.getPreferredSize().width > cancelButton.getPreferredSize().width ?
                     approveButton.getPreferredSize() : cancelButton.getPreferredSize();
@@ -467,6 +476,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         buttonPanel.add(Box.createRigidArea(verticalStrut2));
         
         cancelButton = new JButton(cancelButtonText) {
+            @Override
             public Dimension getMaximumSize() {
                 return approveButton.getPreferredSize().width > cancelButton.getPreferredSize().width ?
                     approveButton.getPreferredSize() : cancelButton.getPreferredSize();
@@ -508,6 +518,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             private Dimension prefSize = new Dimension(ACCESSORY_WIDTH, 0);
             private Dimension minSize = new Dimension(ACCESSORY_WIDTH, 0);
             
+            @Override
             public Dimension getMinimumSize () {
                 if (fc.getAccessory() != null) {
                     minSize.height = getAccessoryPanel().getMinimumSize().height;
@@ -515,6 +526,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 }
                 return super.getMinimumSize();
             }
+            @Override
             public Dimension getPreferredSize () {
                 if (fc.getAccessory() != null) {
                     Dimension origPref = getAccessoryPanel().getPreferredSize();
@@ -570,12 +582,14 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         // fixed #97525, made the height of the
         // combo box bigger.
         directoryComboBox = new JComboBox() {
+            @Override
             public Dimension getMinimumSize() {
                 Dimension d = super.getMinimumSize();
                 d.width = 60;
                 return d;
             }
             
+            @Override
             public Dimension getPreferredSize() {
                 Dimension d = super.getPreferredSize();
                 // Must be small enough to not affect total width and height.
@@ -775,6 +789,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         java.util.List<TreePath> paths;
                 
+        @Override
         public void keyPressed(KeyEvent evt) {
             if(evt.getKeyCode() == KeyEvent.VK_DELETE) {
                 deleteAction();
@@ -830,10 +845,12 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             }
         }
         
+        @Override
         public void focusGained(FocusEvent e) {
             resetBuffer();
         }
 
+        @Override
         public void focusLost(FocusEvent e) {
             resetBuffer();
         }
@@ -876,6 +893,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         JMenuItem item2 = new JMenuItem(getBundle().getString("LBL_Rename"));
         item2.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent e) {
                 DirectoryNode node = (DirectoryNode)tree.getLastSelectedPathComponent();
                 applyEdit(node);
@@ -884,6 +902,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         JMenuItem item3 = new JMenuItem(getBundle().getString("LBL_Delete"));
         item3.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent e) {
                 deleteAction();
             }
@@ -926,6 +945,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 int cannotDelete;
                 ArrayList<DirectoryNode> nodes2Remove = new ArrayList<DirectoryNode>(nodePath.length);
 
+                @Override
                 public void run() {
                     if (!EventQueue.isDispatchThread()) {
                         // first pass, out of EQ thread, deletes files
@@ -1092,6 +1112,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         updateWorker = RequestProcessor.getDefault().post(new Runnable() {
             DirectoryNode node;
             long startTime;
+            @Override
             public void run() {
                 if (!EventQueue.isDispatchThread()) {
                     // first pass, out of EQ thread
@@ -1142,6 +1163,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 JButton notShow = new JButton(
                         NbBundle.getMessage(DirectoryChooserUI.class, "BTN_NotShow"));
                 notShow.addActionListener(new ActionListener() {
+                    @Override
                     public void actionPerformed(ActionEvent e) {
                         NbPreferences.forModule(DirectoryChooserUI.class).putLong(TIMEOUT_KEY, 0);
                         centerPanel.remove(slownessPanel);
@@ -1171,6 +1193,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         return themeActive;
     }
     
+    @Override
     protected void installStrings(JFileChooser fc) {
         super.installStrings(fc);
         
@@ -1194,6 +1217,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
     }
     
+    @Override
     protected void installListeners(JFileChooser fc) {
         super.installListeners(fc);
         ActionMap actionMap = getActionMap();
@@ -1206,9 +1230,11 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     
     protected ActionMap createActionMap() {
         AbstractAction escAction = new AbstractAction() {
+            @Override
             public void actionPerformed(ActionEvent e) {
                 getFileChooser().cancelSelection();
             }
+            @Override
             public boolean isEnabled(){
                 return getFileChooser().isEnabled();
             }
@@ -1220,10 +1246,12 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         return map;
     }
     
+    @Override
     public Action getNewFolderAction() {
         return newFolderAction;
     }
     
+    @Override
     public void uninstallUI(JComponent c) {
         c.removePropertyChangeListener(filterTypeComboBoxModel);
         cancelButton.removeActionListener(getCancelSelectionAction());
@@ -1244,6 +1272,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
      * @return   a <code>Dimension</code> specifying the preferred
      *           width and height of the file chooser
      */
+    @Override
     public Dimension getPreferredSize(JComponent c) {
         int prefWidth = PREF_SIZE.width;
         Dimension d = c.getLayout().preferredLayoutSize(c);
@@ -1262,6 +1291,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
      * @return   a <code>Dimension</code> specifying the minimum
      *           width and height of the file chooser
      */
+    @Override
     public Dimension getMinimumSize(JComponent c) {
         return MIN_SIZE;
     }
@@ -1273,6 +1303,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
      * @return   a <code>Dimension</code> specifying the maximum
      *           width and height of the file chooser
      */
+    @Override
     public Dimension getMaximumSize(JComponent c) {
         return new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE);
     }
@@ -1462,8 +1493,10 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
      * Listen for filechooser property changes, such as
      * the selected file changing, or the type of the dialog changing.
      */
+    @Override
     public PropertyChangeListener createPropertyChangeListener(JFileChooser fc) {
         return new PropertyChangeListener() {
+            @Override
             public void propertyChange(PropertyChangeEvent e) {
                 String s = e.getPropertyName();
                 if(s.equals(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY)) {
@@ -1516,6 +1549,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         bottomPanel.add(buttonPanel);
     }
     
+    @Override
     public String getFileName() {
         if(filenameTextField != null) {
             return filenameTextField.getText();
@@ -1524,6 +1558,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         }
     }
     
+    @Override
     public void setFileName(String filename) {
         if(filenameTextField != null) {
             filenameTextField.setText(filename);
@@ -1546,10 +1581,12 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         return new FilterTypeComboBoxModel();
     }
     
+    @Override
     protected JButton getApproveButton(JFileChooser fc) {
         return approveButton;
     }
     
+    @Override
     public FileView getFileView(JFileChooser fc) {
         
         // fix bug #96957, should use DirectoryChooserFileView
@@ -1576,8 +1613,10 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     
     private void addNewDirectory(final TreePath path) {
         RequestProcessor.getDefault().post(new Runnable() {
+            @Override
             public void run() {
                 EventQueue.invokeLater(new Runnable() {
+                    @Override
                     public void run() {
                         DirectoryNode selectedNode = (DirectoryNode)path.getLastPathComponent();
                         
@@ -1632,6 +1671,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         RequestProcessor.getDefault().post(new Runnable() {
             DirectoryNode node;
             
+            @Override
             public void run() {
                 if (!EventQueue.isDispatchThread()) {
                     // first pass, out of EQ thread, loads data
@@ -1687,6 +1727,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         Icon icon = null;
         int depth = 0;
         
+        @Override
         public void paintIcon(Component c, Graphics g, int x, int y) {
             if (icon == null) {
                 return;
@@ -1698,10 +1739,12 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             }
         }
         
+        @Override
         public int getIconWidth() {
             return icon != null ? icon.getIconWidth() + depth*space : null;
         }
         
+        @Override
         public int getIconHeight() {
             return icon != null ? icon.getIconHeight() : null;
         }
@@ -1715,6 +1758,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             setOpaque(true);
         }
         
+        @Override
         public Component getListCellRendererComponent(JList list, Object value,
                 int index, boolean isSelected,
                 boolean cellHasFocus) {
@@ -1854,19 +1898,23 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             return (depths != null && i >= 0 && i < depths.length) ? depths[i] : 0;
         }
         
+        @Override
         public void setSelectedItem(Object selectedDirectory) {
             this.selectedDirectory = (File)selectedDirectory;
             fireContentsChanged(this, -1, -1);
         }
         
+        @Override
         public Object getSelectedItem() {
             return selectedDirectory;
         }
         
+        @Override
         public int getSize() {
             return directories.size();
         }
         
+        @Override
         public Object getElementAt(int index) {
             return directories.elementAt(index);
         }
@@ -1881,6 +1929,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             setOpaque(true);
         }
         
+        @Override
         public Component getListCellRendererComponent(JList list,
                 Object value, int index, boolean isSelected,
                 boolean cellHasFocus) {
@@ -1904,6 +1953,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         }
         
         // #89393: GTK needs name to render cell renderer "natively"
+        @Override
         public String getName() {
             String name = super.getName();
             return name == null ? "ComboBox.renderer" : name;  // NOI18N
@@ -1921,6 +1971,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             filters = getFileChooser().getChoosableFileFilters();
         }
         
+        @Override
         public void propertyChange(PropertyChangeEvent e) {
             String prop = e.getPropertyName();
             if(prop == JFileChooser.CHOOSABLE_FILE_FILTER_CHANGED_PROPERTY) {
@@ -1931,6 +1982,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             }
         }
         
+        @Override
         public void setSelectedItem(Object filter) {
             if(filter != null) {
                 getFileChooser().setFileFilter((FileFilter) filter);
@@ -1939,6 +1991,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             }
         }
         
+        @Override
         public Object getSelectedItem() {
             // Ensure that the current filter is in the list.
             // NOTE: we shouldnt' have to do this, since JFileChooser adds
@@ -1960,6 +2013,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             return getFileChooser().getFileFilter();
         }
         
+        @Override
         public int getSize() {
             if(filters != null) {
                 return filters.length;
@@ -1968,6 +2022,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             }
         }
         
+        @Override
         public Object getElementAt(int index) {
             if(index > getSize() - 1) {
                 // This shouldn't happen. Try to recover gracefully.
@@ -1985,6 +2040,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
      * Gets calls when the ComboBox has changed the selected item.
      */
     private class DirectoryComboBoxAction implements ActionListener {
+        @Override
         public void actionPerformed(ActionEvent e) {
             File f = (File)directoryComboBox.getSelectedItem();
             getFileChooser().setCurrentDirectory(f);
@@ -1993,6 +2049,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     
     private class DirectoryChooserFileView extends BasicFileView {
         
+        @Override
         public Icon getIcon(File f) {
             Icon icon = getCachedIcon(f);
             if (icon != null) {
@@ -2018,6 +2075,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     }
     
     private class TextFieldKeyListener extends KeyAdapter {
+        @Override
         public void keyPressed(KeyEvent evt) {
             showPopupCompletion = true;
             int keyCode = evt.getKeyCode();
@@ -2064,6 +2122,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         /************ imple of TreeSelectionListener *******/
         
+        @Override
         public void valueChanged(TreeSelectionEvent e) {
             showPopupCompletion = false;
             FileSystemView fsv = fileChooser.getFileSystemView();
@@ -2104,6 +2163,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         /********* impl of MouseListener ***********/
         
+        @Override
         public void mouseClicked(MouseEvent e) {
             final JTree tree = (JTree) e.getSource();
             Point p = e.getPoint();
@@ -2198,6 +2258,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         /********** implementation of CellEditorListener ****************/
 
         /** Refresh filename text field after rename */
+        @Override
         public void editingStopped(ChangeEvent e) {
             DirectoryNode node = (DirectoryNode) tree.getLastSelectedPathComponent();
             if (node != null) {
@@ -2205,12 +2266,14 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             }
         }
 
+        @Override
         public void editingCanceled(ChangeEvent e) {
             // no operation
         }
 
         /********** ActionListener impl, slow-double-click rename ******/ 
         
+        @Override
         public void actionPerformed(ActionEvent e) {
             if (tree.isFocusOwner() && isSelectionKept(pathToRename)) {
                 DirectoryNode node = (DirectoryNode)tree.getLastSelectedPathComponent();
@@ -2252,6 +2315,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         /******** implementation of focus listener, for slow click rename cancelling ******/ 
 
+        @Override
         public void focusGained(FocusEvent e) {
             // don't allow to invoke click to rename immediatelly after focus gain
             // what may happen is that tree gains focus by mouse
@@ -2263,10 +2327,12 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             SwingUtilities.invokeLater(this);
         }
 
+        @Override
         public void run() {
             cancelRename();
         }
 
+        @Override
         public void focusLost(FocusEvent e) {
             cancelRename();
         }
@@ -2274,6 +2340,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     }
     
     private class TreeExpansionHandler implements  TreeExpansionListener  {
+        @Override
         public void treeExpanded(TreeExpansionEvent evt) {
             TreePath path = evt.getPath();
             DirectoryNode node = (DirectoryNode) path
@@ -2291,6 +2358,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 refreshNode( path , node );
             }
         }
+        @Override
         public void treeCollapsed(TreeExpansionEvent event) {
         }
         
@@ -2318,6 +2386,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
 
         RequestProcessor.getDefault().post(new Runnable() {
             private Set<String> realDirs;
+            @Override
             public void run() {
                 if (!EventQueue.isDispatchThread()) {
                     // first phase
@@ -2368,6 +2437,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
 
     
     private class NewDirectoryAction extends AbstractAction {
+        @Override
         public void actionPerformed(ActionEvent e) {
             final TreePath path = tree.getSelectionPath();
             
@@ -2392,6 +2462,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     private class DirectoryTreeRenderer implements TreeCellRenderer {
         HtmlRenderer.Renderer renderer = HtmlRenderer.createRenderer();
 
+        @Override
         public Component getTreeCellRendererComponent(
                 JTree tree,
                 Object value,
@@ -2455,6 +2526,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             super(root);
         }
         
+        @Override
         public void valueForPathChanged(TreePath path, Object newValue) {
             boolean refreshTree = false;
             DirectoryNode node = (DirectoryNode)path.getLastPathComponent();

--- a/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DirectoryNode.java
+++ b/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/DirectoryNode.java
@@ -238,6 +238,7 @@ public class DirectoryNode extends DefaultMutableTreeNode {
 
     private class DirectoryFilter implements FileFilter {
 
+        @Override
         public boolean accept(File f) {
             return f.isDirectory();
         }
@@ -250,6 +251,7 @@ public class DirectoryNode extends DefaultMutableTreeNode {
     /** Compares files ignoring case sensitivity */
     private static class FileNameComparator implements Comparator<File> {
 
+        @Override
         public int compare(File f1, File f2) {
             return String.CASE_INSENSITIVE_ORDER.compare(f1.getName(), f2.getName());
         }

--- a/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/FileCompletionPopup.java
+++ b/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/FileCompletionPopup.java
@@ -151,6 +151,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
     }
     
     private class MouseHandler extends MouseAdapter implements MouseMotionListener{
+        @Override
         public void mouseMoved(MouseEvent e) {
             if (e.getSource() == list) {
                 Point location = e.getPoint();
@@ -163,6 +164,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
             }
         }
         
+        @Override
         public void mouseDragged(MouseEvent e) {
             if (e.getSource() == list) {
                 return;
@@ -214,6 +216,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
 
     /****** implementation of KeyListener of fileNameTextField ******/
     
+    @Override
     public void keyPressed(KeyEvent e) {
         if (!isVisible()) {
             return;
@@ -261,10 +264,12 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
         }
     }
 
+    @Override
     public void keyReleased(KeyEvent e) {
         // no operation
     }
     
+    @Override
     public void keyTyped(KeyEvent e) {
         // no operation
     }

--- a/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/InputBlocker.java
+++ b/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/InputBlocker.java
@@ -97,25 +97,32 @@ public class InputBlocker extends JComponent implements MouseInputListener {
         glassPane.setVisible(false);
     }
 
+    @Override
     public void mouseClicked(MouseEvent e) {
         Toolkit.getDefaultToolkit().beep();
     }
 
+    @Override
     public void mousePressed(MouseEvent e) {
     }
 
+    @Override
     public void mouseReleased(MouseEvent e) {
     }
 
+    @Override
     public void mouseEntered(MouseEvent e) {
     }
 
+    @Override
     public void mouseExited(MouseEvent e) {
     }
 
+    @Override
     public void mouseDragged(MouseEvent e) {
     }
 
+    @Override
     public void mouseMoved(MouseEvent e) {
     }
 }

--- a/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/Module.java
+++ b/modules/DirectoryChooser/src/main/java/org/netbeans/swing/dirchooser/Module.java
@@ -91,6 +91,7 @@ public class Module extends ModuleInstall {
         }
         // #61147: prevent NB from switching to a different UI later (under GTK):
         uid.addPropertyChangeListener(pcl = new PropertyChangeListener() {
+            @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
                 Object className = uid.get(KEY);

--- a/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterDLPanel.java
+++ b/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterDLPanel.java
@@ -81,6 +81,7 @@ public class UIExporterDLPanel extends javax.swing.JPanel {
 
         matrixRadioButton.setText("Matrix");
         matrixRadioButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 matrixRadioButtonActionPerformed(evt);
             }
@@ -88,6 +89,7 @@ public class UIExporterDLPanel extends javax.swing.JPanel {
 
         listRadioButton.setText("List");
         listRadioButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 listRadioButtonActionPerformed(evt);
             }

--- a/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterGDFPanel.java
+++ b/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterGDFPanel.java
@@ -106,6 +106,7 @@ public class UIExporterGDFPanel extends javax.swing.JPanel {
 
         quotesCheckbox.setText(org.openide.util.NbBundle.getMessage(UIExporterGDFPanel.class, "UIExporterGDFPanel.quotesCheckbox.text")); // NOI18N
         quotesCheckbox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 quotesCheckboxActionPerformed(evt);
             }

--- a/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterGMLPanel.java
+++ b/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterGMLPanel.java
@@ -115,6 +115,7 @@ public class UIExporterGMLPanel extends javax.swing.JPanel implements Validation
 
         exportNotRecognizedCheckBox.setText(org.openide.util.NbBundle.getMessage(UIExporterGMLPanel.class, "UIExporterGML.attributes.text")); // NOI18N
         exportNotRecognizedCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 exportNotRecognizedCheckBoxActionPerformed(evt);
             }

--- a/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterVNAPanel.java
+++ b/modules/ExportPluginUI/src/main/java/org/gephi/ui/exporter/plugin/UIExporterVNAPanel.java
@@ -108,6 +108,7 @@ public class UIExporterVNAPanel extends javax.swing.JPanel {
 
         exportAttributesCheckBox.setText(org.openide.util.NbBundle.getMessage(UIExporterVNAPanel.class, "UIExporterGML.attributes.text")); // NOI18N
         exportAttributesCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 exportAttributesCheckBoxActionPerformed(evt);
             }

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/attribute/EqualStringPanel.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/attribute/EqualStringPanel.java
@@ -67,6 +67,7 @@ public class EqualStringPanel extends javax.swing.JPanel implements ActionListen
         okButton.addActionListener(this);
     }
 
+    @Override
     public void actionPerformed(ActionEvent evt) {
         FilterProperty pattern = filter.getProperties()[1];
         FilterProperty useRegex = filter.getProperties()[2];
@@ -102,6 +103,7 @@ public class EqualStringPanel extends javax.swing.JPanel implements ActionListen
         ValidationGroup group = validationPanel.getValidationGroup();
         validationPanel.addChangeListener(new ChangeListener() {
 
+            @Override
             public void stateChanged(ChangeEvent e) {
                 innerPanel.okButton.setEnabled(!validationPanel.isProblem());
             }

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/attribute/EqualStringUIImpl.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/attribute/EqualStringUIImpl.java
@@ -53,6 +53,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = EqualStringUI.class)
 public class EqualStringUIImpl implements EqualStringUI {
 
+    @Override
     public JPanel getPanel(EqualStringFilter filter) {
         EqualStringPanel panel = new EqualStringPanel();
         panel.setup(filter);

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/dynamic/DynamicRangePanel.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/dynamic/DynamicRangePanel.java
@@ -72,6 +72,7 @@ public class DynamicRangePanel extends javax.swing.JPanel {
         timelineButton.setText(bottomComponent.isVisible() ? CLOSE : OPEN);
         timelineButton.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
 
                 if (!bottomComponent.isVisible()) {
@@ -86,6 +87,7 @@ public class DynamicRangePanel extends javax.swing.JPanel {
         keepEmptyCheckbox.setSelected(filter.isKeepNull());
         keepEmptyCheckbox.addItemListener(new ItemListener() {
 
+            @Override
             public void itemStateChanged(ItemEvent e) {
                 if (!filter.isKeepNull() == keepEmptyCheckbox.isSelected()) {
                     filter.getProperties()[1].setValue(keepEmptyCheckbox.isSelected());

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/dynamic/DynamicRangeUIImpl.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/dynamic/DynamicRangeUIImpl.java
@@ -53,6 +53,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = DynamicRangeUI.class)
 public class DynamicRangeUIImpl implements DynamicRangeUI {
 
+    @Override
     public JPanel getPanel(DynamicRangeFilter filter) {
         DynamicRangePanel panel = new DynamicRangePanel();
         panel.setup(filter);

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/graph/EgoUIImpl.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/graph/EgoUIImpl.java
@@ -53,6 +53,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = EgoUI.class)
 public class EgoUIImpl implements EgoUI {
 
+    @Override
     public JPanel getPanel(EgoFilter egoFilter) {
         EgoPanel egoPanel = new EgoPanel();
         egoPanel.setup(egoFilter);

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/graph/NeighborsPanel.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/graph/NeighborsPanel.java
@@ -59,6 +59,7 @@ public class NeighborsPanel extends javax.swing.JPanel {
 
         depthComboBox.addItemListener(new ItemListener() {
 
+            @Override
             public void itemStateChanged(ItemEvent e) {
                 int depth = -1;
                 int index = depthComboBox.getSelectedIndex();
@@ -75,6 +76,7 @@ public class NeighborsPanel extends javax.swing.JPanel {
 
         withSelfCheckbox.addItemListener(new ItemListener() {
 
+            @Override
             public void itemStateChanged(ItemEvent e) {
                 if (!neighborsFilter.isSelf() == withSelfCheckbox.isSelected()) {
                     neighborsFilter.getProperties()[1].setValue(withSelfCheckbox.isSelected());

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/operator/MASKEdgePanel.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/operator/MASKEdgePanel.java
@@ -61,6 +61,7 @@ public class MASKEdgePanel extends javax.swing.JPanel implements ActionListener 
         targetButton.addActionListener(this);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         if (operator != null) {
             MASKBuilderEdge.MaskEdgeOperator.EdgesOptions option = MASKBuilderEdge.MaskEdgeOperator.EdgesOptions.ANY;

--- a/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/operator/MASKEdgeUIImpl.java
+++ b/modules/FiltersPluginUI/src/main/java/org/gephi/ui/filters/plugin/operator/MASKEdgeUIImpl.java
@@ -54,6 +54,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = MASKEdgeUI.class)
 public class MASKEdgeUIImpl implements MASKEdgeUI {
 
+    @Override
     public JPanel getPanel(MaskEdgeOperator filter) {
         MASKEdgePanel panel = new MASKEdgePanel();
         panel.setup(filter);

--- a/modules/ImportPluginUI/src/main/java/org/gephi/ui/importer/plugin/EdgeListPanel.java
+++ b/modules/ImportPluginUI/src/main/java/org/gephi/ui/importer/plugin/EdgeListPanel.java
@@ -287,6 +287,7 @@ public class EdgeListPanel extends javax.swing.JPanel {
 
         configurationCombo.setModel(new EdgeListPanel.ConfigurationComboModel());
         configurationCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 configurationComboActionPerformed(evt);
             }
@@ -325,6 +326,7 @@ public class EdgeListPanel extends javax.swing.JPanel {
         testConnection.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/ui/importer/plugin/resources/test_connection.png"))); // NOI18N
         testConnection.setText(org.openide.util.NbBundle.getMessage(EdgeListPanel.class, "EdgeListPanel.testConnection.text")); // NOI18N
         testConnection.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 testConnectionActionPerformed(evt);
             }
@@ -341,6 +343,7 @@ public class EdgeListPanel extends javax.swing.JPanel {
         removeConfigurationButton.setMargin(new java.awt.Insets(0, 4, 0, 2));
         removeConfigurationButton.setPreferredSize(new java.awt.Dimension(65, 29));
         removeConfigurationButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 removeConfigurationButtonActionPerformed(evt);
             }

--- a/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/ExporterBuilderPDF.java
+++ b/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/ExporterBuilderPDF.java
@@ -54,15 +54,18 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = VectorFileExporterBuilder.class)
 public class ExporterBuilderPDF implements VectorFileExporterBuilder {
 
+    @Override
     public VectorExporter buildExporter() {
         return new PDFExporter();
     }
 
+    @Override
     public FileType[] getFileTypes() {
         FileType ft = new FileType(".pdf", NbBundle.getMessage(ExporterBuilderPDF.class, "fileType_PDF_Name"));
         return new FileType[]{ft};
     }
 
+    @Override
     public String getName() {
         return NbBundle.getMessage(ExporterBuilderPDF.class, "ExporterPDF_name");
     }

--- a/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/ExporterBuilderSVG.java
+++ b/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/ExporterBuilderSVG.java
@@ -54,15 +54,18 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = VectorFileExporterBuilder.class)
 public class ExporterBuilderSVG implements VectorFileExporterBuilder {
 
+    @Override
     public VectorExporter buildExporter() {
         return new SVGExporter();
     }
 
+    @Override
     public FileType[] getFileTypes() {
         FileType ft = new FileType(".svg", NbBundle.getMessage(ExporterBuilderSVG.class, "fileType_SVG_Name"));
         return new FileType[]{ft};
     }
 
+    @Override
     public String getName() {
         return NbBundle.getMessage(ExporterBuilderSVG.class, "ExporterSVG_name");
     }

--- a/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/PDFExporter.java
+++ b/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/PDFExporter.java
@@ -87,6 +87,7 @@ public class PDFExporter implements ByteExporter, VectorExporter, LongTask {
     private boolean landscape = false;
     private Rectangle pageSize = PageSize.A4;
 
+    @Override
     public boolean execute() {
         Progress.start(progress);
 
@@ -189,10 +190,12 @@ public class PDFExporter implements ByteExporter, VectorExporter, LongTask {
         this.pageSize = pageSize;
     }
 
+    @Override
     public void setOutputStream(OutputStream stream) {
         this.stream = stream;
     }
 
+    @Override
     public void setWorkspace(Workspace workspace) {
         this.workspace = workspace;
     }
@@ -201,10 +204,12 @@ public class PDFExporter implements ByteExporter, VectorExporter, LongTask {
         this.landscape = landscape;
     }
 
+    @Override
     public Workspace getWorkspace() {
         return workspace;
     }
 
+    @Override
     public boolean cancel() {
         this.cancel = true;
         if (target instanceof LongTask) {
@@ -213,6 +218,7 @@ public class PDFExporter implements ByteExporter, VectorExporter, LongTask {
         return true;
     }
 
+    @Override
     public void setProgressTicket(ProgressTicket progressTicket) {
         this.progress = progressTicket;
     }

--- a/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/SVGExporter.java
+++ b/modules/PreviewExport/src/main/java/org/gephi/io/exporter/preview/SVGExporter.java
@@ -78,6 +78,7 @@ public class SVGExporter implements CharacterExporter, VectorExporter, LongTask 
     private boolean scaleStrokes = false;
     private float margin = 4;
 
+    @Override
     public boolean execute() {
         PreviewController controller = Lookup.getDefault().lookup(PreviewController.class);
         controller.getModel(workspace).getProperties().putValue(PreviewProperty.VISIBILITY_RATIO, 1.0);
@@ -118,6 +119,7 @@ public class SVGExporter implements CharacterExporter, VectorExporter, LongTask 
         return !cancel;
     }
 
+    @Override
     public boolean cancel() {
         cancel = true;
         if (target instanceof LongTask) {
@@ -126,18 +128,22 @@ public class SVGExporter implements CharacterExporter, VectorExporter, LongTask 
         return true;
     }
 
+    @Override
     public void setProgressTicket(ProgressTicket progressTicket) {
         this.progress = progressTicket;
     }
 
+    @Override
     public void setWriter(Writer writer) {
         this.writer = writer;
     }
 
+    @Override
     public Workspace getWorkspace() {
         return workspace;
     }
 
+    @Override
     public void setWorkspace(Workspace workspace) {
         this.workspace = workspace;
     }

--- a/modules/PreviewExportUI/src/main/java/org/gephi/ui/exporter/preview/UIExporterPDF.java
+++ b/modules/PreviewExportUI/src/main/java/org/gephi/ui/exporter/preview/UIExporterPDF.java
@@ -60,11 +60,13 @@ public class UIExporterPDF implements ExporterUI {
     private ValidationPanel validationPanel;
     private PDFExporter exporterPDF;
 
+    @Override
     public void setup(Exporter exporter) {
         exporterPDF = (PDFExporter) exporter;
         panel.setup(exporterPDF);
     }
 
+    @Override
     public void unsetup(boolean update) {
         if (update) {
             panel.unsetup(exporterPDF);
@@ -73,16 +75,19 @@ public class UIExporterPDF implements ExporterUI {
         exporterPDF = null;
     }
 
+    @Override
     public JPanel getPanel() {
         panel = new UIExporterPDFPanel();
         validationPanel = UIExporterPDFPanel.createValidationPanel(panel);
         return validationPanel;
     }
 
+    @Override
     public boolean isUIForExporter(Exporter exporter) {
         return exporter instanceof PDFExporter;
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(UIExporterPDF.class, "UIExporterPDF.name");
     }

--- a/modules/PreviewExportUI/src/main/java/org/gephi/ui/exporter/preview/UIExporterPDFPanel.java
+++ b/modules/PreviewExportUI/src/main/java/org/gephi/ui/exporter/preview/UIExporterPDFPanel.java
@@ -128,6 +128,7 @@ public class UIExporterPDFPanel extends javax.swing.JPanel implements Validation
     private void initEvents() {
         pageSizeCombo.addItemListener(new ItemListener() {
 
+            @Override
             public void itemStateChanged(ItemEvent e) {
                 Object selectedItem = pageSizeCombo.getSelectedItem();
                 if (selectedItem != customSizeString) {
@@ -139,6 +140,7 @@ public class UIExporterPDFPanel extends javax.swing.JPanel implements Validation
 
         widthTextField.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 updatePageSize();
             }
@@ -146,12 +148,14 @@ public class UIExporterPDFPanel extends javax.swing.JPanel implements Validation
 
         heightTextField.addActionListener(new ActionListener() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 updatePageSize();
             }
         });
         unitLink.setAction(new AbstractAction() {
 
+            @Override
             public void actionPerformed(ActionEvent e) {
                 millimeter = !millimeter;
                 refreshUnit(true);
@@ -170,6 +174,7 @@ public class UIExporterPDFPanel extends javax.swing.JPanel implements Validation
         return validationPanel;
     }
 
+    @Override
     public void validate(ValidationGroup group) {
         //Size
         group.add(widthTextField, Validators.REQUIRE_NON_EMPTY_STRING,

--- a/modules/PreviewExportUI/src/main/java/org/gephi/ui/exporter/preview/UIExporterSVG.java
+++ b/modules/PreviewExportUI/src/main/java/org/gephi/ui/exporter/preview/UIExporterSVG.java
@@ -59,12 +59,14 @@ public class UIExporterSVG implements ExporterUI {
     private UIExporterSVGPanel panel;
     private SVGExporter exporterSVG;
 
+    @Override
     public void setup(Exporter exporter) {
         exporterSVG = (SVGExporter) exporter;
         loadPreferences();
         panel.setup(exporterSVG);
     }
 
+    @Override
     public void unsetup(boolean update) {
         if (update) {
             panel.unsetup(exporterSVG);
@@ -74,15 +76,18 @@ public class UIExporterSVG implements ExporterUI {
         exporterSVG = null;
     }
 
+    @Override
     public JPanel getPanel() {
         panel = new UIExporterSVGPanel();
         return panel;
     }
 
+    @Override
     public boolean isUIForExporter(Exporter exporter) {
         return exporter instanceof SVGExporter;
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(UIExporterPDF.class, "UIExporterSVG.name");
     }

--- a/modules/ProjectUI/src/main/java/org/gephi/ui/project/ProjectPropertiesUIImpl.java
+++ b/modules/ProjectUI/src/main/java/org/gephi/ui/project/ProjectPropertiesUIImpl.java
@@ -55,15 +55,18 @@ public class ProjectPropertiesUIImpl implements ProjectPropertiesUI {
 
     private ProjectPropertiesEditor panel;
 
+    @Override
     public JPanel getPanel() {
         panel = new ProjectPropertiesEditor();
         return panel;
     }
 
+    @Override
     public void setup(Project project) {
         panel.load(project);
     }
 
+    @Override
     public void unsetup(Project project) {
         panel.save(project);
         panel = null;

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsControllerImpl.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsControllerImpl.java
@@ -217,6 +217,7 @@ public class StatisticsControllerImpl implements StatisticsController {
         model.addReport(statistics);
     }
 
+    @Override
     public StatisticsBuilder getBuilder(Class<? extends Statistics> statisticsClass) {
         for (StatisticsBuilder b : statisticsBuilders) {
             if (b.getStatisticsClass().equals(statisticsClass)) {
@@ -226,10 +227,12 @@ public class StatisticsControllerImpl implements StatisticsController {
         return null;
     }
 
+    @Override
     public StatisticsModelImpl getModel() {
         return model;
     }
 
+    @Override
     public StatisticsModel getModel(Workspace workspace) {
         StatisticsModel statModel = workspace.getLookup().lookup(StatisticsModelImpl.class);
         if (statModel == null) {
@@ -253,6 +256,7 @@ public class StatisticsControllerImpl implements StatisticsController {
             }
         }
 
+        @Override
         public boolean cancel() {
             cancel = true;
             if (longTask != null) {
@@ -261,6 +265,7 @@ public class StatisticsControllerImpl implements StatisticsController {
             return true;
         }
 
+        @Override
         public void setProgressTicket(ProgressTicket progressTicket) {
             this.progressTicket = progressTicket;
         }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsModelImpl.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsModelImpl.java
@@ -82,6 +82,7 @@ public class StatisticsModelImpl implements StatisticsModel {
         reportMap.put(statistics.getClass(), statistics.getReport());
     }
 
+    @Override
     public String getReport(Class<? extends Statistics> statisticsClass) {
         return reportMap.get(statisticsClass);
     }

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/DynamicStatistics.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/DynamicStatistics.java
@@ -68,6 +68,7 @@ public interface DynamicStatistics extends Statistics {
      * graph structure and the attribute model the attribute columns.
      * @param graphModel the graph model
      */
+    @Override
     public void execute(GraphModel graphModel);
 
     /**

--- a/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/dynamic/DynamicNbEdges.java
+++ b/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/dynamic/DynamicNbEdges.java
@@ -135,6 +135,7 @@ public class DynamicNbEdges implements DynamicStatistics {
     public void end() {
     }
 
+    @Override
     public void setBounds(Interval bounds) {
         this.bounds = bounds;
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ClusteringCoefficientUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ClusteringCoefficientUI.java
@@ -59,11 +59,13 @@ public class ClusteringCoefficientUI implements StatisticsUI {
     private ClusteringCoefficientPanel panel;
     private ClusteringCoefficient clusteringCoefficient;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new ClusteringCoefficientPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.clusteringCoefficient = (ClusteringCoefficient) statistics;
         if (panel != null) {
@@ -71,6 +73,7 @@ public class ClusteringCoefficientUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             clusteringCoefficient.setDirected(panel.isDirected());
@@ -79,27 +82,33 @@ public class ClusteringCoefficientUI implements StatisticsUI {
         panel = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return ClusteringCoefficient.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(clusteringCoefficient.getAverageClusteringCoefficient());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "ClusteringCoefficientUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NODE_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 300;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "ClusteringCoefficientUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ConnectedComponentUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ConnectedComponentUI.java
@@ -59,11 +59,13 @@ public class ConnectedComponentUI implements StatisticsUI {
     private ConnectedComponentPanel panel;
     private ConnectedComponents connectedComponents;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new ConnectedComponentPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.connectedComponents = (ConnectedComponents) statistics;
         if (panel != null) {
@@ -71,6 +73,7 @@ public class ConnectedComponentUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             connectedComponents.setDirected(panel.isDirected());
@@ -79,27 +82,33 @@ public class ConnectedComponentUI implements StatisticsUI {
         panel = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return ConnectedComponents.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(connectedComponents.getConnectedComponentsCount());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "ConnectedComponentUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 900;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "ConnectedComponentUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DegreeUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DegreeUI.java
@@ -58,39 +58,48 @@ public class DegreeUI implements StatisticsUI {
 
     private Degree inOutDegree;
 
+    @Override
     public JPanel getSettingsPanel() {
         return null;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.inOutDegree = (Degree) statistics;
     }
 
+    @Override
     public void unsetup() {
         inOutDegree = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return Degree.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(inOutDegree.getAverageDegree());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "InOutDegreeUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 1;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "InOutDegreeUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DiameterUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DiameterUI.java
@@ -55,11 +55,13 @@ public class DiameterUI implements StatisticsUI {
     private GraphDistancePanel panel;
     private GraphDistance graphDistance;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new GraphDistancePanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.graphDistance = (GraphDistance) statistics;
         if (panel != null) {
@@ -68,6 +70,7 @@ public class DiameterUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             graphDistance.setDirected(panel.isDirected());
@@ -77,27 +80,33 @@ public class DiameterUI implements StatisticsUI {
         graphDistance = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return GraphDistance.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(graphDistance.getDiameter());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DiameterUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 100;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "DiameterUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/EigenvectorCentralityPanel.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/EigenvectorCentralityPanel.java
@@ -115,6 +115,7 @@ public class EigenvectorCentralityPanel extends javax.swing.JPanel {
         buttonGroup1.add(undirectedRadioButton);
         undirectedRadioButton.setText(org.openide.util.NbBundle.getMessage(EigenvectorCentralityPanel.class, "EigenvectorCentralityPanel.undirectedButton.text")); // NOI18N
         undirectedRadioButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 undirectedRadioButtonActionPerformed(evt);
             }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/EigenvectorCentralityUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/EigenvectorCentralityUI.java
@@ -59,11 +59,13 @@ public class EigenvectorCentralityUI implements StatisticsUI {
     private EigenvectorCentralityPanel panel;
     private EigenvectorCentrality eigen;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new EigenvectorCentralityPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.eigen = (EigenvectorCentrality) statistics;
         if (panel != null) {
@@ -73,6 +75,7 @@ public class EigenvectorCentralityUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             eigen.setNumRuns(panel.getNumRuns());
@@ -83,26 +86,32 @@ public class EigenvectorCentralityUI implements StatisticsUI {
         eigen = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return EigenvectorCentrality.class;
     }
 
+    @Override
     public String getValue() {
         return null;
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "EigenvectorCentralityUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NODE_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 1000;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "EigenvectorCentralityUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/GraphDensityUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/GraphDensityUI.java
@@ -57,11 +57,13 @@ public class GraphDensityUI implements StatisticsUI {
     /** */
     private GraphDensity graphDensity;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new GraphDensityPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.graphDensity = (GraphDensity) statistics;
         if (panel != null) {
@@ -69,6 +71,7 @@ public class GraphDensityUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             graphDensity.setDirected(panel.isDirected());
@@ -77,27 +80,33 @@ public class GraphDensityUI implements StatisticsUI {
         panel = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return GraphDensity.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(graphDensity.getDensity());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "GraphDensityUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 200;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "GraphDensityUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/GraphDistancePanel.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/GraphDistancePanel.java
@@ -104,6 +104,7 @@ public class GraphDistancePanel extends javax.swing.JPanel {
         directedButtonGroup.add(directedRadioButton);
         directedRadioButton.setText(org.openide.util.NbBundle.getMessage(GraphDistancePanel.class, "GraphDistancePanel.directedRadioButton.text")); // NOI18N
         directedRadioButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 directedRadioButtonActionPerformed(evt);
             }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/HitsUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/HitsUI.java
@@ -59,11 +59,13 @@ public class HitsUI implements StatisticsUI {
     private HitsPanel panel;
     private Hits hits;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new HitsPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.hits = (Hits) statistics;
         if (panel != null) {
@@ -73,6 +75,7 @@ public class HitsUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             hits.setEpsilon(panel.getEpsilon());
@@ -83,26 +86,32 @@ public class HitsUI implements StatisticsUI {
         hits = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return Hits.class;
     }
 
+    @Override
     public String getValue() {
         return null;
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "HitsUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 500;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "HitsUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ModularityUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ModularityUI.java
@@ -56,11 +56,13 @@ public class ModularityUI implements StatisticsUI {
     private ModularityPanel panel;
     private Modularity mod;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new ModularityPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.mod = (Modularity) statistics;
         if (panel != null) {
@@ -71,6 +73,7 @@ public class ModularityUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             mod.setRandom(panel.isRandomize());
@@ -82,27 +85,33 @@ public class ModularityUI implements StatisticsUI {
         panel = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return Modularity.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(mod.getModularity());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "ModularityUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 600;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "ModularityUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PageRankUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PageRankUI.java
@@ -55,11 +55,13 @@ public class PageRankUI implements StatisticsUI {
     private PageRankPanel panel;
     private PageRank pageRank;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new PageRankPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.pageRank = (PageRank) statistics;
         if (panel != null) {
@@ -71,6 +73,7 @@ public class PageRankUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             pageRank.setEpsilon(panel.getEpsilon());
@@ -83,26 +86,32 @@ public class PageRankUI implements StatisticsUI {
         pageRank = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return PageRank.class;
     }
 
+    @Override
     public String getValue() {
         return null;
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "PageRankUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 800;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "PageRankUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PathLengthUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PathLengthUI.java
@@ -55,11 +55,13 @@ public class PathLengthUI implements StatisticsUI {
     private GraphDistancePanel panel;
     private GraphDistance graphDistance;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new GraphDistancePanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.graphDistance = (GraphDistance) statistics;
         if (panel != null) {
@@ -68,6 +70,7 @@ public class PathLengthUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             graphDistance.setDirected(panel.isDirected());
@@ -77,27 +80,33 @@ public class PathLengthUI implements StatisticsUI {
         panel = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return GraphDistance.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(graphDistance.getPathLength());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "PathLengthUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_EDGE_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 200;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "PathLengthUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/WeightedDegreeUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/WeightedDegreeUI.java
@@ -58,39 +58,48 @@ public class WeightedDegreeUI implements StatisticsUI {
 
     private WeightedDegree weightedDegree;
 
+    @Override
     public JPanel getSettingsPanel() {
         return null;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.weightedDegree = (WeightedDegree) statistics;
     }
 
+    @Override
     public void unsetup() {
         weightedDegree = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return WeightedDegree.class;
     }
 
+    @Override
     public String getValue() {
         DecimalFormat df = new DecimalFormat("###.###");
         return "" + df.format(weightedDegree.getAverageDegree());
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "WeightedDegreeUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
     }
 
+    @Override
     public int getPosition() {
         return 1;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "WeightedDegreeUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicClusteringCoefficientUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicClusteringCoefficientUI.java
@@ -59,11 +59,13 @@ public class DynamicClusteringCoefficientUI implements StatisticsUI {
     private DynamicClusteringCoefficient clusetingCoefficient;
     private DynamicClusteringCoefficientPanel panel;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new DynamicClusteringCoefficientPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.clusetingCoefficient = (DynamicClusteringCoefficient) statistics;
         if (panel != null) {
@@ -73,6 +75,7 @@ public class DynamicClusteringCoefficientUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             clusetingCoefficient.setDirected(panel.isDirected());
@@ -82,26 +85,32 @@ public class DynamicClusteringCoefficientUI implements StatisticsUI {
         clusetingCoefficient = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return DynamicClusteringCoefficient.class;
     }
 
+    @Override
     public String getValue() {
         return "";
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicClusteringCoefficientUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_DYNAMIC;
     }
 
+    @Override
     public int getPosition() {
         return 400;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "DynamicClusteringCoefficientUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicDegreeUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicDegreeUI.java
@@ -59,11 +59,13 @@ public class DynamicDegreeUI implements StatisticsUI {
     private DynamicDegree degree;
     private DynamicDegreePanel panel;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new DynamicDegreePanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.degree = (DynamicDegree) statistics;
         if (panel != null) {
@@ -73,6 +75,7 @@ public class DynamicDegreeUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             degree.setDirected(panel.isDirected());
@@ -83,26 +86,32 @@ public class DynamicDegreeUI implements StatisticsUI {
         panel = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return DynamicDegree.class;
     }
 
+    @Override
     public String getValue() {
         return "";
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicDegreeUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_DYNAMIC;
     }
 
+    @Override
     public int getPosition() {
         return 300;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "DynamicDegreeUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbEdgesUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbEdgesUI.java
@@ -59,11 +59,13 @@ public class DynamicNbEdgesUI implements StatisticsUI {
     private DynamicNbEdges nbEdges;
     private DynamicNbEdgesPanel panel;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new DynamicNbEdgesPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.nbEdges = (DynamicNbEdges) statistics;
         if (panel != null) {
@@ -71,6 +73,7 @@ public class DynamicNbEdgesUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             settings.save(nbEdges);
@@ -78,26 +81,32 @@ public class DynamicNbEdgesUI implements StatisticsUI {
         nbEdges = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return DynamicNbEdges.class;
     }
 
+    @Override
     public String getValue() {
         return "";
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicNbEdgesUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_DYNAMIC;
     }
 
+    @Override
     public int getPosition() {
         return 200;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "DynamicNbEdgesUI.shortDescription");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbNodesUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbNodesUI.java
@@ -59,11 +59,13 @@ public class DynamicNbNodesUI implements StatisticsUI {
     private DynamicNbNodes nbNodes;
     private DynamicNbNodesPanel panel;
 
+    @Override
     public JPanel getSettingsPanel() {
         panel = new DynamicNbNodesPanel();
         return panel;
     }
 
+    @Override
     public void setup(Statistics statistics) {
         this.nbNodes = (DynamicNbNodes) statistics;
         if (panel != null) {
@@ -71,6 +73,7 @@ public class DynamicNbNodesUI implements StatisticsUI {
         }
     }
 
+    @Override
     public void unsetup() {
         if (panel != null) {
             settings.save(nbNodes);
@@ -78,26 +81,32 @@ public class DynamicNbNodesUI implements StatisticsUI {
         nbNodes = null;
     }
 
+    @Override
     public Class<? extends Statistics> getStatisticsClass() {
         return DynamicNbNodes.class;
     }
 
+    @Override
     public String getValue() {
         return "";
     }
 
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicNbNodesUI.name");
     }
 
+    @Override
     public String getCategory() {
         return StatisticsUI.CATEGORY_DYNAMIC;
     }
 
+    @Override
     public int getPosition() {
         return 100;
     }
 
+    @Override
     public String getShortDescription() {
         return NbBundle.getMessage(getClass(), "DynamicNbNodesUI.shortDescription");
     }

--- a/modules/ToolsPlugin/src/main/java/org/gephi/ui/tools/plugin/EdgePencilPanel.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/ui/tools/plugin/EdgePencilPanel.java
@@ -127,6 +127,7 @@ public class EdgePencilPanel extends javax.swing.JPanel {
         labelColor.setText(org.openide.util.NbBundle.getMessage(EdgePencilPanel.class, "EdgePencilPanel.labelColor.text")); // NOI18N
 
         typeComboBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 typeComboBoxActionPerformed(evt);
             }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/JFreeChartDialog.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/JFreeChartDialog.java
@@ -139,6 +139,7 @@ public class JFreeChartDialog extends javax.swing.JDialog {
 
         closeButton.setText(org.openide.util.NbBundle.getMessage(JFreeChartDialog.class, "JFreeChartDialog.closeButton.text")); // NOI18N
         closeButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 closeButtonActionPerformed(evt);
             }
@@ -147,6 +148,7 @@ public class JFreeChartDialog extends javax.swing.JDialog {
         resetButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/ui/components/resources/magnifier-history.png"))); // NOI18N
         resetButton.setText(org.openide.util.NbBundle.getMessage(JFreeChartDialog.class, "JFreeChartDialog.resetButton.text")); // NOI18N
         resetButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 resetButtonActionPerformed(evt);
             }
@@ -155,6 +157,7 @@ public class JFreeChartDialog extends javax.swing.JDialog {
         zoomOutButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/ui/components/resources/magnifier--minus.png"))); // NOI18N
         zoomOutButton.setText(org.openide.util.NbBundle.getMessage(JFreeChartDialog.class, "JFreeChartDialog.zoomOutButton.text")); // NOI18N
         zoomOutButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 zoomOutButtonActionPerformed(evt);
             }
@@ -163,6 +166,7 @@ public class JFreeChartDialog extends javax.swing.JDialog {
         zoomInButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/ui/components/resources/magnifier--plus.png"))); // NOI18N
         zoomInButton.setText(org.openide.util.NbBundle.getMessage(JFreeChartDialog.class, "JFreeChartDialog.zoomInButton.text")); // NOI18N
         zoomInButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 zoomInButtonActionPerformed(evt);
             }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/SimpleHTMLReport.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/SimpleHTMLReport.java
@@ -196,6 +196,7 @@ public class SimpleHTMLReport extends javax.swing.JDialog implements Printable {
 
         closeButton.setText(org.openide.util.NbBundle.getMessage(SimpleHTMLReport.class, "SimpleHTMLReport.closeButton.text")); // NOI18N
         closeButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 closeButtonActionPerformed(evt);
             }
@@ -207,6 +208,7 @@ public class SimpleHTMLReport extends javax.swing.JDialog implements Printable {
         printButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/ui/components/resources/print.png"))); // NOI18N
         printButton.setText(org.openide.util.NbBundle.getMessage(SimpleHTMLReport.class, "SimpleHTMLReport.printButton.text")); // NOI18N
         printButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 printButtonActionPerformed(evt);
             }
@@ -216,6 +218,7 @@ public class SimpleHTMLReport extends javax.swing.JDialog implements Printable {
         copyButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/ui/components/resources/copy.gif"))); // NOI18N
         copyButton.setText(org.openide.util.NbBundle.getMessage(SimpleHTMLReport.class, "SimpleHTMLReport.copyButton.text")); // NOI18N
         copyButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 copyButtonActionPerformed(evt);
             }
@@ -225,6 +228,7 @@ public class SimpleHTMLReport extends javax.swing.JDialog implements Printable {
         saveButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/gephi/ui/components/resources/save.png"))); // NOI18N
         saveButton.setText(org.openide.util.NbBundle.getMessage(SimpleHTMLReport.class, "SimpleHTMLReport.saveButton.text")); // NOI18N
         saveButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 saveButtonActionPerformed(evt);
             }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/SwapListPanel.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/SwapListPanel.java
@@ -76,7 +76,9 @@ public class SwapListPanel extends javax.swing.JPanel {
 
         itemList1.setModel(new javax.swing.AbstractListModel() {
             String[] strings = { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
+            @Override
             public int getSize() { return strings.length; }
+            @Override
             public Object getElementAt(int i) { return strings[i]; }
         });
         scrollPane1.setViewportView(itemList1);
@@ -94,7 +96,9 @@ public class SwapListPanel extends javax.swing.JPanel {
 
         itemList2.setModel(new javax.swing.AbstractListModel() {
             String[] strings = { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
+            @Override
             public int getSize() { return strings.length; }
+            @Override
             public Object getElementAt(int i) { return strings[i]; }
         });
         scrollPane2.setViewportView(itemList2);

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/options/DefaultPanel.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/options/DefaultPanel.java
@@ -197,6 +197,7 @@ final class DefaultPanel extends javax.swing.JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(resetButton, org.openide.util.NbBundle.getMessage(DefaultPanel.class, "DefaultPanel.resetButton.text")); // NOI18N
         resetButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 resetButtonActionPerformed(evt);
             }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/options/OpenGLPanel.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/options/OpenGLPanel.java
@@ -102,6 +102,7 @@ final class OpenGLPanel extends javax.swing.JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(resetButton, org.openide.util.NbBundle.getMessage(OpenGLPanel.class, "OpenGLPanel.resetButton.text")); // NOI18N
         resetButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 resetButtonActionPerformed(evt);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1161

Please let me know if you have any questions.

Kirill Vlasov