### PR TITLE
2612 javadoc bundle missing in gephi artefacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           OSSRH_STAGING_PROFILE_ID: ${{ secrets.OSSRH_STAGING_PROFILE_ID }}
 
       - name: Build and publish modules
-        run: mvn -T 4 --batch-mode -Djava.awt.headless=true -Dkeystore.password=${{ secrets.KEYSTORE_PASSWD }} -DstagingRepositoryId=${{ env.staging_repository_id }} deploy -P deployment,sign-artifacts,create-modules,create-sources,create-javadoc,create-autoupdate
+        run: mvn -T 4 --batch-mode -Djava.awt.headless=true -Dkeystore.password=${{ secrets.KEYSTORE_PASSWD }} -DstagingRepositoryId=${{ env.staging_repository_id }} site deploy -P deployment,sign-artifacts,create-modules,create-sources,create-javadoc,create-autoupdate
         env:
           OSSRH_USER: ${{ secrets.OSSRH_USER }}
           OSSRH_PASS: ${{ secrets.OSSRH_PASS }}

--- a/modules/application/pom.xml
+++ b/modules/application/pom.xml
@@ -995,7 +995,7 @@
                                     <artifacts>
                                         <artifact>
                                             <!-- Aggregate file is generated in gephi-parent but attached here -->
-                                            <file>${project.build.directory}/../../../target/${project.artifactId}-parent-${project.version}-javadoc.jar</file>
+                                            <file>${project.parent.basedir}/target/${project.artifactId}-parent-${project.version}-javadoc.jar</file>
                                             <type>jar</type>
                                             <classifier>javadoc</classifier>
                                         </artifact>

--- a/modules/application/pom.xml
+++ b/modules/application/pom.xml
@@ -976,7 +976,7 @@
             </build>
         </profile>
 
-        <!-- Attach aggregate Javadoc -->
+        <!-- Attach aggregate Javadoc, need to be run with site phase -->
         <profile>
             <id>create-javadoc</id>
             <build>

--- a/modules/application/pom.xml
+++ b/modules/application/pom.xml
@@ -976,6 +976,36 @@
             </build>
         </profile>
 
+        <!-- Attach aggregate Javadoc -->
+        <profile>
+            <id>create-javadoc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/../../../target/${project.artifactId}-parent-${project.version}-javadoc.jar</file>
+                                            <type>jar</type>
+                                            <classifier>javadoc</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         
         <!-- Profile used along with deployment to create the tar.gz artifact -->
         <profile>

--- a/modules/application/pom.xml
+++ b/modules/application/pom.xml
@@ -994,6 +994,7 @@
                                 <configuration>
                                     <artifacts>
                                         <artifact>
+                                            <!-- Aggregate file is generated in gephi-parent but attached here -->
                                             <file>${project.build.directory}/../../../target/${project.artifactId}-parent-${project.version}-javadoc.jar</file>
                                             <type>jar</type>
                                             <classifier>javadoc</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
 
         <gephi.maven-jarsigner-plugin.version>3.0.0</gephi.maven-jarsigner-plugin.version>
 
-        <gephi.maven-javadoc-plugin.version>3.3.2</gephi.maven-javadoc-plugin.version> 
+        <gephi.maven-javadoc-plugin.version>3.4.1</gephi.maven-javadoc-plugin.version>
 
         <gephi.maven-license-plugin.version>1.9.0</gephi.maven-license-plugin.version>
 
@@ -1270,7 +1270,7 @@
                                 <phase>site</phase>
                                 <inherited>false</inherited>
                                 <goals>
-                                    <goal>aggregate</goal>
+                                    <goal>aggregate-jar</goal>
                                 </goals>
                                 <configuration>
                                     <show>public</show>

--- a/pom.xml
+++ b/pom.xml
@@ -1348,46 +1348,6 @@
                 </plugins>
             </build>
         </profile>
-        
-        <!-- Properties for release -->
-        <profile>
-            <id>release</id>
-            <properties>
-            </properties>
-        </profile>
-        
-        <!-- Profile activated for windows/macos release only. Should be called alone so it only creates the windows installer/compressed dmg -->
-        <profile>
-            <id>release-extra</id>
-            <build>
-                <plugins>
-                    
-                    <!-- Skip Javadoc creation -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution> 
-                                <id>attach-javadocs</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-            
-                    <!-- Skip sources attach -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <phase>none</phase> 
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
                 
     <!-- List of modules -->

--- a/pom.xml
+++ b/pom.xml
@@ -1265,6 +1265,7 @@
                                     <goal>jar</goal>
                                 </goals> 
                             </execution>
+                            <!-- Aggregate Javadoc, attached in gephi-app -->
                             <execution>
                                 <id>aggregate</id>
                                 <phase>site</phase>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -37,7 +37,7 @@
             <li>Add <code>getNormalizedValue()</code> to <code>Ranking</code> to more easily retrieve the normalised value.</li>
             <li><code>Partition</code> now has a static <code>DEFAULT_COLOR</code> when the color is not found for a given value.</li>
             <li>Removed <code>Partition.setColors()</code> as it was prone to confusion.</li>
-            <li>Add <code>transformAll(Iterable<? extends Element>)</code> to <code>Function</code>.</li>
+            <li>Add <code>transformAll(Iterable&#60;&#63; extends Element&#62;)</code> to <code>Function</code>.</li>
             <li>Split <code>isLocalScale()</code> into <code>isRankingLocalScale()</code> and <code>isPartitionLocalScale()</code> in <code>AppearanceModel</code>.</li>
             <li>Make <code>Function</code> getters in <code>AppearanceModel</code> independent from <code>Graph</code> as this should be handled automatically based on the local/global state.</li>
         </ul>


### PR DESCRIPTION
## Description

Fixes #2612.

<!--
Please include a summary of the code changes. Please also link the GitHub issue if it exists.
-->

## Checklist

- [ ] Merged with master beforehand -> no as this branch is first meant for 0.9.8

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren’t needed
