### PR TITLE
Fixing Json export position normalization

### DIFF
--- a/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterJson.java
+++ b/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterJson.java
@@ -324,7 +324,7 @@ public class ExporterJson implements GraphExporter, CharacterExporter, LongTask 
                 float x = normalization.normalizeX(node.x());
                 float y = normalization.normalizeY(node.y());
                 float z = normalization.normalizeZ(node.z());
-                if (!(x == 0 && y == 0 && z == 0)) {
+                if (normalize || !(x == 0 && y == 0 && z == 0)) {
                     out.name("x");
                     out.value(x);
                     out.name("y");

--- a/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterJson.java
+++ b/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterJson.java
@@ -326,12 +326,12 @@ public class ExporterJson implements GraphExporter, CharacterExporter, LongTask 
                 float z = normalization.normalizeZ(node.z());
                 if (!(x == 0 && y == 0 && z == 0)) {
                     out.name("x");
-                    out.value(node.x());
+                    out.value(x);
                     out.name("y");
-                    out.value(node.y());
+                    out.value(y);
                     if (normalization.minZ != 0 || normalization.maxZ != 0) {
                         out.name("z");
-                        out.value(node.z());
+                        out.value(z);
                     }
                 }
             }

--- a/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/JsonTest.java
+++ b/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/JsonTest.java
@@ -81,7 +81,44 @@ public class JsonTest {
         exporterJson.setExportColors(true);
         Utils.assertExporterMatch("json/colors.json", exporterJson);
     }
+    
+    @Test
+    public void testPosition() throws IOException {
+                GraphGenerator graphGenerator =
+                GraphGenerator.build().generateTinyGraphWithPosition();
+        Graph graph = graphGenerator.getGraph();
+        Node n1 = graph.getNode(GraphGenerator.FIRST_NODE);
+        Node n2 = graph.getNode(GraphGenerator.SECOND_NODE);
+        n1.setColor(Color.CYAN);
+        n2.setColor(new Color(255, 100, 120, 254));
 
+        ExporterJson exporterJson = createExporter(graphGenerator);
+        exporterJson.setExportPosition(true);
+        exporterJson.setNormalize(false);
+        
+        exporterJson.execute();
+        Utils.assertExporterMatch("json/position.json", exporterJson);
+    }
+    
+    @Test
+    public void testPositionNormalized() throws IOException {
+                GraphGenerator graphGenerator =
+                GraphGenerator.build().generateTinyGraphWithPosition();
+        Graph graph = graphGenerator.getGraph();
+        Node n1 = graph.getNode(GraphGenerator.FIRST_NODE);
+        Node n2 = graph.getNode(GraphGenerator.SECOND_NODE);
+        n1.setColor(Color.CYAN);
+        n2.setColor(new Color(255, 100, 120, 254));
+
+        ExporterJson exporterJson = createExporter(graphGenerator);
+        exporterJson.setExportPosition(true);
+        exporterJson.setNormalize(true);
+ 
+        
+        exporterJson.execute();
+        Utils.assertExporterMatch("json/position_normalized.json", exporterJson);
+    }
+    
     private static ExporterJson createExporter(GraphGenerator graphGenerator) {
         Workspace workspace = graphGenerator.getWorkspace();
         ExporterJson exporterJson = new ExporterJson();
@@ -92,4 +129,5 @@ public class JsonTest {
         exporterJson.setExportSize(false);
         return exporterJson;
     }
+    
 }

--- a/modules/ExportPlugin/src/test/resources/org/gephi/io/exporter/plugin/json/position.json
+++ b/modules/ExportPlugin/src/test/resources/org/gephi/io/exporter/plugin/json/position.json
@@ -1,0 +1,33 @@
+{
+  "options": {
+    "multi": false,
+    "allowSelfLoops": true,
+    "type": "directed"
+  },
+  "nodes": [
+    {
+      "key": "1",
+      "attributes": {
+        "x": 2.5,
+        "y": 4.7
+      }
+    },
+    {
+      "key": "2",
+      "attributes": {
+        "x": -3.3,
+        "y": -5.4
+      }
+    }
+  ],
+  "edges": [
+    {
+      "key": "1",
+      "source": "1",
+      "target": "2",
+      "attributes": {
+        "weight": 1.0
+      }
+    }
+  ]
+}

--- a/modules/ExportPlugin/src/test/resources/org/gephi/io/exporter/plugin/json/position_normalized.json
+++ b/modules/ExportPlugin/src/test/resources/org/gephi/io/exporter/plugin/json/position_normalized.json
@@ -1,0 +1,33 @@
+{
+  "options": {
+    "multi": false,
+    "allowSelfLoops": true,
+    "type": "directed"
+  },
+  "nodes": [
+    {
+      "key": "1",
+      "attributes": {
+        "x": 1.0,
+        "y": 1.0
+      }
+    },
+    {
+      "key": "2",
+      "attributes": {
+        "x": 0.0,
+        "y": 0.0
+      }
+    }
+  ],
+  "edges": [
+    {
+      "key": "1",
+      "source": "1",
+      "target": "2",
+      "attributes": {
+        "weight": 1.0
+      }
+    }
+  ]
+}

--- a/modules/GraphAPI/src/test/java/org/gephi/graph/GraphGenerator.java
+++ b/modules/GraphAPI/src/test/java/org/gephi/graph/GraphGenerator.java
@@ -94,6 +94,20 @@ public class GraphGenerator {
         graphModel.getDirectedGraph().addEdge(e);
         return this;
     }
+    
+     public GraphGenerator generateTinyGraphWithPosition() {
+        Node n1 = graphModel.factory().newNode(FIRST_NODE);
+        n1.setX(2.5f);
+        n1.setY(4.7f);
+        Node n2 = graphModel.factory().newNode(SECOND_NODE);
+        n2.setX(-3.3f);
+        n2.setY(-5.4f);
+        Edge e = graphModel.factory().newEdge(FIRST_EDGE, n1, n2, 0, 1.0, true);
+        graphModel.getDirectedGraph().addNode(n1);
+        graphModel.getDirectedGraph().addNode(n2);
+        graphModel.getDirectedGraph().addEdge(e);
+        return this;
+    }
 
     public GraphGenerator generateTinyUndirectedGraph() {
         Node n1 = graphModel.factory().newNode(FIRST_NODE);


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->
https://github.com/gephi/gephi/issues/2741


## Description
When exporting, you can have the option to normalize the coordinate from 0 to 1.
This PR solve the issue.

Discussion : 
Current behaviour doesn't write the position component (X, Y, Z) in the json if all component = 0 : 
- With the normalization, this behaviour shouldn't appears, therefore added a condition to let write when XYZ=0
- Should we actually write anyway position with component XYZ = 0 i nany case ? 
<!--
Please include a summary of the code changes. Please also link the GitHub issue if it exists.
-->

## Checklist

- [X] Merged with master beforehand

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [X] 🙅 no, because they aren’t needed
