### PR TITLE
Create CI configuration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: "Build & Test"
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 6 * * 1' # Run every monday at 06:00 UTC
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows, macos]
+        node: ['16']
+        include:
+          - os: ubuntu
+            node: '17'
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: mvn clean install
+      - run: mvn nbm:cluster-app nbm:run-platform
+        working-directory: modules/application

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: mvn clean install
-      - run: mvn nbm:cluster-app nbm:run-platform
+      - run: mvn nbm:cluster-app
+        working-directory: modules/application
+      - if: matrix.os == 'ubuntu'
+        run: mvn nbm:run-platform
         working-directory: modules/application


### PR DESCRIPTION
Builds Gephi on Ubuntu, Windows and macOS using Node.JS 16 LTS, and also on Ubuntu for Node.JS 17. On the two Ubuntu run, it also tests it with `mvn nbm:run-platform`. It runs on every push, pull request and once a week.

GitHub Actions needs to be enabled on https://github.com/gephi/gephi/actions. In the mean time you can find an [example run](https://github.com/EwoutH/gephi/actions/runs/1434593829) on my fork.

<img width="720" alt="Screenshot_664" src="https://user-images.githubusercontent.com/15776622/140738696-d2b55a9e-65ed-4fc6-9004-a04beea77dd5.png">
<img width="720" alt="Screenshot_665" src="https://user-images.githubusercontent.com/15776622/140738784-434aff1e-6350-418e-bc58-ea2d925e4670.png">
