### PR TITLE
#2779 Excluding '#' in DOT file parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [Gephi](http://gephi.org) is an award-winning open-source platform for visualizing and manipulating large graphs. It runs on Windows, Mac OS X and Linux. Localization is available in English, French, Spanish, Japanese, Russian, Brazilian Portuguese, Chinese, Czech, German and Romanian.
 
-- **Fast** Power by a built-in OpenGL engine, Gephi is able to push the envelope with very large networks. Visualize networks up to a million elements. All actions (e.g. layout, filter, drag) run in real-time.
+- **Fast** Powered by a built-in OpenGL engine, Gephi is able to push the envelope with very large networks. Visualize networks up to a million elements. All actions (e.g. layout, filter, drag) run in real-time.
 
 - **Simple** Easy to install and [get started](https://gephi.github.io/users/quick-start). An UI that is centered around the visualization. Like Photoshop™ for graphs.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [Gephi](http://gephi.org) is an award-winning open-source platform for visualizing and manipulating large graphs. It runs on Windows, Mac OS X and Linux. Localization is available in English, French, Spanish, Japanese, Russian, Brazilian Portuguese, Chinese, Czech, German and Romanian.
 
-- **Fast** Powered by a built-in OpenGL engine, Gephi is able to push the envelope with very large networks. Visualize networks up to a million elements. All actions (e.g. layout, filter, drag) run in real-time.
+- **Fast** Power by a built-in OpenGL engine, Gephi is able to push the envelope with very large networks. Visualize networks up to a million elements. All actions (e.g. layout, filter, drag) run in real-time.
 
 - **Simple** Easy to install and [get started](https://gephi.github.io/users/quick-start). An UI that is centered around the visualization. Like Photoshop™ for graphs.
 

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterDOT.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterDOT.java
@@ -106,7 +106,8 @@ public class ImporterDOT implements FileImporter, LongTask {
         tk.slashStarComments(true);
         tk.slashSlashComments(true);
         tk.whitespaceChars(0, ' ');
-        tk.wordChars(' ' + 1, '\u00ff');
+        tk.wordChars(' ' + 1, '#' - 1);
+        tk.wordChars('#' + 1, '\u00ff');
         tk.ordinaryChar('[');
         tk.ordinaryChar(']');
         tk.ordinaryChar('{');


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description

<!--

-->
Adjust the word character range in the DOT file parser to exclude '#' while considering characters in the specified range as word constituents. This ensures correct tokenization and parsing of DOT files, preventing '#' from being treated as part of words.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren’t needed
