### PR TITLE
Added per-node opacity property

### DIFF
--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewProperty.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PreviewProperty.java
@@ -101,6 +101,14 @@ public class PreviewProperty {
      * 100 means opaque.
      */
     public static final String NODE_OPACITY = "node.opacity";
+
+    /**
+     * Node <code>Boolean</code> property indicating whether or not to use the
+     * opacity value defined as part of the Node color. If true, NODE_OPACITY will
+     * be ignored.
+     */
+    public static final String NODE_PER_NODE_OPACITY = "node.per.node.opacity";
+
     //Constants edges
     /**
      * Edge <code>Boolean</code> property defining whether to show edges.

--- a/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeRenderer.java
+++ b/modules/PreviewPlugin/src/main/java/org/gephi/preview/plugin/renderers/NodeRenderer.java
@@ -69,6 +69,7 @@ public class NodeRenderer implements Renderer {
     protected float defaultBorderWidth = 1f;
     protected DependantColor defaultBorderColor = new DependantColor(Color.BLACK);
     protected float defaultOpacity = 100f;
+    protected boolean defaultPerNodeOpacity = false;
 
     @Override
     public void preProcess(PreviewModel previewModel) {
@@ -110,7 +111,9 @@ public class NodeRenderer implements Renderer {
         Color color = item.getData(NodeItem.COLOR);
         Color borderColor = ((DependantColor) properties.getValue(PreviewProperty.NODE_BORDER_COLOR)).getColor(color);
         float borderSize = properties.getFloatValue(PreviewProperty.NODE_BORDER_WIDTH);
-        int alpha = (int) ((properties.getFloatValue(PreviewProperty.NODE_OPACITY) / 100f) * 255f);
+        int alpha = properties.getBooleanValue(PreviewProperty.NODE_PER_NODE_OPACITY) ?
+                color.getAlpha() :
+                (int) ((properties.getFloatValue(PreviewProperty.NODE_OPACITY) / 100f) * 255f);
         if (alpha < 0) {
             alpha = 0;
         }
@@ -144,7 +147,9 @@ public class NodeRenderer implements Renderer {
         Color color = item.getData(NodeItem.COLOR);
         Color borderColor = ((DependantColor) properties.getValue(PreviewProperty.NODE_BORDER_COLOR)).getColor(color);
         float borderSize = properties.getFloatValue(PreviewProperty.NODE_BORDER_WIDTH);
-        float alpha = properties.getFloatValue(PreviewProperty.NODE_OPACITY) / 100f;
+        float alpha = properties.getBooleanValue(PreviewProperty.NODE_PER_NODE_OPACITY) ?
+                color.getAlpha() / 255f:
+                properties.getFloatValue(PreviewProperty.NODE_OPACITY) / 100f;
         if (alpha > 1) {
             alpha = 1;
         }
@@ -174,7 +179,9 @@ public class NodeRenderer implements Renderer {
         Color color = item.getData(NodeItem.COLOR);
         Color borderColor = ((DependantColor) properties.getValue(PreviewProperty.NODE_BORDER_COLOR)).getColor(color);
         float borderSize = properties.getFloatValue(PreviewProperty.NODE_BORDER_WIDTH);
-        float alpha = properties.getFloatValue(PreviewProperty.NODE_OPACITY) / 100f;
+        float alpha = properties.getBooleanValue(PreviewProperty.NODE_PER_NODE_OPACITY) ?
+                color.getAlpha() / 255f :
+                properties.getFloatValue(PreviewProperty.NODE_OPACITY) / 100f;
 
         PdfContentByte cb = target.getContentByte();
         cb.setRGBColorStroke(borderColor.getRed(), borderColor.getGreen(), borderColor.getBlue());
@@ -201,18 +208,23 @@ public class NodeRenderer implements Renderer {
     @Override
     public PreviewProperty[] getProperties() {
         return new PreviewProperty[]{
-            PreviewProperty.createProperty(this, PreviewProperty.NODE_BORDER_WIDTH, Float.class,
-            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderWidth.displayName"),
-            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderWidth.description"),
-            PreviewProperty.CATEGORY_NODES).setValue(defaultBorderWidth),
-            PreviewProperty.createProperty(this, PreviewProperty.NODE_BORDER_COLOR, DependantColor.class,
-            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderColor.displayName"),
-            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderColor.description"),
-            PreviewProperty.CATEGORY_NODES).setValue(defaultBorderColor),
-            PreviewProperty.createProperty(this, PreviewProperty.NODE_OPACITY, Float.class,
-            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.displayName"),
-            NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.description"),
-            PreviewProperty.CATEGORY_NODES).setValue(defaultOpacity)};
+                PreviewProperty.createProperty(this, PreviewProperty.NODE_BORDER_WIDTH, Float.class,
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderWidth.displayName"),
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderWidth.description"),
+                        PreviewProperty.CATEGORY_NODES).setValue(defaultBorderWidth),
+                PreviewProperty.createProperty(this, PreviewProperty.NODE_BORDER_COLOR, DependantColor.class,
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderColor.displayName"),
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.borderColor.description"),
+                        PreviewProperty.CATEGORY_NODES).setValue(defaultBorderColor),
+                PreviewProperty.createProperty(this, PreviewProperty.NODE_OPACITY, Float.class,
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.displayName"),
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.opacity.description"),
+                        PreviewProperty.CATEGORY_NODES).setValue(defaultOpacity),
+                PreviewProperty.createProperty(this, PreviewProperty.NODE_PER_NODE_OPACITY, Boolean.class,
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.perNodeOpacity.displayName"),
+                        NbBundle.getMessage(NodeRenderer.class, "NodeRenderer.property.perNodeOpacity.description"),
+                        PreviewProperty.CATEGORY_NODES).setValue(defaultPerNodeOpacity)
+        };
     }
 
     private boolean showNodes(PreviewProperties properties) {

--- a/modules/PreviewPlugin/src/main/resources/org/gephi/preview/plugin/renderers/Bundle.properties
+++ b/modules/PreviewPlugin/src/main/resources/org/gephi/preview/plugin/renderers/Bundle.properties
@@ -5,6 +5,8 @@ NodeRenderer.property.borderColor.displayName = Border Color
 NodeRenderer.property.borderColor.description =
 NodeRenderer.property.opacity.displayName = opacity
 NodeRenderer.property.opacity.description =
+NodeRenderer.property.perNodeOpacity.displayName = Per-Node Opacity
+NodeRenderer.property.perNodeOpacity.description = Use opacity defined at node level. If true, renderer's opacity property will be ignored.
 
 EdgeRenderer.name = Default edges
 EdgeRenderer.property.display.displayName = Show Edges


### PR DESCRIPTION
NodeRenderer now uses the Node's alpha value when rendering the node in SVG, G2D and PDF outputs. It only uses this value if the new per-node opacity property is checked, so existing behaviour is preserved by default.

It's the answer to my SO question [here](http://stackoverflow.com/questions/35731271/can-the-gephi-node-renderer-preserve-the-original-node-opacity).

The justification for this is, I have a large graph from Spark GraphX that I'd like to visualize. I render one visualization for the full graph, and then I want to render separate visualizations for subgraphs. But I want to preserve the positions of the vertices from the original graph, to maintain the visual context.

One way to do this is to set the alpha of the hidden vertices to 0 and then call the OpenORD layout with the same randomSeed as I used for the full graph visualization.