### PR TITLE
Change one timeline field trigger validation on both

### DIFF
--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
@@ -44,6 +44,8 @@ package org.gephi.desktop.timeline;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.text.NumberFormat;
 import java.util.Locale;
 import javax.swing.JTextField;
@@ -91,6 +93,52 @@ public class CustomBoundsDialog extends javax.swing.JPanel {
             @Override
             public void actionPerformed(ActionEvent e) {
                 setDefaults();
+            }
+        });
+        
+        // change one field trigger validation on both.
+        endTextField.addKeyListener(new KeyListener() {
+
+             @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+            
+            @Override
+            public void keyTyped(KeyEvent e) {
+                new java.util.Timer().schedule(
+                        new java.util.TimerTask() {
+                    @Override
+                    public void run() {
+                        startTextField.setText(startTextField.getText());
+                    }
+                }, 200);
+            }
+        });
+
+        // change one field trigger validation on both.
+        startTextField.addKeyListener(new KeyListener() {
+             @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+            
+            @Override
+            public void keyTyped(KeyEvent e) {
+                new java.util.Timer().schedule(
+                        new java.util.TimerTask() {
+                    @Override
+                    public void run() {
+                        endTextField.setText(endTextField.getText());
+                    }
+                }, 200);
+
             }
         });
     }


### PR DESCRIPTION
Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - #2854 Fix issue with overlooked timeline field validation


Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description

<!--
 - #2854 Fix issue with overlooked timeline field validation
 - Trigger validation on the paired timeline _Interval_ _Start_ or _End_ fields upon change of a single field, by calling the relevant **setText()** method.
 - A 200ms latency is added to handle the intricate and nested validation logic in external dependencies.

-->

## Checklist

- [ x ] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [ x ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [ x ] 🙅 no, because they aren’t needed
