### PR TITLE
Fix - add try/finally logic to wrap graph reentrant locks for layouts

### DIFF
--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/force/yifanHu/YifanHuLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/force/yifanHu/YifanHuLayout.java
@@ -41,8 +41,6 @@
  */
 package org.gephi.layout.plugin.force.yifanHu;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.Node;
@@ -57,6 +55,9 @@ import org.gephi.layout.spi.Layout;
 import org.gephi.layout.spi.LayoutBuilder;
 import org.gephi.layout.spi.LayoutProperty;
 import org.openide.util.NbBundle;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Hu's basic algorithm
@@ -229,19 +230,33 @@ public class YifanHuLayout extends AbstractLayout implements Layout {
             return;
         }
         graph = graphModel.getGraphVisible();
-        energy = Float.POSITIVE_INFINITY;
-        for (Node n : graph.getNodes()) {
-            n.setLayoutData(new ForceVector());
+        graph.readLock();
+        try
+        {
+            energy = Float.POSITIVE_INFINITY;
+            for (Node n : graph.getNodes())
+            {
+                n.setLayoutData(new ForceVector());
+            }
+            progress = 0;
+            setConverged(false);
+            setStep(initialStep);
+        } finally {
+            graph.readUnlock();
         }
-        progress = 0;
-        setConverged(false);
-        setStep(initialStep);
     }
 
     @Override
     public void endAlgo() {
-        for (Node n : graph.getNodes()) {
-            n.setLayoutData(null);
+        graph.readLock();
+        try
+        {
+            for (Node n : graph.getNodes())
+            {
+                n.setLayoutData(null);
+            }
+        } finally {
+            graph.readUnlock();
         }
     }
 
@@ -249,68 +264,77 @@ public class YifanHuLayout extends AbstractLayout implements Layout {
     public void goAlgo() {
         graph = graphModel.getGraphVisible();
         graph.readLock();
-        Node[] nodes = graph.getNodes().toArray();
-        for (Node n : nodes) {
-            if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceVector)) {
-                n.setLayoutData(new ForceVector());
+        try
+        {
+            Node[] nodes = graph.getNodes().toArray();
+            for (Node n : nodes)
+            {
+                if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceVector))
+                {
+                    n.setLayoutData(new ForceVector());
+                }
             }
-        }
 
-        // Evaluates n^2 inter node forces using BarnesHut.
-        QuadTree tree = QuadTree.buildTree(graph, getQuadTreeMaxLevel());
+            // Evaluates n^2 inter node forces using BarnesHut.
+            QuadTree tree = QuadTree.buildTree(graph, getQuadTreeMaxLevel());
 
-//        double electricEnergy = 0; ///////////////////////
-//        double springEnergy = 0; ///////////////////////
-        BarnesHut barnes = new BarnesHut(getNodeForce());
-        barnes.setTheta(getBarnesHutTheta());
-        for (Node node : nodes) {
-            ForceVector layoutData = node.getLayoutData();
+            //        double electricEnergy = 0; ///////////////////////
+            //        double springEnergy = 0; ///////////////////////
+            BarnesHut barnes = new BarnesHut(getNodeForce());
+            barnes.setTheta(getBarnesHutTheta());
+            for (Node node : nodes)
+            {
+                ForceVector layoutData = node.getLayoutData();
 
-            ForceVector f = barnes.calculateForce(node, tree);
-            layoutData.add(f);
-//            electricEnergy += f.getEnergy();
-        }
-
-        // Apply edge forces.
-
-        for (Edge e : graph.getEdges()) {
-            if (!e.getSource().equals(e.getTarget())) {
-                Node n1 = e.getSource();
-                Node n2 = e.getTarget();
-                ForceVector f1 = n1.getLayoutData();
-                ForceVector f2 = n2.getLayoutData();
-
-                ForceVector f = getEdgeForce().calculateForce(n1, n2);
-                f1.add(f);
-                f2.subtract(f);
+                ForceVector f = barnes.calculateForce(node, tree);
+                layoutData.add(f);
+                //            electricEnergy += f.getEnergy();
             }
-        }
 
-        // Calculate energy and max force.
-        energy0 = energy;
-        energy = 0;
-        double maxForce = 1;
-        for (Node n : nodes) {
-            ForceVector force = n.getLayoutData();
+            // Apply edge forces.
 
-            energy += force.getNorm();
-            maxForce = Math.max(maxForce, force.getNorm());
-        }
+            for (Edge e : graph.getEdges())
+            {
+                if (!e.getSource().equals(e.getTarget()))
+                {
+                    Node n1 = e.getSource();
+                    Node n2 = e.getTarget();
+                    ForceVector f1 = n1.getLayoutData();
+                    ForceVector f2 = n2.getLayoutData();
 
-        // Apply displacements on nodes.
-        for (Node n : nodes) {
-            if (!n.isFixed()) {
+                    ForceVector f = getEdgeForce().calculateForce(n1, n2);
+                    f1.add(f);
+                    f2.subtract(f);
+                }
+            }
+
+            // Calculate energy and max force.
+            energy0 = energy;
+            energy = 0;
+            double maxForce = 1;
+            for (Node n : nodes)
+            {
                 ForceVector force = n.getLayoutData();
 
-                force.multiply((float) (1.0 / maxForce));
-                getDisplacement().moveNode(n, force);
+                energy += force.getNorm();
+                maxForce = Math.max(maxForce, force.getNorm());
             }
+
+            // Apply displacements on nodes.
+            for (Node n : nodes)
+            {
+                if (!n.isFixed())
+                {
+                    ForceVector force = n.getLayoutData();
+
+                    force.multiply((float) (1.0 / maxForce));
+                    getDisplacement().moveNode(n, force);
+                }
+            }
+            postAlgo();
+        } finally {
+            graph.readUnlock();
         }
-        postAlgo();
-//        springEnergy = energy - electricEnergy;
-//        System.out.println("electric: " + electricEnergy + "    spring: " + springEnergy);
-//        System.out.println("energy0 = " + energy0 + "   energy = " + energy);
-        graph.readUnlock();
     }
 
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas/ForceAtlasLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas/ForceAtlasLayout.java
@@ -41,8 +41,6 @@
  */
 package org.gephi.layout.plugin.forceAtlas;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.Node;
@@ -53,6 +51,9 @@ import org.gephi.layout.spi.Layout;
 import org.gephi.layout.spi.LayoutBuilder;
 import org.gephi.layout.spi.LayoutProperty;
 import org.openide.util.NbBundle;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -104,131 +105,178 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
     public void goAlgo() {
         this.graph = graphModel.getGraphVisible();
         graph.readLock();
-        Node[] nodes = graph.getNodes().toArray();
-        Edge[] edges = graph.getEdges().toArray();
+        try
+        {
+            Node[] nodes = graph.getNodes().toArray();
+            Edge[] edges = graph.getEdges().toArray();
 
-        for (Node n : nodes) {
-            if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceVectorNodeLayoutData)) {
-                n.setLayoutData(new ForceVectorNodeLayoutData());
+            for (Node n : nodes)
+            {
+                if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceVectorNodeLayoutData))
+                {
+                    n.setLayoutData(new ForceVectorNodeLayoutData());
+                }
             }
-        }
 
-        for (Node n : nodes) {
-            ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-            layoutData.old_dx = layoutData.dx;
-            layoutData.old_dy = layoutData.dy;
-            layoutData.dx *= inertia;
-            layoutData.dy *= inertia;
-        }
-        // repulsion
-        if (isAdjustSizes()) {
-            for (Node n1 : nodes) {
-                for (Node n2 : nodes) {
-                    if (n1 != n2) {
-                        ForceVectorUtils.fcBiRepulsor_noCollide(n1, n2, getRepulsionStrength() * (1 + graph.getDegree(n1)) * (1 + graph.getDegree(n2)));
+            for (Node n : nodes)
+            {
+                ForceVectorNodeLayoutData layoutData = n.getLayoutData();
+                layoutData.old_dx = layoutData.dx;
+                layoutData.old_dy = layoutData.dy;
+                layoutData.dx *= inertia;
+                layoutData.dy *= inertia;
+            }
+            // repulsion
+            if (isAdjustSizes())
+            {
+                for (Node n1 : nodes)
+                {
+                    for (Node n2 : nodes)
+                    {
+                        if (n1 != n2)
+                        {
+                            ForceVectorUtils.fcBiRepulsor_noCollide(n1, n2, getRepulsionStrength() * (1 + graph.getDegree(n1)) * (1 + graph.getDegree(n2)));
+                        }
                     }
                 }
             }
-        } else {
-            for (Node n1 : nodes) {
-                for (Node n2 : nodes) {
-                    if (n1 != n2) {
-                        ForceVectorUtils.fcBiRepulsor(n1, n2, getRepulsionStrength() * (1 + graph.getDegree(n1)) * (1 + graph.getDegree(n2)));
+            else
+            {
+                for (Node n1 : nodes)
+                {
+                    for (Node n2 : nodes)
+                    {
+                        if (n1 != n2)
+                        {
+                            ForceVectorUtils.fcBiRepulsor(n1, n2, getRepulsionStrength() * (1 + graph.getDegree(n1)) * (1 + graph.getDegree(n2)));
+                        }
                     }
                 }
             }
-        }
-        // attraction
-        if (isAdjustSizes()) {
-            if (isOutboundAttractionDistribution()) {
-                for (Edge e : edges) {
-                    Node nf = e.getSource();
-                    Node nt = e.getTarget();
-                    double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                    bonus *= e.getWeight();
-                    ForceVectorUtils.fcBiAttractor_noCollide(nf, nt, bonus * getAttractionStrength() / (1 + graph.getDegree(nf)));
+            // attraction
+            if (isAdjustSizes())
+            {
+                if (isOutboundAttractionDistribution())
+                {
+                    for (Edge e : edges)
+                    {
+                        Node nf = e.getSource();
+                        Node nt = e.getTarget();
+                        double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
+                        bonus *= e.getWeight();
+                        ForceVectorUtils.fcBiAttractor_noCollide(nf, nt, bonus * getAttractionStrength() / (1 + graph.getDegree(nf)));
+                    }
                 }
-            } else {
-                for (Edge e : edges) {
-                    Node nf = e.getSource();
-                    Node nt = e.getTarget();
-                    double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                    bonus *= e.getWeight();
-                    ForceVectorUtils.fcBiAttractor_noCollide(nf, nt, bonus * getAttractionStrength());
-                }
-            }
-        } else {
-            if (isOutboundAttractionDistribution()) {
-                for (Edge e : edges) {
-                    Node nf = e.getSource();
-                    Node nt = e.getTarget();
-                    double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                    bonus *= e.getWeight();
-                    ForceVectorUtils.fcBiAttractor(nf, nt, bonus * getAttractionStrength() / (1 + graph.getDegree(nf)));
-                }
-            } else {
-                for (Edge e : edges) {
-                    Node nf = e.getSource();
-                    Node nt = e.getTarget();
-                    double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                    bonus *= e.getWeight();
-                    ForceVectorUtils.fcBiAttractor(nf, nt, bonus * getAttractionStrength());
+                else
+                {
+                    for (Edge e : edges)
+                    {
+                        Node nf = e.getSource();
+                        Node nt = e.getTarget();
+                        double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
+                        bonus *= e.getWeight();
+                        ForceVectorUtils.fcBiAttractor_noCollide(nf, nt, bonus * getAttractionStrength());
+                    }
                 }
             }
-        }
-        // gravity
-        for (Node n : nodes) {
+            else
+            {
+                if (isOutboundAttractionDistribution())
+                {
+                    for (Edge e : edges)
+                    {
+                        Node nf = e.getSource();
+                        Node nt = e.getTarget();
+                        double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
+                        bonus *= e.getWeight();
+                        ForceVectorUtils.fcBiAttractor(nf, nt, bonus * getAttractionStrength() / (1 + graph.getDegree(nf)));
+                    }
+                }
+                else
+                {
+                    for (Edge e : edges)
+                    {
+                        Node nf = e.getSource();
+                        Node nt = e.getTarget();
+                        double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
+                        bonus *= e.getWeight();
+                        ForceVectorUtils.fcBiAttractor(nf, nt, bonus * getAttractionStrength());
+                    }
+                }
+            }
+            // gravity
+            for (Node n : nodes)
+            {
 
-            float nx = n.x();
-            float ny = n.y();
-            double d = 0.0001 + Math.sqrt(nx * nx + ny * ny);
-            double gf = 0.0001 * getGravity() * d;
-            ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-            layoutData.dx -= gf * nx / d;
-            layoutData.dy -= gf * ny / d;
-        }
-        // speed
-        if (isFreezeBalance()) {
-            for (Node n : nodes) {
+                float nx = n.x();
+                float ny = n.y();
+                double d = 0.0001 + Math.sqrt(nx * nx + ny * ny);
+                double gf = 0.0001 * getGravity() * d;
                 ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-                layoutData.dx *= getSpeed() * 10f;
-                layoutData.dy *= getSpeed() * 10f;
+                layoutData.dx -= gf * nx / d;
+                layoutData.dy -= gf * ny / d;
             }
-        } else {
-            for (Node n : nodes) {
-                ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-                layoutData.dx *= getSpeed();
-                layoutData.dy *= getSpeed();
-            }
-        }
-        // apply forces
-        for (Node n : nodes) {
-            ForceVectorNodeLayoutData nLayout = n.getLayoutData();
-            if (!n.isFixed()) {
-                double d = 0.0001 + Math.sqrt(nLayout.dx * nLayout.dx + nLayout.dy * nLayout.dy);
-                float ratio;
-                if (isFreezeBalance()) {
-                    nLayout.freeze = (float) (getFreezeInertia() * nLayout.freeze + (1 - getFreezeInertia()) * 0.1 * getFreezeStrength() * (Math.sqrt(Math.sqrt((nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) + (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy)))));
-                    ratio = (float) Math.min((d / (d * (1f + nLayout.freeze))), getMaxDisplacement() / d);
-                } else {
-                    ratio = (float) Math.min(1, getMaxDisplacement() / d);
+            // speed
+            if (isFreezeBalance())
+            {
+                for (Node n : nodes)
+                {
+                    ForceVectorNodeLayoutData layoutData = n.getLayoutData();
+                    layoutData.dx *= getSpeed() * 10f;
+                    layoutData.dy *= getSpeed() * 10f;
                 }
-                nLayout.dx *= ratio / getCooling();
-                nLayout.dy *= ratio / getCooling();
-                float x = n.x() + nLayout.dx;
-                float y = n.y() + nLayout.dy;
-
-                n.setX(x);
-                n.setY(y);
             }
+            else
+            {
+                for (Node n : nodes)
+                {
+                    ForceVectorNodeLayoutData layoutData = n.getLayoutData();
+                    layoutData.dx *= getSpeed();
+                    layoutData.dy *= getSpeed();
+                }
+            }
+            // apply forces
+            for (Node n : nodes)
+            {
+                ForceVectorNodeLayoutData nLayout = n.getLayoutData();
+                if (!n.isFixed())
+                {
+                    double d = 0.0001 + Math.sqrt(nLayout.dx * nLayout.dx + nLayout.dy * nLayout.dy);
+                    float ratio;
+                    if (isFreezeBalance())
+                    {
+                        nLayout.freeze = (float) (getFreezeInertia() * nLayout.freeze + (1 - getFreezeInertia()) * 0.1 * getFreezeStrength() * (Math.sqrt(Math.sqrt((nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) + (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy)))));
+                        ratio = (float) Math.min((d / (d * (1f + nLayout.freeze))), getMaxDisplacement() / d);
+                    }
+                    else
+                    {
+                        ratio = (float) Math.min(1, getMaxDisplacement() / d);
+                    }
+                    nLayout.dx *= ratio / getCooling();
+                    nLayout.dy *= ratio / getCooling();
+                    float x = n.x() + nLayout.dx;
+                    float y = n.y() + nLayout.dy;
+
+                    n.setX(x);
+                    n.setY(y);
+                }
+            }
+        } finally {
+            graph.readUnlock();
         }
-        graph.readUnlock();
     }
 
     @Override
     public void endAlgo() {
-        for (Node n : graph.getNodes()) {
-            n.setLayoutData(null);
+        graph.readLock();
+        try
+        {
+            for (Node n : graph.getNodes())
+            {
+                n.setLayoutData(null);
+            }
+        } finally {
+            graph.readUnlock();
         }
     }
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
@@ -41,12 +41,6 @@
  */
 package org.gephi.layout.plugin.forceAtlas2;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphModel;
@@ -56,8 +50,13 @@ import org.gephi.layout.plugin.forceAtlas2.ForceFactory.RepulsionForce;
 import org.gephi.layout.spi.Layout;
 import org.gephi.layout.spi.LayoutBuilder;
 import org.gephi.layout.spi.LayoutProperty;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * ForceAtlas 2 Layout, manages each step of the computations.
@@ -100,24 +99,31 @@ public class ForceAtlas2 implements Layout {
         graph = graphModel.getGraphVisible();
 
         graph.readLock();
-        Node[] nodes = graph.getNodes().toArray();
+        try
+        {
+            Node[] nodes = graph.getNodes().toArray();
 
-        // Initialise layout data
-        for (Node n : nodes) {
-            if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceAtlas2LayoutData)) {
-                ForceAtlas2LayoutData nLayout = new ForceAtlas2LayoutData();
-                n.setLayoutData(nLayout);
+            // Initialise layout data
+            for (Node n : nodes)
+            {
+                if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceAtlas2LayoutData))
+                {
+                    ForceAtlas2LayoutData nLayout = new ForceAtlas2LayoutData();
+                    n.setLayoutData(nLayout);
+                }
+                ForceAtlas2LayoutData nLayout = n.getLayoutData();
+                nLayout.mass = 1 + graph.getDegree(n);
+                nLayout.old_dx = 0;
+                nLayout.old_dy = 0;
+                nLayout.dx = 0;
+                nLayout.dy = 0;
             }
-            ForceAtlas2LayoutData nLayout = n.getLayoutData();
-            nLayout.mass = 1 + graph.getDegree(n);
-            nLayout.old_dx = 0;
-            nLayout.old_dy = 0;
-            nLayout.dx = 0;
-            nLayout.dy = 0;
-        }
 
-        pool = Executors.newFixedThreadPool(threadCount);
-        currentThreadCount = threadCount;
+            pool = Executors.newFixedThreadPool(threadCount);
+            currentThreadCount = threadCount;
+        } finally {
+            graph.readUnlock();
+        }
     }
 
     @Override
@@ -129,166 +135,201 @@ public class ForceAtlas2 implements Layout {
         graph = graphModel.getGraphVisible();
 
         graph.readLock();
-        Node[] nodes = graph.getNodes().toArray();
-        Edge[] edges = graph.getEdges().toArray();
+        try
+        {
+            Node[] nodes = graph.getNodes().toArray();
+            Edge[] edges = graph.getEdges().toArray();
 
-        // Initialise layout data
-        for (Node n : nodes) {
-            if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceAtlas2LayoutData)) {
-                ForceAtlas2LayoutData nLayout = new ForceAtlas2LayoutData();
-                n.setLayoutData(nLayout);
-            }
-            ForceAtlas2LayoutData nLayout = n.getLayoutData();
-            nLayout.mass = 1 + graph.getDegree(n);
-            nLayout.old_dx = nLayout.dx;
-            nLayout.old_dy = nLayout.dy;
-            nLayout.dx = 0;
-            nLayout.dy = 0;
-        }
-
-        // If Barnes Hut active, initialize root region
-        if (isBarnesHutOptimize()) {
-            rootRegion = new Region(nodes);
-            rootRegion.buildSubRegions();
-        }
-
-        // If outboundAttractionDistribution active, compensate.
-        if (isOutboundAttractionDistribution()) {
-            outboundAttCompensation = 0;
-            for (Node n : nodes) {
+            // Initialise layout data
+            for (Node n : nodes)
+            {
+                if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceAtlas2LayoutData))
+                {
+                    ForceAtlas2LayoutData nLayout = new ForceAtlas2LayoutData();
+                    n.setLayoutData(nLayout);
+                }
                 ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                outboundAttCompensation += nLayout.mass;
+                nLayout.mass = 1 + graph.getDegree(n);
+                nLayout.old_dx = nLayout.dx;
+                nLayout.old_dy = nLayout.dy;
+                nLayout.dx = 0;
+                nLayout.dy = 0;
             }
-            outboundAttCompensation /= nodes.length;
-        }
 
-        // Repulsion (and gravity)
-        // NB: Muti-threaded
-        RepulsionForce Repulsion = ForceFactory.builder.buildRepulsion(isAdjustSizes(), getScalingRatio());
-
-        int taskCount = 8 * currentThreadCount;  // The threadPool Executor Service will manage the fetching of tasks and threads.
-        // We make more tasks than threads because some tasks may need more time to compute.
-        ArrayList<Future> threads = new ArrayList();
-        for (int t = taskCount; t > 0; t--) {
-            int from = (int) Math.floor(nodes.length * (t - 1) / taskCount);
-            int to = (int) Math.floor(nodes.length * t / taskCount);
-            Future future = pool.submit(new NodesThread(nodes, from, to, isBarnesHutOptimize(), getBarnesHutTheta(), getGravity(), (isStrongGravityMode()) ? (ForceFactory.builder.getStrongGravity(getScalingRatio())) : (Repulsion), getScalingRatio(), rootRegion, Repulsion));
-            threads.add(future);
-        }
-        for (Future future : threads) {
-            try {
-                future.get();
-            } catch (InterruptedException ex) {
-                Exceptions.printStackTrace(ex);
-            } catch (ExecutionException ex) {
-                Exceptions.printStackTrace(ex);
+            // If Barnes Hut active, initialize root region
+            if (isBarnesHutOptimize())
+            {
+                rootRegion = new Region(nodes);
+                rootRegion.buildSubRegions();
             }
-        }
 
-        // Attraction
-        AttractionForce Attraction = ForceFactory.builder.buildAttraction(isLinLogMode(), isOutboundAttractionDistribution(), isAdjustSizes(), 1 * ((isOutboundAttractionDistribution()) ? (outboundAttCompensation) : (1)));
-        if (getEdgeWeightInfluence() == 0) {
-            for (Edge e : edges) {
-                Attraction.apply(e.getSource(), e.getTarget(), 1);
+            // If outboundAttractionDistribution active, compensate.
+            if (isOutboundAttractionDistribution())
+            {
+                outboundAttCompensation = 0;
+                for (Node n : nodes)
+                {
+                    ForceAtlas2LayoutData nLayout = n.getLayoutData();
+                    outboundAttCompensation += nLayout.mass;
+                }
+                outboundAttCompensation /= nodes.length;
             }
-        } else if (getEdgeWeightInfluence() == 1) {
-            for (Edge e : edges) {
-                Attraction.apply(e.getSource(), e.getTarget(), e.getWeight());
+
+            // Repulsion (and gravity)
+            // NB: Muti-threaded
+            RepulsionForce Repulsion = ForceFactory.builder.buildRepulsion(isAdjustSizes(), getScalingRatio());
+
+            int taskCount = 8 * currentThreadCount;  // The threadPool Executor Service will manage the fetching of tasks and threads.
+            // We make more tasks than threads because some tasks may need more time to compute.
+            ArrayList<Future> threads = new ArrayList();
+            for (int t = taskCount; t > 0; t--)
+            {
+                int from = (int) Math.floor(nodes.length * (t - 1) / taskCount);
+                int to = (int) Math.floor(nodes.length * t / taskCount);
+                Future future = pool.submit(new NodesThread(nodes, from, to, isBarnesHutOptimize(), getBarnesHutTheta(), getGravity(), (isStrongGravityMode()) ? (ForceFactory.builder.getStrongGravity(getScalingRatio())) : (Repulsion), getScalingRatio(), rootRegion, Repulsion));
+                threads.add(future);
             }
-        } else {
-            for (Edge e : edges) {
-                Attraction.apply(e.getSource(), e.getTarget(), Math.pow(e.getWeight(), getEdgeWeightInfluence()));
-            }
-        }
-
-        // Auto adjust speed
-        double totalSwinging = 0d;  // How much irregular movement
-        double totalEffectiveTraction = 0d;  // Hom much useful movement
-        for (Node n : nodes) {
-            ForceAtlas2LayoutData nLayout = n.getLayoutData();
-            if (!n.isFixed()) {
-                double swinging = Math.sqrt(Math.pow(nLayout.old_dx - nLayout.dx, 2) + Math.pow(nLayout.old_dy - nLayout.dy, 2));
-                totalSwinging += nLayout.mass * swinging;   // If the node has a burst change of direction, then it's not converging.
-                totalEffectiveTraction += nLayout.mass * 0.5 * Math.sqrt(Math.pow(nLayout.old_dx + nLayout.dx, 2) + Math.pow(nLayout.old_dy + nLayout.dy, 2));
-            }
-        }
-        // We want that swingingMovement < tolerance * convergenceMovement
-
-        // Optimize jitter tolerance
-        // The 'right' jitter tolerance for this network. Bigger networks need more tolerance. Denser networks need less tolerance. Totally empiric.
-        double estimatedOptimalJitterTolerance = 0.05 * Math.sqrt(nodes.length);
-        double minJT = Math.sqrt(estimatedOptimalJitterTolerance);
-        double maxJT = 10;
-        double jt = jitterTolerance * Math.max(minJT, Math.min(maxJT, estimatedOptimalJitterTolerance * totalEffectiveTraction / Math.pow(nodes.length, 2)));
-
-        double minSpeedEfficiency = 0.05;
-
-        // Protection against erratic behavior
-        if (totalSwinging / totalEffectiveTraction > 2.0) {
-            if (speedEfficiency > minSpeedEfficiency) {
-                speedEfficiency *= 0.5;
-            }
-            jt = Math.max(jt, jitterTolerance);
-        }
-
-        double targetSpeed = jt * speedEfficiency * totalEffectiveTraction / totalSwinging;
-
-        // Speed efficiency is how the speed really corresponds to the swinging vs. convergence tradeoff
-        // We adjust it slowly and carefully
-        if (totalSwinging > jt * totalEffectiveTraction) {
-            if (speedEfficiency > minSpeedEfficiency) {
-                speedEfficiency *= 0.7;
-            }
-        } else if (speed < 1000) {
-            speedEfficiency *= 1.3;
-        }
-
-        // But the speed shoudn't rise too much too quickly, since it would make the convergence drop dramatically.
-        double maxRise = 0.5;   // Max rise: 50%
-        speed = speed + Math.min(targetSpeed - speed, maxRise * speed);
-
-        // Apply forces
-        if (isAdjustSizes()) {
-            // If nodes overlap prevention is active, it's not possible to trust the swinging mesure.
-            for (Node n : nodes) {
-                ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                if (!n.isFixed()) {
-
-                    // Adaptive auto-speed: the speed of each node is lowered
-                    // when the node swings.
-                    double swinging = nLayout.mass * Math.sqrt((nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) + (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy));
-                    double factor = 0.1 * speed / (1f + Math.sqrt(speed * swinging));
-
-                    double df = Math.sqrt(Math.pow(nLayout.dx, 2) + Math.pow(nLayout.dy, 2));
-                    factor = Math.min(factor * df, 10.) / df;
-
-                    double x = n.x() + nLayout.dx * factor;
-                    double y = n.y() + nLayout.dy * factor;
-
-                    n.setX((float) x);
-                    n.setY((float) y);
+            for (Future future : threads)
+            {
+                try
+                {
+                    future.get();
+                }
+                catch (Exception e)
+                {
+                    throw new RuntimeException("Unable to layout " + this.getClass().getSimpleName() + ".", e);
                 }
             }
-        } else {
-            for (Node n : nodes) {
-                ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                if (!n.isFixed()) {
 
-                    // Adaptive auto-speed: the speed of each node is lowered
-                    // when the node swings.
-                    double swinging = nLayout.mass * Math.sqrt((nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) + (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy));
-                    //double factor = speed / (1f + Math.sqrt(speed * swinging));
-                    double factor = speed / (1f + Math.sqrt(speed * swinging));
-
-                    double x = n.x() + nLayout.dx * factor;
-                    double y = n.y() + nLayout.dy * factor;
-
-                    n.setX((float) x);
-                    n.setY((float) y);
+            // Attraction
+            AttractionForce Attraction = ForceFactory.builder.buildAttraction(isLinLogMode(), isOutboundAttractionDistribution(), isAdjustSizes(), 1 * ((isOutboundAttractionDistribution()) ? (outboundAttCompensation) : (1)));
+            if (getEdgeWeightInfluence() == 0)
+            {
+                for (Edge e : edges)
+                {
+                    Attraction.apply(e.getSource(), e.getTarget(), 1);
                 }
             }
+            else if (getEdgeWeightInfluence() == 1)
+            {
+                for (Edge e : edges)
+                {
+                    Attraction.apply(e.getSource(), e.getTarget(), e.getWeight());
+                }
+            }
+            else
+            {
+                for (Edge e : edges)
+                {
+                    Attraction.apply(e.getSource(), e.getTarget(), Math.pow(e.getWeight(), getEdgeWeightInfluence()));
+                }
+            }
+
+            // Auto adjust speed
+            double totalSwinging = 0d;  // How much irregular movement
+            double totalEffectiveTraction = 0d;  // Hom much useful movement
+            for (Node n : nodes)
+            {
+                ForceAtlas2LayoutData nLayout = n.getLayoutData();
+                if (!n.isFixed())
+                {
+                    double swinging = Math.sqrt(Math.pow(nLayout.old_dx - nLayout.dx, 2) + Math.pow(nLayout.old_dy - nLayout.dy, 2));
+                    totalSwinging += nLayout.mass * swinging;   // If the node has a burst change of direction, then it's not converging.
+                    totalEffectiveTraction += nLayout.mass * 0.5 * Math.sqrt(Math.pow(nLayout.old_dx + nLayout.dx, 2) + Math.pow(nLayout.old_dy + nLayout.dy, 2));
+                }
+            }
+            // We want that swingingMovement < tolerance * convergenceMovement
+
+            // Optimize jitter tolerance
+            // The 'right' jitter tolerance for this network. Bigger networks need more tolerance. Denser networks need less tolerance. Totally empiric.
+            double estimatedOptimalJitterTolerance = 0.05 * Math.sqrt(nodes.length);
+            double minJT = Math.sqrt(estimatedOptimalJitterTolerance);
+            double maxJT = 10;
+            double jt = jitterTolerance * Math.max(minJT, Math.min(maxJT, estimatedOptimalJitterTolerance * totalEffectiveTraction / Math.pow(nodes.length, 2)));
+
+            double minSpeedEfficiency = 0.05;
+
+            // Protection against erratic behavior
+            if (totalSwinging / totalEffectiveTraction > 2.0)
+            {
+                if (speedEfficiency > minSpeedEfficiency)
+                {
+                    speedEfficiency *= 0.5;
+                }
+                jt = Math.max(jt, jitterTolerance);
+            }
+
+            double targetSpeed = jt * speedEfficiency * totalEffectiveTraction / totalSwinging;
+
+            // Speed efficiency is how the speed really corresponds to the swinging vs. convergence tradeoff
+            // We adjust it slowly and carefully
+            if (totalSwinging > jt * totalEffectiveTraction)
+            {
+                if (speedEfficiency > minSpeedEfficiency)
+                {
+                    speedEfficiency *= 0.7;
+                }
+            }
+            else if (speed < 1000)
+            {
+                speedEfficiency *= 1.3;
+            }
+
+            // But the speed shoudn't rise too much too quickly, since it would make the convergence drop dramatically.
+            double maxRise = 0.5;   // Max rise: 50%
+            speed = speed + Math.min(targetSpeed - speed, maxRise * speed);
+
+            // Apply forces
+            if (isAdjustSizes())
+            {
+                // If nodes overlap prevention is active, it's not possible to trust the swinging mesure.
+                for (Node n : nodes)
+                {
+                    ForceAtlas2LayoutData nLayout = n.getLayoutData();
+                    if (!n.isFixed())
+                    {
+
+                        // Adaptive auto-speed: the speed of each node is lowered
+                        // when the node swings.
+                        double swinging = nLayout.mass * Math.sqrt((nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) + (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy));
+                        double factor = 0.1 * speed / (1f + Math.sqrt(speed * swinging));
+
+                        double df = Math.sqrt(Math.pow(nLayout.dx, 2) + Math.pow(nLayout.dy, 2));
+                        factor = Math.min(factor * df, 10.) / df;
+
+                        double x = n.x() + nLayout.dx * factor;
+                        double y = n.y() + nLayout.dy * factor;
+
+                        n.setX((float) x);
+                        n.setY((float) y);
+                    }
+                }
+            }
+            else
+            {
+                for (Node n : nodes)
+                {
+                    ForceAtlas2LayoutData nLayout = n.getLayoutData();
+                    if (!n.isFixed())
+                    {
+
+                        // Adaptive auto-speed: the speed of each node is lowered
+                        // when the node swings.
+                        double swinging = nLayout.mass * Math.sqrt((nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) + (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy));
+                        //double factor = speed / (1f + Math.sqrt(speed * swinging));
+                        double factor = speed / (1f + Math.sqrt(speed * swinging));
+
+                        double x = n.x() + nLayout.dx * factor;
+                        double y = n.y() + nLayout.dy * factor;
+
+                        n.setX((float) x);
+                        n.setY((float) y);
+                    }
+                }
+            }
+        } finally {
+            graph.readUnlock();
         }
-        graph.readUnlockAll();
     }
 
     @Override
@@ -298,11 +339,17 @@ public class ForceAtlas2 implements Layout {
 
     @Override
     public void endAlgo() {
-        for (Node n : graph.getNodes()) {
-            n.setLayoutData(null);
+        graph.readLock();
+        try
+        {
+            for (Node n : graph.getNodes())
+            {
+                n.setLayoutData(null);
+            }
+            pool.shutdown();
+        } finally {
+            graph.readUnlock();
         }
-        pool.shutdown();
-        graph.readUnlockAll();
     }
 
     @Override

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/fruchterman/FruchtermanReingold.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/fruchterman/FruchtermanReingold.java
@@ -41,8 +41,6 @@
  */
 package org.gephi.layout.plugin.fruchterman;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.Node;
@@ -52,6 +50,9 @@ import org.gephi.layout.spi.Layout;
 import org.gephi.layout.spi.LayoutBuilder;
 import org.gephi.layout.spi.LayoutProperty;
 import org.openide.util.NbBundle;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -87,92 +88,115 @@ public class FruchtermanReingold extends AbstractLayout implements Layout {
     public void goAlgo() {
         this.graph = graphModel.getGraphVisible();
         graph.readLock();
-        Node[] nodes = graph.getNodes().toArray();
-        Edge[] edges = graph.getEdges().toArray();
+        try
+        {
+            Node[] nodes = graph.getNodes().toArray();
+            Edge[] edges = graph.getEdges().toArray();
 
-        for (Node n : nodes) {
-            if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceVectorNodeLayoutData)) {
-                n.setLayoutData(new ForceVectorNodeLayoutData());
+            for (Node n : nodes)
+            {
+                if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceVectorNodeLayoutData))
+                {
+                    n.setLayoutData(new ForceVectorNodeLayoutData());
+                }
+                ForceVectorNodeLayoutData layoutData = n.getLayoutData();
+                layoutData.dx = 0;
+                layoutData.dy = 0;
             }
-            ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-            layoutData.dx = 0;
-            layoutData.dy = 0;
-        }
 
-        float maxDisplace = (float) (Math.sqrt(AREA_MULTIPLICATOR * area) / 10f);					// Déplacement limite : on peut le calibrer...
-        float k = (float) Math.sqrt((AREA_MULTIPLICATOR * area) / (1f + nodes.length));		// La variable k, l'idée principale du layout.
+            float maxDisplace = (float) (Math.sqrt(AREA_MULTIPLICATOR * area) / 10f);                    // Déplacement limite : on peut le calibrer...
+            float k = (float) Math.sqrt((AREA_MULTIPLICATOR * area) / (1f + nodes.length));        // La variable k, l'idée principale du layout.
 
-        for (Node N1 : nodes) {
-            for (Node N2 : nodes) {	// On fait toutes les paires de noeuds
-                if (N1 != N2) {
-                    float xDist = N1.x() - N2.x();	// distance en x entre les deux noeuds
-                    float yDist = N1.y() - N2.y();
-                    float dist = (float) Math.sqrt(xDist * xDist + yDist * yDist);	// distance tout court
+            for (Node N1 : nodes)
+            {
+                for (Node N2 : nodes)
+                {    // On fait toutes les paires de noeuds
+                    if (N1 != N2)
+                    {
+                        float xDist = N1.x() - N2.x();    // distance en x entre les deux noeuds
+                        float yDist = N1.y() - N2.y();
+                        float dist = (float) Math.sqrt(xDist * xDist + yDist * yDist);    // distance tout court
 
-                    if (dist > 0) {
-                        float repulsiveF = k * k / dist;			// Force de répulsion
-                        ForceVectorNodeLayoutData layoutData = N1.getLayoutData();
-                        layoutData.dx += xDist / dist * repulsiveF;		// on l'applique...
-                        layoutData.dy += yDist / dist * repulsiveF;
+                        if (dist > 0)
+                        {
+                            float repulsiveF = k * k / dist;            // Force de répulsion
+                            ForceVectorNodeLayoutData layoutData = N1.getLayoutData();
+                            layoutData.dx += xDist / dist * repulsiveF;        // on l'applique...
+                            layoutData.dy += yDist / dist * repulsiveF;
+                        }
                     }
                 }
             }
-        }
-        for (Edge E : edges) {
-            // Idem, pour tous les noeuds on applique la force d'attraction
+            for (Edge E : edges)
+            {
+                // Idem, pour tous les noeuds on applique la force d'attraction
 
-            Node Nf = E.getSource();
-            Node Nt = E.getTarget();
+                Node Nf = E.getSource();
+                Node Nt = E.getTarget();
 
-            float xDist = Nf.x() - Nt.x();
-            float yDist = Nf.y() - Nt.y();
-            float dist = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+                float xDist = Nf.x() - Nt.x();
+                float yDist = Nf.y() - Nt.y();
+                float dist = (float) Math.sqrt(xDist * xDist + yDist * yDist);
 
-            float attractiveF = dist * dist / k;
+                float attractiveF = dist * dist / k;
 
-            if (dist > 0) {
-                ForceVectorNodeLayoutData sourceLayoutData = Nf.getLayoutData();
-                ForceVectorNodeLayoutData targetLayoutData = Nt.getLayoutData();
-                sourceLayoutData.dx -= xDist / dist * attractiveF;
-                sourceLayoutData.dy -= yDist / dist * attractiveF;
-                targetLayoutData.dx += xDist / dist * attractiveF;
-                targetLayoutData.dy += yDist / dist * attractiveF;
+                if (dist > 0)
+                {
+                    ForceVectorNodeLayoutData sourceLayoutData = Nf.getLayoutData();
+                    ForceVectorNodeLayoutData targetLayoutData = Nt.getLayoutData();
+                    sourceLayoutData.dx -= xDist / dist * attractiveF;
+                    sourceLayoutData.dy -= yDist / dist * attractiveF;
+                    targetLayoutData.dx += xDist / dist * attractiveF;
+                    targetLayoutData.dy += yDist / dist * attractiveF;
+                }
             }
-        }
-        // gravity
-        for (Node n : nodes) {
-            ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-            float d = (float) Math.sqrt(n.x() * n.x() + n.y() * n.y());
-            float gf = 0.01f * k * (float) gravity * d;
-            layoutData.dx -= gf * n.x() / d;
-            layoutData.dy -= gf * n.y() / d;
-        }
-        // speed
-        for (Node n : nodes) {
-            ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-            layoutData.dx *= speed / SPEED_DIVISOR;
-            layoutData.dy *= speed / SPEED_DIVISOR;
-        }
-        for (Node n : nodes) {
-            // Maintenant on applique le déplacement calculé sur les noeuds.
-            // nb : le déplacement à chaque passe "instantanné" correspond à la force : c'est une sorte d'accélération.
-            ForceVectorNodeLayoutData layoutData = n.getLayoutData();
-            float xDist = layoutData.dx;
-            float yDist = layoutData.dy;
-            float dist = (float) Math.sqrt(layoutData.dx * layoutData.dx + layoutData.dy * layoutData.dy);
-            if (dist > 0 && !n.isFixed()) {
-                float limitedDist = Math.min(maxDisplace * ((float) speed / SPEED_DIVISOR), dist);
-                n.setX(n.x() + xDist / dist * limitedDist);
-                n.setY(n.y() + yDist / dist * limitedDist);
+            // gravity
+            for (Node n : nodes)
+            {
+                ForceVectorNodeLayoutData layoutData = n.getLayoutData();
+                float d = (float) Math.sqrt(n.x() * n.x() + n.y() * n.y());
+                float gf = 0.01f * k * (float) gravity * d;
+                layoutData.dx -= gf * n.x() / d;
+                layoutData.dy -= gf * n.y() / d;
             }
+            // speed
+            for (Node n : nodes)
+            {
+                ForceVectorNodeLayoutData layoutData = n.getLayoutData();
+                layoutData.dx *= speed / SPEED_DIVISOR;
+                layoutData.dy *= speed / SPEED_DIVISOR;
+            }
+            for (Node n : nodes)
+            {
+                // Maintenant on applique le déplacement calculé sur les noeuds.
+                // nb : le déplacement à chaque passe "instantanné" correspond à la force : c'est une sorte d'accélération.
+                ForceVectorNodeLayoutData layoutData = n.getLayoutData();
+                float xDist = layoutData.dx;
+                float yDist = layoutData.dy;
+                float dist = (float) Math.sqrt(layoutData.dx * layoutData.dx + layoutData.dy * layoutData.dy);
+                if (dist > 0 && !n.isFixed())
+                {
+                    float limitedDist = Math.min(maxDisplace * ((float) speed / SPEED_DIVISOR), dist);
+                    n.setX(n.x() + xDist / dist * limitedDist);
+                    n.setY(n.y() + yDist / dist * limitedDist);
+                }
+            }
+        } finally {
+            graph.readUnlock();
         }
-        graph.readUnlock();
     }
 
     @Override
     public void endAlgo() {
-        for (Node n : graph.getNodes()) {
-            n.setLayoutData(null);
+        graph.readLock();
+        try
+        {
+            for (Node n : graph.getNodes())
+            {
+                n.setLayoutData(null);
+            }
+        } finally {
+            graph.readUnlock();
         }
     }
 


### PR DESCRIPTION
Graph layouts use graph read locks without proper try-catch logic as per the jdk documentation.  When the layouts generate a runtime exception the result leaves the graph in a locked state, which then blocks all access threads (including swing/javafx).
