### PR TITLE
MacOS build cleanup

### DIFF
--- a/modules/application/pom.xml
+++ b/modules/application/pom.xml
@@ -694,7 +694,7 @@
 
                                         <!-- Move bin/gephi script into MacOS/gephi and modify the script so it founds its resources -->
                                         <move file="${project.build.directory}/${gephi.appbundle.name}.app/Contents/Resources/${brandingToken}/bin/${brandingToken}" todir="${project.build.directory}/${gephi.appbundle.name}.app/Contents/MacOS"/>
-                                        <replace file="${project.build.directory}/${gephi.appbundle.name}.app/Contents/MacOS/${brandingToken}" token="`dirname &quot;$PRG&quot;`" value="`dirname &quot;$PRG&quot;`&quot;/../Resources/gephi/bin&quot;"/>
+                                        <replace file="${project.build.directory}/${gephi.appbundle.name}.app/Contents/MacOS/${brandingToken}" token="`dirname &quot;$PRG&quot;`" value="`dirname &quot;$PRG&quot;`&quot;/../Resources/${brandingToken}/bin&quot;"/>
                                         <chmod file="${project.build.directory}/${gephi.appbundle.name}.app/Contents/MacOS/${brandingToken}" perm="ugo+rx"/>
 
                                         <!-- Download and untar JRE -->
@@ -713,14 +713,14 @@
                                         <exec dir="${project.build.directory}" executable="tar">
                                             <arg line="-zxf"/>
                                             <arg line="${gephi.bundle.jre.version}.tar.gz"/>
-                                            <arg line="-C ${gephi.appbundle.name}.app/Contents/PlugIns"/>
+                                            <arg line="-C &quot;${gephi.appbundle.name}.app/Contents/PlugIns&quot;"/>
                                         </exec>
 
                                         <!-- Remove quarantine bit set recursively on JRE -->
                                         <exec dir="${project.build.directory}" os="Mac OS X" executable="xattr">
                                             <arg line="-rd"/>
                                             <arg line="com.apple.quarantine"/>
-                                            <arg line="${gephi.appbundle.name}.app/Contents/PlugIns"/>
+                                            <arg line="&quot;${gephi.appbundle.name}.app/Contents/PlugIns&quot;"/>
                                         </exec>
 
                                         <!-- Get the JRE folder name -->

--- a/modules/application/src/main/resources/Info.plist
+++ b/modules/application/src/main/resources/Info.plist
@@ -3,13 +3,13 @@
     <dict>
 
         <key>CFBundleName</key>
-        <string>Gephi</string>
+        <string>${gephi.appbundle.name}</string>
     
         <key>CFBundleVersion</key>
         <string>${project.version}</string>
     
         <key>CFBundleExecutable</key>
-        <string>gephi</string>
+        <string>${brandingToken}</string>
     
         <key>CFBundlePackageType</key>
         <string>APPL</string>
@@ -24,10 +24,10 @@
         <string>6.0</string>
     
         <key>CFBundleIdentifier</key>
-        <string>org.gephi</string>
+        <string>${project.groupId}</string>
     
         <key>CFBundleIconFile</key>
-        <string>gephi.icns</string>
+        <string>${brandingToken}.icns</string>
     
         <key>NSHighResolutionCapable</key> 
         <true/>

--- a/modules/application/src/main/resources/gephi.conf
+++ b/modules/application/src/main/resources/gephi.conf
@@ -4,7 +4,7 @@ default_mac_userdir="\${HOME}/Library/Application Support/\${APPNAME}/${project.
 
 # options used by the launcher by default, can be overridden by explicit
 # command line switches
-default_options="--branding gephi -J-Xms64m -J-Xmx512m -J-Xverify:none -J-Dsun.java2d.noddraw=true -J-Dsun.awt.noerasebackground=true -J-Dnetbeans.indexing.noFileRefresh=true -J-Dplugin.manager.check.interval=EVERY_DAY"
+default_options="--branding ${branding.token} -J-Xms64m -J-Xmx512m -J-Xverify:none -J-Dsun.java2d.noddraw=true -J-Dsun.awt.noerasebackground=true -J-Dnetbeans.indexing.noFileRefresh=true -J-Dplugin.manager.check.interval=EVERY_DAY"
 # for development purposes you may wish to append: -J-Dnetbeans.logger.console=true -J-ea
 
 # default location of JDK/JRE, can be overridden by using --jdkhome <dir> switch


### PR DESCRIPTION
I found this project while looking for OSS NetBeans Platform deployment examples and was really impressed by what you have. While migrating some of the Gephi build features into my application ([also OSS](https://github.com/winder/Universal-G-Code-Sender)) I made a couple minor improvements that you might like to include in the gephi project:

* Quotes to allow spaces in 'gephi.appbundle.name'
* Replace 'gephi' with '${brandingToken}' in a couple spots.
* Use more maven properties in Info.plist

Thanks for all the comments put into the POM files, it really made integrating similar patterns into my own project much simpler.

I'm also wondering if you would consider writing a blog post about the way your Netbeans Platform build infrastructure works? Gephi has some really nice deployment features that could be a really useful template for other Netbeans Platform developers.