### PR TITLE
Add unit tests for MathUtil, HTMLEscape, PrefsUtils and XMLChar

### DIFF
--- a/modules/Gleem/src/test/java/org/gephi/lib/gleem/linalg/MathUtilTest.java
+++ b/modules/Gleem/src/test/java/org/gephi/lib/gleem/linalg/MathUtilTest.java
@@ -1,0 +1,66 @@
+package org.gephi.lib.gleem.linalg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MathUtilTest {
+
+	@Test
+	public void testClamp() {
+		Assert.assertEquals(0, MathUtil.clamp(0, 0, 0));
+		Assert.assertEquals(0, MathUtil.clamp(1, 0, 0));
+		Assert.assertEquals(0.0f,
+			MathUtil.clamp(0.0f, 0.0f, 0.0f), 0.0f);
+		Assert.assertEquals(0.0f,
+			MathUtil.clamp(0x1p-149f, 0.0f, 0.0f), 0.0f);
+		Assert.assertEquals(-0.0f,
+			MathUtil.clamp(-0x1p-149f, -0.0f, -0.0f), 0.0f);
+		Assert.assertEquals(-2_013_331_714,
+			MathUtil.clamp(-2_030_108_929, -2_013_331_714, -2_030_108_930));
+	}
+
+	@Test
+	public void testMakePerpendicular1() {
+		Vec3f dest = new Vec3f(0.0f, 0.0f, 0.0f);
+
+		Assert.assertTrue(MathUtil.makePerpendicular(new Vec3f(-2.0f, Float.NaN, -0.0f), dest));
+
+		Assert.assertEquals(0.0f, dest.get(2), 0.0f);
+		Assert.assertEquals(Float.NaN, dest.get(0), 0.0f);
+		Assert.assertEquals(-2.0f, dest.get(1), 0.0f);
+	}
+
+	@Test
+	public void testMakePerpendicular2() {
+		Vec3f dest = new Vec3f(0.0f, 0.0f, 0.0f);
+
+		Assert.assertTrue(MathUtil.makePerpendicular(new Vec3f(-2.0f, 0.0f, -0.0f), dest));
+
+		Assert.assertEquals(-2.0f, dest.get(2), 0.0f);
+		Assert.assertEquals(0.0f, dest.get(0), 0.0f);
+		Assert.assertEquals(0.0f, dest.get(1), 0.0f);
+	}
+
+	@Test
+	public void testMakePerpendicular3() {
+		Vec3f dest = new Vec3f(0.0f, 0.0f, 0.0f);
+
+		Assert.assertTrue(MathUtil.makePerpendicular(new Vec3f(0.0f, 0.0f, -0x1p-149f), dest));
+
+		Assert.assertEquals(0.0f, dest.get(2), 0.0f);
+		Assert.assertEquals(1.0f, dest.get(0), 0.0f);
+		Assert.assertEquals(0.0f, dest.get(1), 0.0f);
+	}
+
+	@Test
+	public void testMakePerpendicular4() {
+		Assert.assertFalse(MathUtil.makePerpendicular(new Vec3f(0.0f, -0.0f, -0.0f), null));
+	}
+
+	@Test
+	public void testSgn() {
+		Assert.assertEquals(1, MathUtil.sgn(0x1.01p+0f));
+		Assert.assertEquals(0, MathUtil.sgn(0.0f));
+		Assert.assertEquals(-1, MathUtil.sgn(-0x1p-149f));
+	}
+}

--- a/modules/ProjectAPI/src/test/java/org/gephi/project/io/XMLCharTest.java
+++ b/modules/ProjectAPI/src/test/java/org/gephi/project/io/XMLCharTest.java
@@ -1,0 +1,14 @@
+package org.gephi.project.io;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XMLCharTest {
+
+	@Test
+	public void testIsValid() {
+		Assert.assertFalse(XMLChar.isValid(1_114_113));
+
+		Assert.assertTrue(XMLChar.isValid(1_048_577));
+	}
+}

--- a/modules/UIUtils/src/test/java/org/gephi/ui/utils/PrefsUtilsTest.java
+++ b/modules/UIUtils/src/test/java/org/gephi/ui/utils/PrefsUtilsTest.java
@@ -1,0 +1,19 @@
+package org.gephi.ui.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrefsUtilsTest {
+
+	@Test
+	public void testFloatArrayToString() {
+		Assert.assertEquals("1.0, 2.0, 3.0",
+			PrefsUtils.floatArrayToString(new float[] { 1.0f, 2.0f, 3.0f }));
+	}
+
+	@Test
+	public void testStringToFloatArray() {
+		Assert.assertArrayEquals(new float[] { 1.0f, 2.0f, 3.0f },
+			PrefsUtils.stringToFloatArray("1, 2, 3"), 0.0f);
+	}
+}

--- a/modules/Utils/src/test/java/org/gephi/utils/HTMLEscapeTest.java
+++ b/modules/Utils/src/test/java/org/gephi/utils/HTMLEscapeTest.java
@@ -1,0 +1,29 @@
+package org.gephi.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HTMLEscapeTest {
+
+	@Test
+	public void testStringToHTMLString() {
+		Assert.assertEquals("foo",
+			HTMLEscape.stringToHTMLString("foo"));
+		Assert.assertEquals("foo &nbsp;bar",
+			HTMLEscape.stringToHTMLString("foo  bar"));
+		Assert.assertEquals("&quot;foo&quot;",
+			HTMLEscape.stringToHTMLString("\"foo\""));
+		Assert.assertEquals("foo&amp;bar",
+			HTMLEscape.stringToHTMLString("foo&bar"));
+		Assert.assertEquals("foo&lt;bar",
+			HTMLEscape.stringToHTMLString("foo<bar"));
+		Assert.assertEquals("foo&gt;bar",
+			HTMLEscape.stringToHTMLString("foo>bar"));
+		Assert.assertEquals("foo<br>\nbar",
+			HTMLEscape.stringToHTMLString("foo\nbar"));
+		Assert.assertEquals("foobar",
+			HTMLEscape.stringToHTMLString("foo\rbar"));
+		Assert.assertEquals("&#233;",
+			HTMLEscape.stringToHTMLString("é"));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -800,6 +800,12 @@
             <version>${gephi.testng.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `org.gephi.lib.gleem.linalg.MathUtil`, `org.gephi.utils.HTMLEscape`, `org.gephi.ui.utils.PrefsUtils` and `org.gephi.project.io.XMLChar` are not fully tested.

I've written some tests that cover this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.