### PR TITLE
Bugfix on load .gephi file with multiple workspace.

### DIFF
--- a/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/FiltersTopComponent.java
+++ b/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/FiltersTopComponent.java
@@ -102,7 +102,9 @@ public final class FiltersTopComponent extends TopComponent {
 
             @Override
             public void unselect(Workspace workspace) {
-                observers.destroy();
+                if(observers != null) {
+                    observers.destroy();
+                }
             }
 
             @Override

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
@@ -313,7 +313,7 @@ public class ProjectControllerImpl implements ProjectController {
                 openWorkspace(workspace);
             }
         } else {
-            fireWorkspaceEvent(EventType.SELECT, projectImpl.getCurrentWorkspace());
+            //fireWorkspaceEvent(EventType.SELECT, projectImpl.getCurrentWorkspace());
         }
     }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description

https://github.com/gephi/gephi/issues/2731

When you open a gephi file with multiple workspace, the UI Freeze.
The cause looks to come from an "infinite loop" of `fireWorkspaceEvent(EVENT, workspace)` that appends after the completion of the open project.


## Checklist

- [ ] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [X] 🙅 no, because they aren’t needed
