### PR TITLE
Negative Weight Support Added

### DIFF
--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas/ForceAtlasLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas/ForceAtlasLayout.java
@@ -41,6 +41,10 @@
  */
 package org.gephi.layout.plugin.forceAtlas;
 
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import static java.sql.DriverManager.println;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.Node;
@@ -103,12 +107,32 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
     public void initAlgo() {
     }
 
-    private double getEdgeWeight(Edge edge, boolean isDynamicWeight, Interval interval) {
+    private double getEdgeWeight(Edge edge, boolean isDynamicWeight, Interval interval, double minWeight) {
         if (isDynamicWeight) {
-            return edge.getWeight(interval);
+            return edge.getWeight(interval)-(minWeight - 1);
         } else {
-            return edge.getWeight();
+            return edge.getWeight() -(minWeight - 1);
         }
+    }
+    
+    
+    private double getMinWeight(Edge[] edges) {
+        
+        double minWeight = 999999;
+         for(Edge e : edges){
+            if(minWeight > e.getWeight())
+            {
+                minWeight = e.getWeight();
+            }
+
+        }
+         
+        //Negative Check
+        if(minWeight > 0)
+            minWeight = 0;
+        
+        return minWeight;
+   
     }
 
     @Override
@@ -118,10 +142,12 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
         boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
         Interval interval = graph.getView().getTimeInterval();
 
+        
+
         try {
             Node[] nodes = graph.getNodes().toArray();
             Edge[] edges = graph.getEdges().toArray();
-
+ 
             for (Node n : nodes) {
                 if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceVectorNodeLayoutData)) {
                     n.setLayoutData(new ForceVectorNodeLayoutData());
@@ -154,21 +180,44 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
                 }
             }
             // attraction
+            
+            double minWeight = getMinWeight(edges);
+
+            
             if (isAdjustSizes()) {
                 if (isOutboundAttractionDistribution()) {
+                    
+                    
+                    
+                    //FileOutputStream out = new FileOutputStream("/Users/astray/Desktop/file.txt");
+                    //String data = "";
+                
+                 
+                    
                     for (Edge e : edges) {
                         Node nf = e.getSource();
                         Node nt = e.getTarget();
                         double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                        bonus *= getEdgeWeight(e, isDynamicWeight, interval);
+                        bonus *= getEdgeWeight(e, isDynamicWeight, interval, minWeight);
+                        
+                        //data +=  "Edge: "+e.getId().toString()+ " Weight: "+bonus+"\n";
+                        
+                    
+                        
                         ForceVectorUtils.fcBiAttractor_noCollide(nf, nt, bonus * getAttractionStrength() / (1 + graph.getDegree(nf)));
                     }
+
+                    //byte[] b = data.getBytes();
+                    //out.write(b);                    
+                    //out.close();
+                    
                 } else {
                     for (Edge e : edges) {
                         Node nf = e.getSource();
                         Node nt = e.getTarget();
                         double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                        bonus *= getEdgeWeight(e, isDynamicWeight, interval);
+                        //ADD HERE
+                        bonus *= getEdgeWeight(e, isDynamicWeight, interval, minWeight);
                         ForceVectorUtils.fcBiAttractor_noCollide(nf, nt, bonus * getAttractionStrength());
                     }
                 }
@@ -178,7 +227,7 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
                         Node nf = e.getSource();
                         Node nt = e.getTarget();
                         double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                        bonus *= getEdgeWeight(e, isDynamicWeight, interval);
+                        bonus *= getEdgeWeight(e, isDynamicWeight, interval, minWeight);
                         ForceVectorUtils.fcBiAttractor(nf, nt, bonus * getAttractionStrength() / (1 + graph.getDegree(nf)));
                     }
                 } else {
@@ -186,7 +235,7 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
                         Node nf = e.getSource();
                         Node nt = e.getTarget();
                         double bonus = (nf.isFixed() || nt.isFixed()) ? (100) : (1);
-                        bonus *= getEdgeWeight(e, isDynamicWeight, interval);
+                        bonus *= getEdgeWeight(e, isDynamicWeight, interval, minWeight);
                         ForceVectorUtils.fcBiAttractor(nf, nt, bonus * getAttractionStrength());
                     }
                 }
@@ -237,6 +286,7 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
                     n.setY(y);
                 }
             }
+
         } finally {
             graph.readUnlockAll();
         }

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
@@ -92,6 +92,25 @@ public class ForceAtlas2 implements Layout {
         this.layoutBuilder = layoutBuilder;
         this.threadCount = Math.min(4, Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
     }
+    
+        private double getMinWeight(Edge[] edges) {
+        
+        double minWeight = 999999;
+         for(Edge e : edges){
+            if(minWeight > e.getWeight())
+            {
+                minWeight = e.getWeight();
+            }
+
+        }
+         
+        //Negative Check
+        if(minWeight > 0)
+            minWeight = 0;
+        
+        return minWeight;
+   
+    }
 
     @Override
     public void initAlgo() {
@@ -125,11 +144,11 @@ public class ForceAtlas2 implements Layout {
         }
     }
     
-    private double getEdgeWeight(Edge edge, boolean isDynamicWeight, Interval interval) {
+    private double getEdgeWeight(Edge edge, boolean isDynamicWeight, Interval interval, double minWeight) {
         if (isDynamicWeight) {
-            return edge.getWeight(interval);
+            return edge.getWeight(interval)-(minWeight - 1);
         } else {
-            return edge.getWeight();
+            return edge.getWeight()-(minWeight - 1);
         }
     }
 
@@ -145,9 +164,13 @@ public class ForceAtlas2 implements Layout {
         boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
         Interval interval = graph.getView().getTimeInterval();
         
+
+        
         try {
             Node[] nodes = graph.getNodes().toArray();
             Edge[] edges = graph.getEdges().toArray();
+            double minWeight = getMinWeight(edges);
+
 
             // Initialise layout data
             for (Node n : nodes) {
@@ -208,11 +231,11 @@ public class ForceAtlas2 implements Layout {
                 }
             } else if (getEdgeWeightInfluence() == 1) {
                 for (Edge e : edges) {
-                    Attraction.apply(e.getSource(), e.getTarget(), getEdgeWeight(e, isDynamicWeight, interval));
+                    Attraction.apply(e.getSource(), e.getTarget(), getEdgeWeight(e, isDynamicWeight, interval, minWeight));
                 }
             } else {
                 for (Edge e : edges) {
-                    Attraction.apply(e.getSource(), e.getTarget(), Math.pow(getEdgeWeight(e, isDynamicWeight, interval), getEdgeWeightInfluence()));
+                    Attraction.apply(e.getSource(), e.getTarget(), Math.pow(getEdgeWeight(e, isDynamicWeight, interval, minWeight), getEdgeWeightInfluence()));
                 }
             }
 


### PR DESCRIPTION

Modified the ForceAtlas and ForceAtlas2 layouts so it supports negative weights.

The main idea is that if a negative weight is detected, we redefine the minimum edge value to 0, and apply the corresponding operations to maintain the graph’s data integrity.

Bug Reproduction:
[Youtube Link](https://youtu.be/IZNaEpLIPhA)
After Fix:
[Youtube Link](https://youtu.be/xw5BETS5U0o)




