### PR TITLE
Migrate Sentry to new SDK

### DIFF
--- a/modules/DesktopBranding/pom.xml
+++ b/modules/DesktopBranding/pom.xml
@@ -100,6 +100,11 @@
             <groupId>io.sentry</groupId>
             <artifactId>sentry</artifactId>
         </dependency>
+	<dependency> <!-- required by Sentry -->
+	    <groupId>com.google.code.gson</groupId>
+	    <artifactId>gson</artifactId>
+        </dependency>
+
         
     </dependencies>
 

--- a/modules/DesktopBranding/pom.xml
+++ b/modules/DesktopBranding/pom.xml
@@ -99,12 +99,6 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry</artifactId>
-            <!-- exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions -->
         </dependency>
         
     </dependencies>

--- a/modules/DesktopBranding/pom.xml
+++ b/modules/DesktopBranding/pom.xml
@@ -97,25 +97,16 @@
             <artifactId>org-openide-awt</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.getsentry.raven</groupId>
-            <artifactId>raven</artifactId>
-            <exclusions>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <!-- exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
-            </exclusions>
+            </exclusions -->
         </dependency>
         
-        <!-- Raven depends on slf4j-api and needs it to work. So manage with dependency directly -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
@@ -82,7 +82,7 @@ import org.w3c.dom.Document;
 public class ReportController {
 
     private static final String POST_URL =
-        "https://d007fbbdeb6241b5b2c542a6bc548cf3:4a1af110df484e838da9243c1496ebe9@app.getsentry.com/85815";
+        "https://d007fbbdeb6241b5b2c542a6bc548cf3@o43889.ingest.sentry.io/85815";
     
     public ReportController() {
         Sentry.init(options -> {

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
@@ -133,8 +133,6 @@ public class ReportController {
         event.setExtra("Processors", report.getNumberOfProcessors());
         event.setExtra("Screen devices", report.getScreenDevices());
         event.setExtra("Screen size", report.getScreenSize());
-        event.setExtra("User description", report.getUserDescription()); // GDPR compliant?
-        event.setExtra("User email", report.getUserEmail()); // GDPR compliant?
         event.setExtra("VM", report.getVm());
         event.setExtra("OpenGL Vendor", report.getGlVendor());
         event.setExtra("OpenGL Renderer", report.getGlRenderer());

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
@@ -137,6 +137,8 @@ public class ReportController {
         event.setExtra("OpenGL Vendor", report.getGlVendor());
         event.setExtra("OpenGL Renderer", report.getGlRenderer());
         event.setExtra("OpenGL Version", report.getGlVersion());
+        // The user email is okay to store privacy-wise, because it is provided by the user voluntarily
+        event.setExtra("User email", report.getUserEmail());
         event.setExtra("Log", report.getLog());
         event.setThrowable(report.getThrowable());
 

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReportController.java
@@ -58,6 +58,7 @@ import java.util.Collections;
 import java.util.MissingResourceException;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -139,7 +140,7 @@ public class ReportController {
         event.setExtra("OpenGL Version", report.getGlVersion());
         // The user email is okay to store privacy-wise, because it is provided by the user voluntarily
         event.setExtra("User email", report.getUserEmail());
-        event.setExtra("Log", report.getLog());
+        event.setExtra("Log", anonymizeLog(report.getLog()));
         event.setThrowable(report.getThrowable());
 
         Sentry.captureEvent(event);
@@ -275,5 +276,14 @@ public class ReportController {
         } catch (Exception e) {
         }
         report.setLog(log);
+    }
+
+    /**
+     * Removes usernames from log files
+     */
+    protected static String anonymizeLog(String log) {
+        return log.replaceAll(
+                "(/((home)|(Users))/[^/\n]*)|(\\\\Users\\\\[^\\\\\n]*)",
+                "/ANONYMIZED_HOME_DIR"); // NOI18N
     }
 }

--- a/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/reporter/ReportControllerTest.java
+++ b/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/reporter/ReportControllerTest.java
@@ -1,0 +1,92 @@
+/*
+Copyright 2008-2021 Gephi
+Authors : Antonin Delpeuch <antonin@delpeuch.eu>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+*/
+
+package org.gephi.branding.desktop.reporter;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+public class ReportControllerTest {
+
+    @Test
+    public void testAnonymizeUnixLog() {
+        String log = "" +
+                "  System Locale; Encoding = en_GB (gephi); UTF-8\n" +
+                "  Home Directory          = /home/mjackson\n" +
+                "  Current Directory       = /home/mjackson/gephi/modules/application\n" +
+                "  User Directory          = /home/mjackson/gephi/modules/application";
+
+        String expected = "" +
+                "  System Locale; Encoding = en_GB (gephi); UTF-8\n" +
+                "  Home Directory          = /ANONYMIZED_HOME_DIR\n" +
+                "  Current Directory       = /ANONYMIZED_HOME_DIR/gephi/modules/application\n" +
+                "  User Directory          = /ANONYMIZED_HOME_DIR/gephi/modules/application";
+
+        String anonymized = ReportController.anonymizeLog(log);
+
+        Assert.assertEquals(expected, anonymized);
+    }
+
+    @Test
+    public void testAnonymizeWindowsLog() {
+        String log = "" +
+                "  Java Home               = C:\\Program Files\\Java\\jre1.8.0_311\n" +
+                "  System Locale; Encoding = en_US (gephi); Cp1254\n" +
+                "  Home Directory          = C:\\Users\\RickAstley\n" +
+                "  Current Directory       = C:\\Program Files\\Gephi-0.9.2\n" +
+                "  User Directory          = C:\\Users\\RickAstley\\AppData\\Roaming\\.gephi\\0.9.2\\dev\n" +
+                "  Cache Directory         = C:\\Users\\RickAstley\\AppData\\Roaming\\.gephi\\0.9.2\\dev\\var\\cache\n" +
+                "  Installation            = C:\\Program Files\\Gephi-0.9.2\\platform";
+
+        String expected = "" +
+                "  Java Home               = C:\\Program Files\\Java\\jre1.8.0_311\n" +
+                "  System Locale; Encoding = en_US (gephi); Cp1254\n" +
+                "  Home Directory          = C:/ANONYMIZED_HOME_DIR\n" +
+                "  Current Directory       = C:\\Program Files\\Gephi-0.9.2\n" +
+                "  User Directory          = C:/ANONYMIZED_HOME_DIR\\AppData\\Roaming\\.gephi\\0.9.2\\dev\n" +
+                "  Cache Directory         = C:/ANONYMIZED_HOME_DIR\\AppData\\Roaming\\.gephi\\0.9.2\\dev\\var\\cache\n" +
+                "  Installation            = C:\\Program Files\\Gephi-0.9.2\\platform";
+        String anonymized = ReportController.anonymizeLog(log);
+
+        Assert.assertEquals(expected, anonymized);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         
         <gephi.slf4j.version>1.7.32</gephi.slf4j.version>
         <!-- TODO: change to new sentry sdk -->
-        <gephi.sentry.raven.version>8.0.3</gephi.sentry.raven.version>
+        <gephi.sentry.version>5.4.2</gephi.sentry.version>
         
         <!--==== Plugin Versions ==================================================================================-->
 
@@ -778,15 +778,15 @@
                 <version>${gephi.slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.getsentry.raven</groupId>
-                <artifactId>raven</artifactId>
-                <version>${gephi.sentry.raven.version}</version>
-                <exclusions>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry</artifactId>
+                <version>${gephi.sentry.version}</version>
+                <!-- exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
-                </exclusions>
+                </exclusions -->
             </dependency>
 
             <!-- Test JARs -->

--- a/pom.xml
+++ b/pom.xml
@@ -199,8 +199,8 @@
         <!--==== Dependency Versions ==================================================================================-->
         
         <gephi.slf4j.version>1.7.32</gephi.slf4j.version>
-        <!-- TODO: change to new sentry sdk -->
         <gephi.sentry.version>5.4.2</gephi.sentry.version>
+        <gephi.gson.version>2.8.5</gephi.gson.version>
         
         <!--==== Plugin Versions ==================================================================================-->
 
@@ -781,6 +781,11 @@
                 <groupId>io.sentry</groupId>
                 <artifactId>sentry</artifactId>
                 <version>${gephi.sentry.version}</version>
+            </dependency>
+	    <dependency> <!-- required by Sentry -->
+		<groupId>com.google.code.gson</groupId>
+		<artifactId>gson</artifactId>
+		<version>${gephi.gson.version}</version>
             </dependency>
 
             <!-- Test JARs -->

--- a/pom.xml
+++ b/pom.xml
@@ -781,12 +781,6 @@
                 <groupId>io.sentry</groupId>
                 <artifactId>sentry</artifactId>
                 <version>${gephi.sentry.version}</version>
-                <!-- exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                </exclusions -->
             </dependency>
 
             <!-- Test JARs -->


### PR DESCRIPTION
For #2340.

This only updates to the new SDK, without solving the problem of logging personal information from users.
It looks like we are already trying to log some personal fields (user name, user email), so a first step would probably be to exclude those? I think @mbastian also had some heuristics to hide user names from paths in mind.