### PR TITLE
Fix #1945 Loading gexf file with 0-weighted edges crashes import

### DIFF
--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ElementFactoryImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ElementFactoryImpl.java
@@ -53,13 +53,15 @@ public class ElementFactoryImpl implements ElementDraft.Factory {
     protected final static AtomicInteger EDGE_IDS = new AtomicInteger();
     protected final ImportContainerImpl container;
 
+    protected AtomicInteger nextSequentialNodeId = new AtomicInteger();
+
     public ElementFactoryImpl(ImportContainerImpl container) {
         this.container = container;
     }
 
     @Override
     public NodeDraftImpl newNodeDraft() {
-        return new NodeDraftImpl(container, String.valueOf(NODE_IDS.getAndIncrement()));
+        return new NodeDraftImpl(container, String.valueOf(NODE_IDS.getAndIncrement()), nextSequentialNodeId.getAndIncrement());
     }
 
     @Override
@@ -68,7 +70,7 @@ public class ElementFactoryImpl implements ElementDraft.Factory {
             String message = NbBundle.getMessage(ElementFactoryImpl.class, "ElementFactoryException_NullNodeId");
             container.getReport().logIssue(new Issue(message, Issue.Level.CRITICAL));
         }
-        return new NodeDraftImpl(container, id);
+        return new NodeDraftImpl(container, id, nextSequentialNodeId.getAndIncrement());
     }
 
     @Override

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
@@ -50,12 +50,9 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectList;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
+
+import java.util.*;
+
 import org.gephi.graph.api.AttributeUtils;
 import org.gephi.graph.api.Interval;
 import org.gephi.graph.api.TimeFormat;
@@ -169,7 +166,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
 
         if (nodeMap.containsKey(nodeDraftImpl.getId())) {
             String message = NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerException_nodeExist", nodeDraftImpl.getId());
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_nodeExist", nodeDraftImpl.getId());
             report.logIssue(new Issue(message, Level.WARNING));
             return;
         }
@@ -193,13 +190,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                 node.setCreatedAuto(true);
                 if (!reportedUnknownNode) {
                     String message =
-                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_AutoNodeCreated");
+                            NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_AutoNodeCreated");
                     report.logIssue(new Issue(message, Level.INFO));
                     reportedUnknownNode = true;
                 }
             } else {
                 String message =
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_UnknowNodeId", id);
+                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_UnknowNodeId", id);
                 report.logIssue(new Issue(message, Level.SEVERE));
             }
         } else {
@@ -222,7 +219,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         NodeDraftImpl targetNode = getNode(target);
         if (sourceNode != null && targetNode != null) {
             boolean undirected = edgeDefault.equals(EdgeDirectionDefault.UNDIRECTED) ||
-                (undirectedEdgesCount > 0 && directedEdgesCount == 0);
+                    (undirectedEdgesCount > 0 && directedEdgesCount == 0);
             long edgeId = getLongId(sourceNode, targetNode, !undirected);
             for (Long2ObjectMap l : edgeTypeSets) {
                 if (l != null) {
@@ -242,13 +239,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         EdgeDraftImpl edgeDraftImpl = (EdgeDraftImpl) edgeDraft;
         if (edgeDraftImpl.getSource() == null) {
             String message =
-                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeSource");
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeSource");
             report.logIssue(new Issue(message, Level.SEVERE));
             return;
         }
         if (edgeDraftImpl.getTarget() == null) {
             String message =
-                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeTarget");
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeTarget");
             report.logIssue(new Issue(message, Level.SEVERE));
             return;
         }
@@ -256,7 +253,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         //Check if already exists
         if (edgeMap.containsKey(edgeDraftImpl.getId())) {
             String message = NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerException_edgeExist", edgeDraftImpl.getId());
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_edgeExist", edgeDraftImpl.getId());
             report.logIssue(new Issue(message, Level.WARNING));
             return;
         }
@@ -275,16 +272,16 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                 case DIRECTED:
                     if (edgeDraftImpl.getDirection().equals(EdgeDirection.UNDIRECTED)) {
                         report.logIssue(new Issue(NbBundle
-                            .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
-                                edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
+                                .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
+                                        edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
                         return;
                     }
                     break;
                 case UNDIRECTED:
                     if (edgeDraftImpl.getDirection().equals(EdgeDirection.DIRECTED)) {
                         report.logIssue(new Issue(NbBundle
-                            .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
-                                edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
+                                .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
+                                        edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
                         return;
                     }
                     break;
@@ -304,8 +301,8 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (edgeTypeSet.containsKey(sourceTargetLong)) {
             if (!parameters.isParallelEdges()) {
                 report.logIssue(new Issue(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Forbidden",
-                        edgeDraftImpl.getId()), Level.SEVERE));
+                        .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Forbidden",
+                                edgeDraftImpl.getId()), Level.SEVERE));
                 return;
             } else {
                 int[] edges = edgeTypeSet.get(sourceTargetLong);
@@ -316,13 +313,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
 
                 if (!reportedParallelEdges) {
                     report.logIssue(new Issue(NbBundle
-                        .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Merged",
-                            edgeDraftImpl.getId()), Level.INFO));
+                            .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Merged",
+                                    edgeDraftImpl.getId()), Level.INFO));
                     reportedParallelEdges = true;
                 }
             }
         } else {
-            edgeTypeSet.put(sourceTargetLong, new int[] {index});
+            edgeTypeSet.put(sourceTargetLong, new int[]{index});
         }
 
         //Self loop
@@ -331,17 +328,12 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         }
 
         //Direction
-        EdgeDirection direction = edgeDraftImpl.getDirection();
-        if (direction != null) {
-            //Counting
-            switch (direction) {
-                case DIRECTED:
-                    directedEdgesCount++;
-                    break;
-                case UNDIRECTED:
-                    undirectedEdgesCount++;
-                    break;
-            }
+        final boolean directed = isEdgeDirected(edgeDraft);
+
+        if (directed) {
+            directedEdgesCount++;
+        } else {
+            undirectedEdgesCount++;
         }
 
         //Adding
@@ -370,18 +362,12 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             return;
         }
 
-        boolean directed = edgeDraftImpl.getDirection() == EdgeDirection.DIRECTED;
+        final boolean directed = isEdgeDirected(edgeDraftImpl);
 
-        if (edgeDraftImpl.getDirection() != null) {
-            //UnCounting
-            switch (edgeDraftImpl.getDirection()) {
-                case DIRECTED:
-                    directedEdgesCount--;
-                    break;
-                case UNDIRECTED:
-                    undirectedEdgesCount--;
-                    break;
-            }
+        if (directed) {
+            directedEdgesCount--;
+        } else {
+            undirectedEdgesCount--;
         }
 
         if (edgeDraftImpl.isSelfLoop()) {
@@ -389,28 +375,38 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         }
 
         int edgeType = getEdgeType(edgeDraftImpl.getType());
-        long sourceTargetLong = getLongId(edgeDraftImpl.getSource(), edgeDraftImpl.getTarget(), directed);
+        long sourceTargetLong = getLongId(edgeDraftImpl);
         ensureLongSetArraySize(edgeType);
         Long2ObjectMap<int[]> edgeTypeSet = edgeTypeSets[edgeType];
 
         //Get index
-        int index = edgeMap.removeInt(id);
+        final int index = edgeMap.removeInt(id);
 
         //Update edgeType set
         int[] edges = edgeTypeSet.remove(sourceTargetLong);
-        if (edges.length > 1) {
-            int[] newEdges = new int[edges.length - 1];
-            int i = 0;
-            for (int e : edges) {
-                if (e != index) {
-                    newEdges[i++] = e;
+        if (Arrays.binarySearch(edges, index) >= 0) {
+            if (edges.length > 1) {
+                int[] newEdges = new int[edges.length - 1];
+                int i = 0;
+                for (int e : edges) {
+                    if (e != index) {
+                        newEdges[i++] = e;
+                    }
                 }
+                edgeTypeSet.put(sourceTargetLong, newEdges);
+            } else {
+                edgeTypeSet.put(sourceTargetLong, new int[0]);
             }
-            edgeTypeSet.put(sourceTargetLong, newEdges);
         }
 
         //Remove edge
         edgeList.set(index, null);
+    }
+
+    private boolean isEdgeDirected(EdgeDraft edgeDraft) {
+        final EdgeDirection direction = edgeDraft.getDirection();
+        return edgeDefault.equals(EdgeDirectionDefault.DIRECTED)
+                || (edgeDefault.equals(EdgeDirectionDefault.MIXED) && direction != EdgeDirection.UNDIRECTED);
     }
 
     @Override
@@ -505,16 +501,16 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             nodeColumns.put(key, column);
             if (dynamic) {
                 report.log(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicNodeColumn", key,
-                        typeClass.getSimpleName()));
+                        .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicNodeColumn", key,
+                                typeClass.getSimpleName()));
             } else {
                 report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.AddNodeColumn", key,
-                    typeClass.getSimpleName()));
+                        typeClass.getSimpleName()));
             }
         } else if (!column.getTypeClass().equals(typeClass)) {
             report.logIssue(new Issue(NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
-                    column.getTypeClass()), Level.SEVERE));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
+                            column.getTypeClass()), Level.SEVERE));
         }
         return column;
     }
@@ -543,16 +539,16 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             edgeColumns.put(key, column);
             if (dynamic) {
                 report.log(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicEdgeColumn", key,
-                        typeClass.getSimpleName()));
+                        .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicEdgeColumn", key,
+                                typeClass.getSimpleName()));
             } else {
                 report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.AddEdgeColumn", key,
-                    typeClass.getSimpleName()));
+                        typeClass.getSimpleName()));
             }
         } else if (!column.getTypeClass().equals(typeClass)) {
             report.logIssue(new Issue(NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
-                    column.getTypeClass()), Level.SEVERE));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
+                            column.getTypeClass()), Level.SEVERE));
         }
         return column;
     }
@@ -592,28 +588,28 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         try {
             double start, end;
             if (startDateTime == null || startDateTime.trim().isEmpty() || "-inf".equalsIgnoreCase(startDateTime) ||
-                "-infinity".equalsIgnoreCase(startDateTime)) {
+                    "-infinity".equalsIgnoreCase(startDateTime)) {
                 start = Double.NEGATIVE_INFINITY;
             } else {
                 start = timeFormat.equals(TimeFormat.DOUBLE) ? Double.parseDouble(startDateTime) :
-                    AttributeUtils.parseDateTime(startDateTime);
+                        AttributeUtils.parseDateTime(startDateTime);
             }
             if (endDateTime == null || endDateTime.trim().isEmpty() || "inf".equalsIgnoreCase(endDateTime) ||
-                "infinity".equalsIgnoreCase(endDateTime)) {
+                    "infinity".equalsIgnoreCase(endDateTime)) {
                 end = Double.POSITIVE_INFINITY;
             } else {
                 end = timeFormat.equals(TimeFormat.DOUBLE) ? Double.parseDouble(endDateTime) :
-                    AttributeUtils.parseDateTime(endDateTime);
+                        AttributeUtils.parseDateTime(endDateTime);
             }
             this.interval = new Interval(start, end);
         } catch (Exception e) {
             report.logIssue(new Issue(NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerException_Interval_Parse_Error",
-                    "[" + startDateTime + "," + endDateTime + "]"), Level.SEVERE));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Interval_Parse_Error",
+                            "[" + startDateTime + "," + endDateTime + "]"), Level.SEVERE));
             return;
         }
         report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.GraphInterval",
-            "[" + startDateTime + "," + endDateTime + "]"));
+                "[" + startDateTime + "," + endDateTime + "]"));
     }
 
     @Override
@@ -630,12 +626,12 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
     public void setTimestamp(String timestamp) {
         try {
             double t = timeFormat.equals(TimeFormat.DOUBLE) ? Double.parseDouble(timestamp) :
-                AttributeUtils.parseDateTime(timestamp);
+                    AttributeUtils.parseDateTime(timestamp);
             this.timestamp = t;
         } catch (Exception e) {
             report.logIssue(new Issue(NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerException_Timestamp_Parse_Error", timestamp),
-                Level.SEVERE));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Timestamp_Parse_Error", timestamp),
+                    Level.SEVERE));
             return;
         }
         report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.GraphTimestamp", timestamp));
@@ -651,7 +647,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (this.elementIdType != type) {
             this.elementIdType = type;
             report.log(NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerLog.ElementIdType", elementIdType.toString()));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.ElementIdType", elementIdType.toString()));
         }
     }
 
@@ -662,13 +658,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             String id = edge.getId();
             if (edge.getWeight() < 0f) {
                 report.logIssue(new Issue(
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Negative_Weight", id),
-                    Level.WARNING));
+                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Negative_Weight", id),
+                        Level.WARNING));
             } else if (edge.getWeight() == 0) {
                 removeEdge(edge);
                 report.logIssue(new Issue(
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Weight_Zero_Ignored", id),
-                    Level.SEVERE));
+                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Weight_Zero_Ignored", id),
+                        Level.SEVERE));
             }
         }
 
@@ -700,8 +696,8 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                 }
             } catch (NumberFormatException e) {
                 report.logIssue(new Issue(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_ElementIdType_Parse_Error",
-                        elementIdType), Level.WARNING));
+                        .getMessage(ImportContainerImpl.class, "ImportContainerException_ElementIdType_Parse_Error",
+                                elementIdType), Level.WARNING));
                 elementIdType = ElementIdType.STRING;
             }
         }
@@ -747,23 +743,23 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         //Print TimeFormat
         if (dynamicGraph) {
             report.log(
-                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeFormat", timeFormat.toString()));
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeFormat", timeFormat.toString()));
             report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeRepresentation",
-                timeRepresentation.toString()));
+                    timeRepresentation.toString()));
             report.log(
-                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeZone", timeZone.toString()));
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeZone", timeZone.toString()));
         }
 
         //Print edge label type
         if (lastEdgeType != null) {
             report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.EdgeLabelType",
-                lastEdgeType.getSimpleName()));
+                    lastEdgeType.getSimpleName()));
         }
 
         //Print edge types
         if (isMultiGraph()) {
             report.log(NbBundle
-                .getMessage(ImportContainerImpl.class, "ImportContainerLog.MultiGraphCount", edgeTypeMap.size() - 1));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.MultiGraphCount", edgeTypeMap.size() - 1));
         }
 
         return true;
@@ -788,11 +784,11 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             //Force undirected
             for (EdgeDraftImpl edge : edgeList.toArray(new EdgeDraftImpl[0])) {
                 final boolean notAlreadyRemoved = edge != null
-                    && edgeMap.containsKey(edge.getId());
+                        && edgeMap.containsKey(edge.getId());
 
                 if (notAlreadyRemoved && edge.getDirection().equals(EdgeDirection.DIRECTED)) {
                     EdgeDraftImpl opposite = getOpposite(edge);
-                    if (opposite != null) {
+                    if (opposite != null && edgeMap.containsKey(opposite.getId())) {
                         mergeDirectedEdges(opposite, edge);
                         removeEdge(opposite);
                     }
@@ -959,7 +955,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (this.edgeDefault != edgeDefault) {
             this.edgeDefault = edgeDefault;
             report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Set_EdgeDefault",
-                edgeDefault.toString()));
+                    edgeDefault.toString()));
         }
     }
 
@@ -1010,23 +1006,23 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (type != null) {
             Class cl = type.getClass();
             if (!(cl.equals(Integer.class)
-                || cl.equals(String.class)
-                || cl.equals(Float.class)
-                || cl.equals(Double.class)
-                || cl.equals(Short.class)
-                || cl.equals(Byte.class)
-                || cl.equals(Long.class)
-                || cl.equals(Character.class)
-                || cl.equals(Boolean.class))) {
+                    || cl.equals(String.class)
+                    || cl.equals(Float.class)
+                    || cl.equals(Double.class)
+                    || cl.equals(Short.class)
+                    || cl.equals(Byte.class)
+                    || cl.equals(Long.class)
+                    || cl.equals(Character.class)
+                    || cl.equals(Boolean.class))) {
                 report.logIssue(new Issue(
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type"),
-                    Level.SEVERE));
+                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type"),
+                        Level.SEVERE));
                 type = null;
             }
             if (type != null && lastEdgeType != null && !lastEdgeType.equals(type.getClass())) {
                 report.logIssue(new Issue(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type_Conflict",
-                        type.getClass().getSimpleName(), lastEdgeType.getSimpleName()), Level.SEVERE));
+                        .getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type_Conflict",
+                                type.getClass().getSimpleName(), lastEdgeType.getSimpleName()), Level.SEVERE));
                 type = null;
             }
         }
@@ -1053,21 +1049,19 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
     }
 
     private long getLongId(EdgeDraftImpl edge) {
-        EdgeDirection direction = edge.getDirection();
-        boolean directed = edgeDefault.equals(EdgeDirectionDefault.DIRECTED)
-            || (edgeDefault.equals(EdgeDirectionDefault.MIXED) && direction != EdgeDirection.UNDIRECTED);
+        final boolean directed = isEdgeDirected(edge);
         return getLongId(edge.getSource(), edge.getTarget(), directed);
     }
 
     private long getLongId(NodeDraftImpl source, NodeDraftImpl target, boolean directed) {
         if (directed) {
-            long edgeId = ((long) source.hashCode()) << 32;
-            edgeId = edgeId | (long) (target.hashCode());
+            long edgeId = ((long) source.getSequentialId()) << 32;
+            edgeId = edgeId | (long) (target.getSequentialId());
             return edgeId;
         } else {
             long edgeId =
-                ((long) (source.hashCode() > target.hashCode() ? source.hashCode() : target.hashCode())) << 32;
-            edgeId = edgeId | (long) (source.hashCode() > target.hashCode() ? target.hashCode() : source.hashCode());
+                    ((long) (Math.max(source.getSequentialId(), target.getSequentialId()))) << 32;
+            edgeId = edgeId | (long) (Math.min(source.getSequentialId(), target.getSequentialId()));
             return edgeId;
         }
     }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
@@ -166,7 +166,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
 
         if (nodeMap.containsKey(nodeDraftImpl.getId())) {
             String message = NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_nodeExist", nodeDraftImpl.getId());
+                .getMessage(ImportContainerImpl.class, "ImportContainerException_nodeExist", nodeDraftImpl.getId());
             report.logIssue(new Issue(message, Level.WARNING));
             return;
         }
@@ -190,13 +190,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                 node.setCreatedAuto(true);
                 if (!reportedUnknownNode) {
                     String message =
-                            NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_AutoNodeCreated");
+                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_AutoNodeCreated");
                     report.logIssue(new Issue(message, Level.INFO));
                     reportedUnknownNode = true;
                 }
             } else {
                 String message =
-                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_UnknowNodeId", id);
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_UnknowNodeId", id);
                 report.logIssue(new Issue(message, Level.SEVERE));
             }
         } else {
@@ -219,7 +219,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         NodeDraftImpl targetNode = getNode(target);
         if (sourceNode != null && targetNode != null) {
             boolean undirected = edgeDefault.equals(EdgeDirectionDefault.UNDIRECTED) ||
-                    (undirectedEdgesCount > 0 && directedEdgesCount == 0);
+                (undirectedEdgesCount > 0 && directedEdgesCount == 0);
             long edgeId = getLongId(sourceNode, targetNode, !undirected);
             for (Long2ObjectMap l : edgeTypeSets) {
                 if (l != null) {
@@ -239,13 +239,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         EdgeDraftImpl edgeDraftImpl = (EdgeDraftImpl) edgeDraft;
         if (edgeDraftImpl.getSource() == null) {
             String message =
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeSource");
+                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeSource");
             report.logIssue(new Issue(message, Level.SEVERE));
             return;
         }
         if (edgeDraftImpl.getTarget() == null) {
             String message =
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeTarget");
+                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_MissingNodeTarget");
             report.logIssue(new Issue(message, Level.SEVERE));
             return;
         }
@@ -253,7 +253,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         //Check if already exists
         if (edgeMap.containsKey(edgeDraftImpl.getId())) {
             String message = NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_edgeExist", edgeDraftImpl.getId());
+                .getMessage(ImportContainerImpl.class, "ImportContainerException_edgeExist", edgeDraftImpl.getId());
             report.logIssue(new Issue(message, Level.WARNING));
             return;
         }
@@ -272,16 +272,16 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                 case DIRECTED:
                     if (edgeDraftImpl.getDirection().equals(EdgeDirection.UNDIRECTED)) {
                         report.logIssue(new Issue(NbBundle
-                                .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
-                                        edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
+                            .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
+                                edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
                         return;
                     }
                     break;
                 case UNDIRECTED:
                     if (edgeDraftImpl.getDirection().equals(EdgeDirection.DIRECTED)) {
                         report.logIssue(new Issue(NbBundle
-                                .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
-                                        edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
+                            .getMessage(ImportContainerImpl.class, "ImportContainerException_Bad_Edge_Type",
+                                edgeDefault, edgeDraftImpl.getId()), Level.SEVERE));
                         return;
                     }
                     break;
@@ -301,8 +301,8 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (edgeTypeSet.containsKey(sourceTargetLong)) {
             if (!parameters.isParallelEdges()) {
                 report.logIssue(new Issue(NbBundle
-                        .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Forbidden",
-                                edgeDraftImpl.getId()), Level.SEVERE));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Forbidden",
+                        edgeDraftImpl.getId()), Level.SEVERE));
                 return;
             } else {
                 int[] edges = edgeTypeSet.get(sourceTargetLong);
@@ -313,13 +313,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
 
                 if (!reportedParallelEdges) {
                     report.logIssue(new Issue(NbBundle
-                            .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Merged",
-                                    edgeDraftImpl.getId()), Level.INFO));
+                        .getMessage(ImportContainerImpl.class, "ImportContainerException_Parallel_Edge_Merged",
+                            edgeDraftImpl.getId()), Level.INFO));
                     reportedParallelEdges = true;
                 }
             }
         } else {
-            edgeTypeSet.put(sourceTargetLong, new int[]{index});
+            edgeTypeSet.put(sourceTargetLong, new int[] {index});
         }
 
         //Self loop
@@ -406,7 +406,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
     private boolean isEdgeDirected(EdgeDraft edgeDraft) {
         final EdgeDirection direction = edgeDraft.getDirection();
         return edgeDefault.equals(EdgeDirectionDefault.DIRECTED)
-                || (edgeDefault.equals(EdgeDirectionDefault.MIXED) && direction != EdgeDirection.UNDIRECTED);
+            || (edgeDefault.equals(EdgeDirectionDefault.MIXED) && direction != EdgeDirection.UNDIRECTED);
     }
 
     @Override
@@ -501,16 +501,16 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             nodeColumns.put(key, column);
             if (dynamic) {
                 report.log(NbBundle
-                        .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicNodeColumn", key,
-                                typeClass.getSimpleName()));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicNodeColumn", key,
+                        typeClass.getSimpleName()));
             } else {
                 report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.AddNodeColumn", key,
-                        typeClass.getSimpleName()));
+                    typeClass.getSimpleName()));
             }
         } else if (!column.getTypeClass().equals(typeClass)) {
             report.logIssue(new Issue(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
-                            column.getTypeClass()), Level.SEVERE));
+                .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
+                    column.getTypeClass()), Level.SEVERE));
         }
         return column;
     }
@@ -539,16 +539,16 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             edgeColumns.put(key, column);
             if (dynamic) {
                 report.log(NbBundle
-                        .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicEdgeColumn", key,
-                                typeClass.getSimpleName()));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.AddDynamicEdgeColumn", key,
+                        typeClass.getSimpleName()));
             } else {
                 report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.AddEdgeColumn", key,
-                        typeClass.getSimpleName()));
+                    typeClass.getSimpleName()));
             }
         } else if (!column.getTypeClass().equals(typeClass)) {
             report.logIssue(new Issue(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
-                            column.getTypeClass()), Level.SEVERE));
+                .getMessage(ImportContainerImpl.class, "ImportContainerException_Column_Type_Mismatch", key,
+                    column.getTypeClass()), Level.SEVERE));
         }
         return column;
     }
@@ -588,28 +588,28 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         try {
             double start, end;
             if (startDateTime == null || startDateTime.trim().isEmpty() || "-inf".equalsIgnoreCase(startDateTime) ||
-                    "-infinity".equalsIgnoreCase(startDateTime)) {
+                "-infinity".equalsIgnoreCase(startDateTime)) {
                 start = Double.NEGATIVE_INFINITY;
             } else {
                 start = timeFormat.equals(TimeFormat.DOUBLE) ? Double.parseDouble(startDateTime) :
-                        AttributeUtils.parseDateTime(startDateTime);
+                    AttributeUtils.parseDateTime(startDateTime);
             }
             if (endDateTime == null || endDateTime.trim().isEmpty() || "inf".equalsIgnoreCase(endDateTime) ||
-                    "infinity".equalsIgnoreCase(endDateTime)) {
+                "infinity".equalsIgnoreCase(endDateTime)) {
                 end = Double.POSITIVE_INFINITY;
             } else {
                 end = timeFormat.equals(TimeFormat.DOUBLE) ? Double.parseDouble(endDateTime) :
-                        AttributeUtils.parseDateTime(endDateTime);
+                    AttributeUtils.parseDateTime(endDateTime);
             }
             this.interval = new Interval(start, end);
         } catch (Exception e) {
             report.logIssue(new Issue(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Interval_Parse_Error",
-                            "[" + startDateTime + "," + endDateTime + "]"), Level.SEVERE));
+                .getMessage(ImportContainerImpl.class, "ImportContainerException_Interval_Parse_Error",
+                    "[" + startDateTime + "," + endDateTime + "]"), Level.SEVERE));
             return;
         }
         report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.GraphInterval",
-                "[" + startDateTime + "," + endDateTime + "]"));
+            "[" + startDateTime + "," + endDateTime + "]"));
     }
 
     @Override
@@ -626,12 +626,12 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
     public void setTimestamp(String timestamp) {
         try {
             double t = timeFormat.equals(TimeFormat.DOUBLE) ? Double.parseDouble(timestamp) :
-                    AttributeUtils.parseDateTime(timestamp);
+                AttributeUtils.parseDateTime(timestamp);
             this.timestamp = t;
         } catch (Exception e) {
             report.logIssue(new Issue(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Timestamp_Parse_Error", timestamp),
-                    Level.SEVERE));
+                .getMessage(ImportContainerImpl.class, "ImportContainerException_Timestamp_Parse_Error", timestamp),
+                Level.SEVERE));
             return;
         }
         report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.GraphTimestamp", timestamp));
@@ -647,7 +647,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (this.elementIdType != type) {
             this.elementIdType = type;
             report.log(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.ElementIdType", elementIdType.toString()));
+                .getMessage(ImportContainerImpl.class, "ImportContainerLog.ElementIdType", elementIdType.toString()));
         }
     }
 
@@ -658,13 +658,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             String id = edge.getId();
             if (edge.getWeight() < 0f) {
                 report.logIssue(new Issue(
-                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Negative_Weight", id),
-                        Level.WARNING));
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Negative_Weight", id),
+                    Level.WARNING));
             } else if (edge.getWeight() == 0) {
                 removeEdge(edge);
                 report.logIssue(new Issue(
-                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Weight_Zero_Ignored", id),
-                        Level.SEVERE));
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Weight_Zero_Ignored", id),
+                    Level.SEVERE));
             }
         }
 
@@ -696,8 +696,8 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                 }
             } catch (NumberFormatException e) {
                 report.logIssue(new Issue(NbBundle
-                        .getMessage(ImportContainerImpl.class, "ImportContainerException_ElementIdType_Parse_Error",
-                                elementIdType), Level.WARNING));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_ElementIdType_Parse_Error",
+                        elementIdType), Level.WARNING));
                 elementIdType = ElementIdType.STRING;
             }
         }
@@ -743,23 +743,23 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         //Print TimeFormat
         if (dynamicGraph) {
             report.log(
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeFormat", timeFormat.toString()));
+                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeFormat", timeFormat.toString()));
             report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeRepresentation",
-                    timeRepresentation.toString()));
+                timeRepresentation.toString()));
             report.log(
-                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeZone", timeZone.toString()));
+                NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.TimeZone", timeZone.toString()));
         }
 
         //Print edge label type
         if (lastEdgeType != null) {
             report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerLog.EdgeLabelType",
-                    lastEdgeType.getSimpleName()));
+                lastEdgeType.getSimpleName()));
         }
 
         //Print edge types
         if (isMultiGraph()) {
             report.log(NbBundle
-                    .getMessage(ImportContainerImpl.class, "ImportContainerLog.MultiGraphCount", edgeTypeMap.size() - 1));
+                .getMessage(ImportContainerImpl.class, "ImportContainerLog.MultiGraphCount", edgeTypeMap.size() - 1));
         }
 
         return true;
@@ -784,7 +784,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             //Force undirected
             for (EdgeDraftImpl edge : edgeList.toArray(new EdgeDraftImpl[0])) {
                 final boolean notAlreadyRemoved = edge != null
-                        && edgeMap.containsKey(edge.getId());
+                    && edgeMap.containsKey(edge.getId());
 
                 if (notAlreadyRemoved && edge.getDirection().equals(EdgeDirection.DIRECTED)) {
                     EdgeDraftImpl opposite = getOpposite(edge);
@@ -955,7 +955,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (this.edgeDefault != edgeDefault) {
             this.edgeDefault = edgeDefault;
             report.log(NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Set_EdgeDefault",
-                    edgeDefault.toString()));
+                edgeDefault.toString()));
         }
     }
 
@@ -1006,23 +1006,23 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (type != null) {
             Class cl = type.getClass();
             if (!(cl.equals(Integer.class)
-                    || cl.equals(String.class)
-                    || cl.equals(Float.class)
-                    || cl.equals(Double.class)
-                    || cl.equals(Short.class)
-                    || cl.equals(Byte.class)
-                    || cl.equals(Long.class)
-                    || cl.equals(Character.class)
-                    || cl.equals(Boolean.class))) {
+                || cl.equals(String.class)
+                || cl.equals(Float.class)
+                || cl.equals(Double.class)
+                || cl.equals(Short.class)
+                || cl.equals(Byte.class)
+                || cl.equals(Long.class)
+                || cl.equals(Character.class)
+                || cl.equals(Boolean.class))) {
                 report.logIssue(new Issue(
-                        NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type"),
-                        Level.SEVERE));
+                    NbBundle.getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type"),
+                    Level.SEVERE));
                 type = null;
             }
             if (type != null && lastEdgeType != null && !lastEdgeType.equals(type.getClass())) {
                 report.logIssue(new Issue(NbBundle
-                        .getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type_Conflict",
-                                type.getClass().getSimpleName(), lastEdgeType.getSimpleName()), Level.SEVERE));
+                    .getMessage(ImportContainerImpl.class, "ImportContainerException_Unsupported_Edge_type_Conflict",
+                        type.getClass().getSimpleName(), lastEdgeType.getSimpleName()), Level.SEVERE));
                 type = null;
             }
         }
@@ -1060,7 +1060,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
             return edgeId;
         } else {
             long edgeId =
-                    ((long) (Math.max(source.getSequentialId(), target.getSequentialId()))) << 32;
+                ((long) (Math.max(source.getSequentialId(), target.getSequentialId()))) << 32;
             edgeId = edgeId | (long) (Math.min(source.getSequentialId(), target.getSequentialId()));
             return edgeId;
         }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/NodeDraftImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/NodeDraftImpl.java
@@ -59,11 +59,18 @@ public class NodeDraftImpl extends ElementDraftImpl implements NodeDraft {
     protected float size;
     protected boolean fixed;
 
-    public NodeDraftImpl(ImportContainerImpl container, String id) {
+    protected final int sequentialId;
+
+    public NodeDraftImpl(ImportContainerImpl container, String id, int sequentialId) {
         super(container, id);
+        this.sequentialId = sequentialId;
     }
 
     //GETTERS
+    public int getSequentialId() {
+        return sequentialId;
+    }
+
     @Override
     public float getSize() {
         return size;

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/importer/plugin/file/GEXFTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/importer/plugin/file/GEXFTest.java
@@ -27,4 +27,15 @@ public class GEXFTest {
     Utils.assertSameIds(nodes, "0", "1");
     Utils.assertSameIds(edges, "0");
   }
+
+  @Test
+  public void testZeroWeight() {
+    ImporterGEXF importer = new ImporterGEXF();
+    importer.setReader(Utils.getReader("zeroweight.gexf"));
+
+    Container container = new ImportContainerImpl();
+    importer.execute(container.getLoader());
+
+    Assert.assertTrue(container.verify());
+  }
 }

--- a/modules/ImportPlugin/src/test/resources/org/gephi/io/importer/plugin/file/spreadsheet/expected/testEdgesTableOppositeForceUndirected_Issue1848_edges.csv
+++ b/modules/ImportPlugin/src/test/resources/org/gephi/io/importer/plugin/file/spreadsheet/expected/testEdgesTableOppositeForceUndirected_Issue1848_edges.csv
@@ -1,5 +1,7 @@
 Source,Target,Type,Label,timeset,Weight
 imbabura,loja,Undirected,,,2
+loja,elarteviveenloja,Undirected,,,714
+sosunl,elarteviveenloja,Undirected,,,2883
 elarteviveenloja,unl,Undirected,,,833
 loja,municipiodeloja,Undirected,,,58
 felizviernes,loja,Undirected,,,6
@@ -16,6 +18,8 @@ unl,sosunl,Undirected,,,71
 arcsa,salud,Undirected,,,12
 salud,elarteviveenloja,Undirected,,,35
 patriciovallejo,elarteviveenloja,Undirected,,,21
+elarteviveenloja,todaunavida,Undirected,,,164
+elarteviveenloja,videovigilanciaecu911,Undirected,,,29
 elarteviveenloja,fiavl,Undirected,,,76
 elscomediants,loja,Undirected,,,2
 temblor,loja,Undirected,,,6
@@ -23,7 +27,6 @@ loja,fiestasdequito,Undirected,,,4
 fiestasdequito,elarteviveenloja,Undirected,,,4
 ecu911,elarteviveenloja,Undirected,,,130
 cbamprendo,3h,Undirected,,,2
-todaunavida,elarteviveenloja,Undirected,,,164
 temblor,elarteviveenloja,Undirected,,,2
 unl,ecuador,Undirected,,,26
 municipiodeloja,elarteviveenloja,Undirected,,,38
@@ -87,9 +90,7 @@ teatro,benjamincarrion,Undirected,,,1
 cultura,elarteviveenloja,Undirected,,,2
 lojamiciudad,loja,Undirected,,,1
 ecu911,loja,Undirected,,,10
-videovigilanciaecu911,elarteviveenloja,Undirected,,,29
 elarteviveenloja,atenter,Undirected,,,16
-loja,elarteviveenloja,Undirected,,,714
 faustomino,elarteviveenloja,Undirected,,,1
 loja,moreno,Undirected,,,1
 elarteviveenloja,guadual,Undirected,,,1
@@ -145,8 +146,9 @@ swinger,loja,Undirected,,,1
 loja,zamora,Undirected,,,1
 zamora,cuenca,Undirected,,,1
 cuenca,machala,Undirected,,,1
+fiavl2017,loja,Undirected,,,4
 elarteviveenloja,presidencia_ec,Undirected,,,1
-sosunl,elarteviveenloja,Undirected,,,2883
+somosculturautpl,elarteviveenloja,Undirected,,,5
 loja,economianaranja,Undirected,,,1
 economianaranja,elarteviveenloja,Undirected,,,1
 raulperez,elarteviveenloja,Undirected,,,7
@@ -171,7 +173,6 @@ consultapopular,sialaconsulta,Undirected,,,1
 sialaconsulta,lojacontigolenin,Undirected,,,1
 los4mundosdelsur,parquenacionalpodoparpus,Undirected,,,3
 parquenacionalpodoparpus,elarteviveenloja,Undirected,,,3
-loja,fiavl2017,Undirected,,,4
 conexionecu911,elarteviveenloja,Undirected,,,36
 iwia,loja,Undirected,,,2
 loja,saraguro,Undirected,,,6
@@ -189,7 +190,6 @@ elarteviveenloja,artesvivas,Undirected,,,4
 artesvivas,loja,Undirected,,,4
 felizviernes,elarteviveenloja,Undirected,,,2
 elarteviveenloja,cifiunl2017,Undirected,,,2
-elarteviveenloja,somosculturautpl,Undirected,,,5
 zaruma,los4mundosdelsur,Undirected,,,20
 karcocha,elarteviveenloja,Undirected,,,4
 elarteviveenloja,weareproudofyoulauren,Undirected,,,2

--- a/modules/ImportPlugin/src/test/resources/org/gephi/io/importer/plugin/file/zeroweight.gexf
+++ b/modules/ImportPlugin/src/test/resources/org/gephi/io/importer/plugin/file/zeroweight.gexf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+    <graph mode="static" defaultedgetype="directed">
+        <nodes>
+            <node id="0" label="Hello" />
+            <node id="1" label="Word" />
+        </nodes>
+        <edges>
+            <edge id="0" source="0" target="1" weight="0.0" />
+        </edges>
+    </graph>
+</gexf>


### PR DESCRIPTION
The main problem was inconsistency in the way `directed` boolean was calculated in several places in `ImportContainerImpl`

It broke an old spreadsheet test about merging opposite directed edges into undirected edges though. I added some fixes to make that test not crash but also changed the expected result file as some source-target pairs are now inverted.