### PR TITLE
Fixed issue with closeness calculations in GraphDistance

### DIFF
--- a/modules/StatisticsPlugin/src/test/java/org/gephi/statistics/plugin/GraphDistanceNGTest.java
+++ b/modules/StatisticsPlugin/src/test/java/org/gephi/statistics/plugin/GraphDistanceNGTest.java
@@ -60,8 +60,11 @@ import org.testng.annotations.Test;
 /**
  *
  * @author Anna
+ * @author Jonny Wray
  */
 public class GraphDistanceNGTest {
+
+    private static final double TOLERANCE = 0.0001;
 
     private ProjectController pc;
 
@@ -107,7 +110,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double averageDegree = d.getPathLength();
-        assertEquals(averageDegree, 1.0);
+        assertEquals(averageDegree, 1.0, TOLERANCE);
     }
 
     @Test
@@ -137,7 +140,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double averageDegree = d.getPathLength();
-        assertEquals(averageDegree, 1.0);
+        assertEquals(averageDegree, 1.0, TOLERANCE);
     }
 
     @Test
@@ -154,7 +157,7 @@ public class GraphDistanceNGTest {
         double averageDegree = d.getPathLength();
         double res = 1.6667;
         double diff = Math.abs(averageDegree - res);
-        assertTrue(diff < 0.01);
+        assertEquals(averageDegree, res, TOLERANCE);
     }
 
     @Test
@@ -169,7 +172,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double averageDegree = d.getPathLength();
-        assertEquals(averageDegree, 1.5);
+        assertEquals(averageDegree, 1.5, TOLERANCE);
     }
 
     @Test
@@ -187,7 +190,7 @@ public class GraphDistanceNGTest {
         double averageDegree = d.getPathLength();
         double res = 1.6667;
         double diff = Math.abs(averageDegree - res);
-        assertTrue(diff < 0.01);
+        assertEquals(averageDegree, res, TOLERANCE);
     }
 
     @Test
@@ -202,7 +205,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double averageDegree = d.getPathLength();
-        assertEquals(averageDegree, 2.5);
+        assertEquals(averageDegree, 2.5, TOLERANCE);
     }
 
     @Test
@@ -227,7 +230,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double averageDegree = d.getPathLength();
-        assertEquals(averageDegree, 1.0);
+        assertEquals(averageDegree, 1.0, TOLERANCE);
     }
 
     @Test
@@ -265,7 +268,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double averageDegree = d.getPathLength();
-        assertEquals(averageDegree, 1.5);
+        assertEquals(averageDegree, 1.5, TOLERANCE);
     }
 
     @Test
@@ -280,7 +283,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 0.0);
+        assertEquals(diameter, 0.0, TOLERANCE);
     }
 
     @Test
@@ -295,7 +298,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 1.0);
+        assertEquals(diameter, 1.0, TOLERANCE);
     }
 
     @Test
@@ -310,7 +313,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 0.0);
+        assertEquals(diameter, 0.0, TOLERANCE);
     }
 
     @Test
@@ -325,7 +328,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 1.0);
+        assertEquals(diameter, 1.0, TOLERANCE);
     }
 
     @Test
@@ -340,7 +343,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 2.0);
+        assertEquals(diameter, 2.0, TOLERANCE);
     }
 
     @Test
@@ -390,7 +393,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 5.0);
+        assertEquals(diameter, 5.0, TOLERANCE);
     }
 
     @Test
@@ -442,7 +445,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 4.0);
+        assertEquals(diameter, 4.0, TOLERANCE);
     }
 
     @Test
@@ -457,7 +460,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 3.0);
+        assertEquals(diameter, 3.0, TOLERANCE);
     }
 
     @Test
@@ -472,7 +475,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 4.0);
+        assertEquals(diameter, 4.0, TOLERANCE);
     }
 
     @Test
@@ -522,7 +525,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 7.0);
+        assertEquals(diameter, 7.0, TOLERANCE);
     }
 
     @Test
@@ -564,7 +567,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double diameter = d.getDiameter();
-        assertEquals(diameter, 4.0);
+        assertEquals(diameter, 4.0, TOLERANCE);
     }
 
     @Test
@@ -579,7 +582,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 0.0);
+        assertEquals(radius, 0.0, TOLERANCE);
     }
 
     @Test
@@ -594,7 +597,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 1.0);
+        assertEquals(radius, 1.0, TOLERANCE);
     }
 
     @Test
@@ -609,7 +612,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 0.0);
+        assertEquals(radius, 0.0, TOLERANCE);
     }
 
     @Test
@@ -624,7 +627,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 1.0);
+        assertEquals(radius, 1.0, TOLERANCE);
     }
 
     @Test
@@ -639,7 +642,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 1.0);
+        assertEquals(radius, 1.0, TOLERANCE);
     }
 
     @Test
@@ -654,7 +657,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 2.0);
+        assertEquals(radius, 2.0, TOLERANCE);
     }
 
     @Test
@@ -669,7 +672,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 3.0);
+        assertEquals(radius, 3.0, TOLERANCE);
     }
 
     @Test
@@ -719,7 +722,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 3.0);
+        assertEquals(radius, 3.0, TOLERANCE);
     }
 
     @Test
@@ -771,7 +774,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 3.0);
+        assertEquals(radius, 3.0, TOLERANCE);
     }
 
     @Test
@@ -786,7 +789,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 4.0);
+        assertEquals(radius, 4.0, TOLERANCE);
     }
 
     @Test
@@ -801,7 +804,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 0.0);
+        assertEquals(radius, 0.0, TOLERANCE);
     }
 
     @Test
@@ -843,7 +846,7 @@ public class GraphDistanceNGTest {
         d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
 
         double radius = d.getRadius();
-        assertEquals(radius, 2.0);
+        assertEquals(radius, 2.0, TOLERANCE);
     }
 
     @Test
@@ -861,7 +864,7 @@ public class GraphDistanceNGTest {
         Node n1 = undirectedGraph.getNode("0");
         int index1 = indicies.get(n1);
 
-        assertEquals(betweenness[index1], 0.0);
+        assertEquals(betweenness[index1], 0.0, TOLERANCE);
     }
 
     @Test
@@ -879,7 +882,25 @@ public class GraphDistanceNGTest {
         Node n1 = undirectedGraph.getNode("0");
         int index1 = indicies.get(n1);
 
-        assertEquals(closeness[index1], 1.0);
+        assertEquals(closeness[index1], 1.0, TOLERANCE);
+    }
+
+    @Test
+    public void testTwoConnectedNodesHarmonicCloseness() {
+        GraphModel graphModel = GraphGenerator.generatePathUndirectedGraph(2);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(undirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n1 = undirectedGraph.getNode("0");
+        int index1 = indicies.get(n1);
+
+        assertEquals(harmonic[index1], 1.0, TOLERANCE);
     }
 
     @Test
@@ -897,7 +918,7 @@ public class GraphDistanceNGTest {
         Node n1 = undirectedGraph.getNode("0");
         int index1 = indicies.get(n1);
 
-        assertEquals(betweenness[index1], 0.0);
+        assertEquals(betweenness[index1], 0.0, TOLERANCE);
     }
 
     @Test
@@ -915,7 +936,25 @@ public class GraphDistanceNGTest {
         Node n1 = undirectedGraph.getNode("0");
         int index1 = indicies.get(n1);
 
-        assertEquals(closeness[index1], 0.0);
+        assertEquals(closeness[index1], 0.0, TOLERANCE);
+    }
+
+    @Test
+    public void testNullGraphHarmonicCloseness() {
+        GraphModel graphModel = GraphGenerator.generateNullUndirectedGraph(5);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(undirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n1 = undirectedGraph.getNode("0");
+        int index1 = indicies.get(n1);
+
+        assertEquals(harmonic[index1], 0.0, TOLERANCE);
     }
 
     @Test
@@ -933,7 +972,7 @@ public class GraphDistanceNGTest {
         Node n1 = undirectedGraph.getNode("0");
         int index1 = indicies.get(n1);
 
-        assertEquals(betweenness[index1], 0.0);
+        assertEquals(betweenness[index1], 0.0, TOLERANCE);
     }
 
     @Test
@@ -951,7 +990,25 @@ public class GraphDistanceNGTest {
         Node n1 = undirectedGraph.getNode("0");
         int index1 = indicies.get(n1);
 
-        assertEquals(closeness[index1], 1.0);
+        assertEquals(closeness[index1], 1.0, TOLERANCE);
+    }
+
+    @Test
+    public void testCompleteGraphHarmonicCloseness() {
+        GraphModel graphModel = GraphGenerator.generateCompleteUndirectedGraph(5);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(undirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n1 = undirectedGraph.getNode("0");
+        int index1 = indicies.get(n1);
+
+        assertEquals(harmonic[index1], 1.0, TOLERANCE);
     }
 
     @Test
@@ -971,8 +1028,8 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(n1);
         int index2 = indicies.get(n2);
 
-        assertEquals(betweenness[index1], 10.0);
-        assertEquals(betweenness[index2], 0.0);
+        assertEquals(betweenness[index1], 10.0, TOLERANCE);
+        assertEquals(betweenness[index2], 0.0, TOLERANCE);
     }
 
     @Test
@@ -992,8 +1049,29 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(n1);
         int index2 = indicies.get(n2);
 
-        assertEquals(closeness[index1], 1.0);
-        assertEquals(closeness[index2], 1.8);
+        assertEquals(closeness[index1], 1.0, TOLERANCE);
+        assertEquals(closeness[index2], 1.0/1.8, TOLERANCE);
+    }
+
+    @Test
+    public void testStarGraphHarmonicCloseness() {
+        GraphModel graphModel = GraphGenerator.generateStarUndirectedGraph(5);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(undirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n1 = undirectedGraph.getNode("0");
+        Node n2 = undirectedGraph.getNode("1");
+        int index1 = indicies.get(n1);
+        int index2 = indicies.get(n2);
+
+        assertEquals(harmonic[index1], 5.0/5.0, TOLERANCE);
+        assertEquals(harmonic[index2], (1.0 + 4*0.5)/5.0, TOLERANCE);
     }
 
     @Test
@@ -1011,7 +1089,7 @@ public class GraphDistanceNGTest {
         Node n4 = undirectedGraph.getNode("3");
         int index4 = indicies.get(n4);
 
-        assertEquals(betweenness[index4], 1.0);
+        assertEquals(betweenness[index4], 1.0, TOLERANCE);
     }
 
     @Test
@@ -1029,7 +1107,7 @@ public class GraphDistanceNGTest {
         Node n2 = undirectedGraph.getNode("1");
         int index2 = indicies.get(n2);
 
-        assertEquals(betweenness[index2], 2.0);
+        assertEquals(betweenness[index2], 2.0, TOLERANCE);
     }
 
     @Test
@@ -1047,7 +1125,25 @@ public class GraphDistanceNGTest {
         Node n3 = undirectedGraph.getNode("2");
         int index3 = indicies.get(n3);
 
-        assertEquals(closeness[index3], 1.5);
+        assertEquals(closeness[index3], 1.0/1.5, TOLERANCE);
+    }
+
+    @Test
+    public void testCyclic5GraphHarmonicCloseness() {
+        GraphModel graphModel = GraphGenerator.generateCyclicUndirectedGraph(5);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(undirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n3 = undirectedGraph.getNode("2");
+        int index3 = indicies.get(n3);
+
+        assertEquals(harmonic[index3], (1.0 + 1.0 + 1.0/2.0 + 1.0/2.0)/4.0, TOLERANCE);
     }
 
     @Test
@@ -1100,8 +1196,8 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(node1);
         int index3 = indicies.get(node3);
 
-        assertEquals(betweenness[index1], 5.);
-        assertEquals(betweenness[index3], 0.2);
+        assertEquals(betweenness[index1], 5., TOLERANCE);
+        assertEquals(betweenness[index3], 0.2, TOLERANCE);
     }
 
     @Test
@@ -1153,10 +1249,64 @@ public class GraphDistanceNGTest {
 
         int index7 = indicies.get(node7);
 
-        double res = 1.1667;
+        double res = 1.0/1.1667;
         double diff = 0.01;
 
-        assertTrue(Math.abs(closeness[index7] - res) < diff);
+        assertEquals(closeness[index7], res, TOLERANCE);
+    }
+
+    @Test
+    public void testSpecial1UndirectedGraphHarmonicCloseness() {
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        Node node1 = graphModel.factory().newNode("0");
+        Node node2 = graphModel.factory().newNode("1");
+        Node node3 = graphModel.factory().newNode("2");
+        Node node4 = graphModel.factory().newNode("3");
+        Node node5 = graphModel.factory().newNode("4");
+        Node node6 = graphModel.factory().newNode("5");
+        Node node7 = graphModel.factory().newNode("6");
+        undirectedGraph.addNode(node1);
+        undirectedGraph.addNode(node2);
+        undirectedGraph.addNode(node3);
+        undirectedGraph.addNode(node4);
+        undirectedGraph.addNode(node5);
+        undirectedGraph.addNode(node6);
+        undirectedGraph.addNode(node7);
+        Edge edge12 = graphModel.factory().newEdge(node1, node2, false);
+        Edge edge13 = graphModel.factory().newEdge(node1, node3, false);
+        Edge edge14 = graphModel.factory().newEdge(node1, node4, false);
+        Edge edge15 = graphModel.factory().newEdge(node1, node5, false);
+        Edge edge16 = graphModel.factory().newEdge(node1, node6, false);
+        Edge edge27 = graphModel.factory().newEdge(node2, node7, false);
+        Edge edge37 = graphModel.factory().newEdge(node3, node7, false);
+        Edge edge47 = graphModel.factory().newEdge(node4, node7, false);
+        Edge edge57 = graphModel.factory().newEdge(node5, node7, false);
+        Edge edge67 = graphModel.factory().newEdge(node6, node7, false);
+        undirectedGraph.addEdge(edge12);
+        undirectedGraph.addEdge(edge13);
+        undirectedGraph.addEdge(edge14);
+        undirectedGraph.addEdge(edge15);
+        undirectedGraph.addEdge(edge16);
+        undirectedGraph.addEdge(edge27);
+        undirectedGraph.addEdge(edge37);
+        undirectedGraph.addEdge(edge47);
+        undirectedGraph.addEdge(edge57);
+        undirectedGraph.addEdge(edge67);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph hierarchicalUndirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(hierarchicalUndirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        int index7 = indicies.get(node7);
+
+        double res = (5.0 + 0.5)/6.0;
+
+        assertEquals(harmonic[index7], res, TOLERANCE);
     }
 
     @Test
@@ -1214,9 +1364,9 @@ public class GraphDistanceNGTest {
         int index6 = indicies.get(n6);
         int index7 = indicies.get(n7);
 
-        assertEquals(betweenness[index4], 12.5);
-        assertEquals(betweenness[index6], 2.5);
-        assertEquals(betweenness[index7], 0.5);
+        assertEquals(betweenness[index4], 12.5, TOLERANCE);
+        assertEquals(betweenness[index6], 2.5, TOLERANCE);
+        assertEquals(betweenness[index7], 0.5, TOLERANCE);
     }
 
     @Test
@@ -1268,10 +1418,63 @@ public class GraphDistanceNGTest {
 
         int index2 = indicies.get(node2);
 
-        double res = 2.2857;
-        double diff = 0.01;
+        double res = 1.0/2.2857;
 
-        assertTrue(Math.abs(closeness[index2] - res) < diff);
+        assertEquals(closeness[index2], res, TOLERANCE);
+    }
+
+    @Test
+    public void testSpecial2UndirectedGraphHarmonicCloseness() {
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        Node node1 = graphModel.factory().newNode("0");
+        Node node2 = graphModel.factory().newNode("1");
+        Node node3 = graphModel.factory().newNode("2");
+        Node node4 = graphModel.factory().newNode("3");
+        Node node5 = graphModel.factory().newNode("4");
+        Node node6 = graphModel.factory().newNode("5");
+        Node node7 = graphModel.factory().newNode("6");
+        Node node8 = graphModel.factory().newNode("7");
+        undirectedGraph.addNode(node1);
+        undirectedGraph.addNode(node2);
+        undirectedGraph.addNode(node3);
+        undirectedGraph.addNode(node4);
+        undirectedGraph.addNode(node5);
+        undirectedGraph.addNode(node6);
+        undirectedGraph.addNode(node7);
+        undirectedGraph.addNode(node8);
+        Edge edge12 = graphModel.factory().newEdge(node1, node2, false);
+        Edge edge13 = graphModel.factory().newEdge(node1, node3, false);
+        Edge edge34 = graphModel.factory().newEdge(node3, node4, false);
+        Edge edge24 = graphModel.factory().newEdge(node2, node4, false);
+        Edge edge56 = graphModel.factory().newEdge(node5, node6, false);
+        Edge edge67 = graphModel.factory().newEdge(node6, node7, false);
+        Edge edge78 = graphModel.factory().newEdge(node7, node8, false);
+        Edge edge85 = graphModel.factory().newEdge(node8, node5, false);
+        Edge edge45 = graphModel.factory().newEdge(node4, node5, false);
+        undirectedGraph.addEdge(edge12);
+        undirectedGraph.addEdge(edge13);
+        undirectedGraph.addEdge(edge34);
+        undirectedGraph.addEdge(edge24);
+        undirectedGraph.addEdge(edge56);
+        undirectedGraph.addEdge(edge67);
+        undirectedGraph.addEdge(edge78);
+        undirectedGraph.addEdge(edge85);
+        undirectedGraph.addEdge(edge45);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph hierarchicalUndirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(hierarchicalUndirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        int index2 = indicies.get(node2);
+
+        double res = (1.0 + 1.0/2.0 + 1.0 + 1.0/2.0 + 1.0/3.0 + 1.0/4.0 + 1.0/3.0)/7.0;
+
+        assertEquals(harmonic[index2], res, TOLERANCE);
     }
 
     @Test
@@ -1327,7 +1530,7 @@ public class GraphDistanceNGTest {
 
         int index3 = indicies.get(node3);
 
-        assertEquals(betweenness[index3], 0.5);
+        assertEquals(betweenness[index3], 0.5, TOLERANCE);
     }
 
     @Test
@@ -1384,8 +1587,66 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(node1);
         int index3 = indicies.get(node3);
 
-        assertEquals(closeness[index1], 1.0);
-        assertEquals(closeness[index3], 1.5);
+        assertEquals(closeness[index1], 1.0, TOLERANCE);
+        assertEquals(closeness[index3], 1.0/1.5, TOLERANCE);
+    }
+
+    @Test
+    public void testSpecial3UndirectedGraphHarmonicCloseness() {
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        Node node1 = graphModel.factory().newNode("0");
+        Node node2 = graphModel.factory().newNode("1");
+        Node node3 = graphModel.factory().newNode("2");
+        Node node4 = graphModel.factory().newNode("3");
+        Node node5 = graphModel.factory().newNode("4");
+        Node node6 = graphModel.factory().newNode("5");
+        Node node7 = graphModel.factory().newNode("6");
+        undirectedGraph.addNode(node1);
+        undirectedGraph.addNode(node2);
+        undirectedGraph.addNode(node3);
+        undirectedGraph.addNode(node4);
+        undirectedGraph.addNode(node5);
+        undirectedGraph.addNode(node6);
+        undirectedGraph.addNode(node7);
+        Edge edge12 = graphModel.factory().newEdge(node1, node2, false);
+        Edge edge13 = graphModel.factory().newEdge(node1, node3, false);
+        Edge edge14 = graphModel.factory().newEdge(node1, node4, false);
+        Edge edge15 = graphModel.factory().newEdge(node1, node5, false);
+        Edge edge16 = graphModel.factory().newEdge(node1, node6, false);
+        Edge edge17 = graphModel.factory().newEdge(node1, node7, false);
+        Edge edge23 = graphModel.factory().newEdge(node2, node3, false);
+        Edge edge34 = graphModel.factory().newEdge(node3, node4, false);
+        Edge edge45 = graphModel.factory().newEdge(node4, node5, false);
+        Edge edge56 = graphModel.factory().newEdge(node5, node6, false);
+        Edge edge67 = graphModel.factory().newEdge(node6, node7, false);
+        Edge edge72 = graphModel.factory().newEdge(node7, node2, false);
+        undirectedGraph.addEdge(edge12);
+        undirectedGraph.addEdge(edge13);
+        undirectedGraph.addEdge(edge14);
+        undirectedGraph.addEdge(edge15);
+        undirectedGraph.addEdge(edge16);
+        undirectedGraph.addEdge(edge17);
+        undirectedGraph.addEdge(edge23);
+        undirectedGraph.addEdge(edge34);
+        undirectedGraph.addEdge(edge45);
+        undirectedGraph.addEdge(edge56);
+        undirectedGraph.addEdge(edge67);
+        undirectedGraph.addEdge(edge72);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph hierarchicalUndirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(hierarchicalUndirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmomic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        int index1 = indicies.get(node1);
+        int index3 = indicies.get(node3);
+
+        assertEquals(harmomic[index1], 6.0/6.0, TOLERANCE);
+        assertEquals(harmomic[index3], (3.0 + 3.0/2.0)/6.0, TOLERANCE);
     }
 
     @Test
@@ -1403,7 +1664,7 @@ public class GraphDistanceNGTest {
         Node n2 = directedGraph.getNode("1");
         int index2 = indicies.get(n2);
 
-        assertEquals(betweenness[index2], 2.0);
+        assertEquals(betweenness[index2], 2.0, TOLERANCE);
     }
 
     @Test
@@ -1423,8 +1684,29 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(n1);
         int index3 = indicies.get(n3);
 
-        assertEquals(closeness[index1], 2.0);
-        assertEquals(closeness[index3], 1.0);
+        assertEquals(closeness[index1], 1.0/2.0, TOLERANCE);
+        assertEquals(closeness[index3], 1.0, TOLERANCE);
+    }
+
+    @Test
+    public void testDirectedPathGraphHarmonicCloseness() {
+        GraphModel graphModel = GraphGenerator.generatePathDirectedGraph(4);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        DirectedGraph directedGraph = graphModel.getDirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(graphModel.getGraph());
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n1 = directedGraph.getNode("0");
+        Node n3 = directedGraph.getNode("2");
+        int index1 = indicies.get(n1);
+        int index3 = indicies.get(n3);
+
+        assertEquals(harmonic[index1], (1.0 + 1.0/2.0 + 1.0/3.0)/3.0, TOLERANCE);
+        assertEquals(harmonic[index3], 1.0, TOLERANCE);
     }
 
     @Test
@@ -1444,8 +1726,8 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(n1);
         int index3 = indicies.get(n3);
 
-        assertEquals(betweenness[index1], 6.0);
-        assertEquals(betweenness[index3], 6.0);
+        assertEquals(betweenness[index1], 6.0, TOLERANCE);
+        assertEquals(betweenness[index3], 6.0, TOLERANCE);
     }
 
     @Test
@@ -1463,7 +1745,25 @@ public class GraphDistanceNGTest {
         Node n2 = directedGraph.getNode("1");
         int index2 = indicies.get(n2);
 
-        assertEquals(closeness[index2], 2.5);
+        assertEquals(closeness[index2], 1.0/2.5, TOLERANCE);
+    }
+
+    @Test
+    public void testDirectedCyclicGraphHarmonicCloseness() {
+        GraphModel graphModel = GraphGenerator.generateCyclicDirectedGraph(5);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        DirectedGraph directedGraph = graphModel.getDirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(graphModel.getGraph());
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n2 = directedGraph.getNode("1");
+        int index2 = indicies.get(n2);
+
+        assertEquals(harmonic[index2], (1.0 + 1.0/2.0 + 1.0/3.0 + 1.0/4.0)/4.0, TOLERANCE);
     }
 
     @Test
@@ -1493,8 +1793,8 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(n1);
         int index5 = indicies.get(n5);
 
-        assertEquals(betweenness[index1], 0.0);
-        assertEquals(betweenness[index5], 0.0);
+        assertEquals(betweenness[index1], 0.0, TOLERANCE);
+        assertEquals(betweenness[index5], 0.0, TOLERANCE);
     }
 
     @Test
@@ -1524,8 +1824,39 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(n1);
         int index6 = indicies.get(n6);
 
-        assertEquals(closeness[index1], 1.0);
-        assertEquals(closeness[index6], 0.0);
+        assertEquals(closeness[index1], 1.0, TOLERANCE);
+        assertEquals(closeness[index6], 0.0, TOLERANCE);
+    }
+
+    @Test
+    public void testDirectedStarOutGraphHarmonicCloseness() {
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
+
+        DirectedGraph directedGraph = graphModel.getDirectedGraph();
+        Node firstNode = graphModel.factory().newNode("0");
+        directedGraph.addNode(firstNode);
+        for (int i = 1; i <= 5; i++) {
+            Node currentNode = graphModel.factory().newNode(((Integer) i).toString());
+            directedGraph.addNode(currentNode);
+            Edge currentEdge = graphModel.factory().newEdge(firstNode, currentNode);
+            directedGraph.addEdge(currentEdge);
+        }
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(graphModel.getGraph());
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        Node n1 = directedGraph.getNode("0");
+        Node n6 = directedGraph.getNode("5");
+        int index1 = indicies.get(n1);
+        int index6 = indicies.get(n6);
+
+        assertEquals(harmonic[index1], 1.0, TOLERANCE);
+        assertEquals(harmonic[index6], 0.0, TOLERANCE);
     }
 
     @Test
@@ -1567,9 +1898,9 @@ public class GraphDistanceNGTest {
         int index3 = indicies.get(node3);
         int index4 = indicies.get(node4);
 
-        assertEquals(betweenness[index1], 3.0);
-        assertEquals(betweenness[index3], 10.0);
-        assertEquals(betweenness[index4], 3.0);
+        assertEquals(betweenness[index1], 3.0, TOLERANCE);
+        assertEquals(betweenness[index3], 10.0, TOLERANCE);
+        assertEquals(betweenness[index4], 3.0, TOLERANCE);
     }
 
     @Test
@@ -1610,8 +1941,50 @@ public class GraphDistanceNGTest {
         int index2 = indicies.get(node2);
         int index3 = indicies.get(node3);
 
-        assertEquals(closeness[index2], 2.5);
-        assertEquals(closeness[index3], 1.5);
+        assertEquals(closeness[index2], 1.0/2.5, TOLERANCE);
+        assertEquals(closeness[index3], 1.0/1.5, TOLERANCE);
+    }
+
+    @Test
+    public void testSpecial1DirectedGraphHarmonicCloseness() {
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
+        DirectedGraph directedGraph = graphModel.getDirectedGraph();
+        Node node1 = graphModel.factory().newNode("0");
+        Node node2 = graphModel.factory().newNode("1");
+        Node node3 = graphModel.factory().newNode("2");
+        Node node4 = graphModel.factory().newNode("3");
+        Node node5 = graphModel.factory().newNode("4");
+        directedGraph.addNode(node1);
+        directedGraph.addNode(node2);
+        directedGraph.addNode(node3);
+        directedGraph.addNode(node4);
+        directedGraph.addNode(node5);
+        Edge edge13 = graphModel.factory().newEdge(node1, node3);
+        Edge edge32 = graphModel.factory().newEdge(node3, node2);
+        Edge edge21 = graphModel.factory().newEdge(node2, node1);
+        Edge edge34 = graphModel.factory().newEdge(node3, node4);
+        Edge edge45 = graphModel.factory().newEdge(node4, node5);
+        Edge edge53 = graphModel.factory().newEdge(node5, node3);
+        directedGraph.addEdge(edge13);
+        directedGraph.addEdge(edge32);
+        directedGraph.addEdge(edge21);
+        directedGraph.addEdge(edge34);
+        directedGraph.addEdge(edge45);
+        directedGraph.addEdge(edge53);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(graphModel.getGraph());
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, true, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        int index2 = indicies.get(node2);
+        int index3 = indicies.get(node3);
+
+        assertEquals(harmonic[index2], (1.0 + 1.0/2.0 + 1.0/3.0 + 1.0/4.0)/4.0, TOLERANCE);
+        assertEquals(harmonic[index3], (1.0/2.0 + 1.0 + 1.0 + 1.0/2.0)/4.0, TOLERANCE);
     }
 
     @Test
@@ -1647,7 +2020,44 @@ public class GraphDistanceNGTest {
         int index1 = indicies.get(node1);
         int index4 = indicies.get(node4);
 
-        assertEquals(closeness[index1], 1.5);
-        assertEquals(closeness[index4], 1.);
+        assertEquals(closeness[index1], 1.0/1.5, TOLERANCE);
+        assertEquals(closeness[index4], 1., TOLERANCE);
+    }
+
+    @Test
+    public void testConnectedComponentsUndirectedGraphHarmonicCloseness() {
+        //expected that values are computed separatly for every connected component
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
+        UndirectedGraph undirectedGraph = graphModel.getUndirectedGraph();
+        Node node1 = graphModel.factory().newNode("0");
+        Node node2 = graphModel.factory().newNode("1");
+        Node node3 = graphModel.factory().newNode("2");
+        Node node4 = graphModel.factory().newNode("3");
+        Node node5 = graphModel.factory().newNode("4");
+        undirectedGraph.addNode(node1);
+        undirectedGraph.addNode(node2);
+        undirectedGraph.addNode(node3);
+        undirectedGraph.addNode(node4);
+        undirectedGraph.addNode(node5);
+        Edge edge12 = graphModel.factory().newEdge(node1, node2, false);
+        Edge edge23 = graphModel.factory().newEdge(node2, node3, false);
+        Edge edge45 = graphModel.factory().newEdge(node4, node5, false);
+        undirectedGraph.addEdge(edge12);
+        undirectedGraph.addEdge(edge23);
+        undirectedGraph.addEdge(edge45);
+
+        GraphDistance d = new GraphDistance();
+        d.initializeStartValues();
+        UndirectedGraph hierarchicalUndirectedGraph = graphModel.getUndirectedGraph();
+        HashMap<Node, Integer> indicies = d.createIndiciesMap(hierarchicalUndirectedGraph);
+
+        HashMap<String, double[]> metricsMap = (HashMap) d.calculateDistanceMetrics(graphModel.getGraph(), indicies, false, false);
+        double[] harmonic = metricsMap.get(GraphDistance.HARMONIC_CLOSENESS);
+
+        int index1 = indicies.get(node1);
+        int index4 = indicies.get(node4);
+
+        assertEquals(harmonic[index1], (1.0 + 1.0/2.0)/2.0, TOLERANCE);
+        assertEquals(harmonic[index4], 1.0, TOLERANCE);
     }
 }


### PR DESCRIPTION
Issue #1341.

- Fixed issues with closeness calculation. Now agrees with commonly accepted definition.
- Added harmonic closeness centrality as a new statistic. Similar to closeness but with some nicer properties
- Removed reporting of shortest path count. It wasn't correct as it only considered one of potentially many shortest paths between a node pair.