### PR TITLE
Remove warning when 0 mutual edges removed

### DIFF
--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
@@ -829,10 +829,10 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                     }
                 }
             }
-
-            report.logIssue(new Issue(NbBundle.getMessage(
-                ImportContainerImpl.class, "ImportContainerClose_MutualEdgesRemoved", mutualEdgesRemoved
-            ), Level.WARNING));
+            if (mutualEdgesRemoved != 0)
+                report.logIssue(new Issue(NbBundle.getMessage(
+                    ImportContainerImpl.class, "ImportContainerClose_MutualEdgesRemoved", mutualEdgesRemoved
+                ), Level.WARNING));
         }
         //TODO check when mixed is forced
 


### PR DESCRIPTION
## Description

Whenever we load an undirected graph from file, we get a warning that `{0} mutual edges removed`, even if it is actually 0 edges, meaning no mutual edges were removed.


![gephi-0-warnings](https://user-images.githubusercontent.com/17569537/229771655-38af823a-8e4a-4e94-8f64-85adce092e1c.png)

I have added a check `if (mutualEdgesRemoved != 0)` prior to issuing the warning.

Now the warning does not show if `0 mutual edges removed`.

## Checklist

- [X] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [X] 🙅 no, because they aren’t needed
