### PR TITLE
Add unit test for DOT importer

### DIFF
--- a/modules/ImportPlugin/src/test/java/org/gephi/io/importer/plugin/file/DOTTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/importer/plugin/file/DOTTest.java
@@ -1,0 +1,28 @@
+package org.gephi.io.importer.plugin.file;
+
+import org.gephi.io.importer.api.Container;
+import org.gephi.io.importer.api.ContainerUnloader;
+import org.gephi.io.importer.api.EdgeDraft;
+import org.gephi.io.importer.api.NodeDraft;
+import org.gephi.io.importer.impl.ImportContainerImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DOTTest {
+
+    @Test
+    public void testEmptyFieldsGraph() {
+        ImporterDOT importer = new ImporterDOT();
+        importer.setReader(Utils.getReader("emptyfields.dot"));
+
+        Container container = new ImportContainerImpl();
+        importer.execute(container.getLoader());
+
+        Assert.assertTrue(container.verify());
+
+        ContainerUnloader unloader = container.getUnloader();
+        NodeDraft[] nodes = Utils.toNodesArray(unloader);
+
+        Utils.assertSameIds(nodes, "a", "b", "c");
+    }
+}

--- a/modules/ImportPlugin/src/test/resources/org/gephi/io/importer/plugin/file/emptyfields.dot
+++ b/modules/ImportPlugin/src/test/resources/org/gephi/io/importer/plugin/file/emptyfields.dot
@@ -1,0 +1,4 @@
+graph {
+  a -- b [color=""]
+  b -- c [color=blue,lhead=""]
+}


### PR DESCRIPTION
I attempted to reproduce #2028 but could not, so this is a test-only PR which adds the corresponding unit test. My commit closes #2028 as unreproducible.