### PR TITLE
Travis CI: Update Xcode to 13.1, and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home;fi
 
   # Build & install innoextract
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then git clone --branch 1.6 --single-branch https://github.com/dscharrer/innoextract.git;fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then git clone --branch 1.9 --depth 1 https://github.com/dscharrer/innoextract.git;fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cd innoextract && mkdir -p build && cd build && cmake .. && make && export PATH=$PATH:$PWD && cd ../..;fi
 
   # OS X keychain init

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     - os: linux
       jdk: openjdk11
     - os: osx
-      osx_image: xcode12.5
+      osx_image: xcode13.1
 branches:
   only:
     - master


### PR DESCRIPTION
- Update Xcode from 12.5 to 13.1 for the macOS build.
- Update dscharrer/innoextract from 1.6 to 1.9. Also clone with `--depth 1`, this implies `--single-branch` and is even faster.