### PR TITLE
#2454: Add “support localization” button to language menu

### DIFF
--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/multilingual/LanguageAction.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/multilingual/LanguageAction.java
@@ -43,10 +43,14 @@
 package org.gephi.branding.desktop.multilingual;
 
 import java.awt.event.ActionEvent;
+import java.awt.Desktop;
+import java.net.URI;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import javax.swing.AbstractAction;
 import javax.swing.Icon;
 import javax.swing.JMenu;
@@ -55,6 +59,7 @@ import javax.swing.JOptionPane;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.LifecycleManager;
+import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
@@ -116,6 +121,28 @@ public final class LanguageAction extends CallableSystemAction {
             }
             menu.add(menuItem);
         }
+
+        // Add "support localization" button to language menu
+        JMenuItem support_localization = new JMenuItem(new AbstractAction("Support localization...") {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                Desktop desktop = Desktop.getDesktop();
+                URI uri;
+                try {
+                    uri = new URI("https://hosted.weblate.org/projects/gephi/");
+                    try {
+                        desktop.browse(uri);
+                    } catch (IOException ex) {
+                        Exceptions.printStackTrace(ex);
+                    }
+                } catch (URISyntaxException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+            }
+        });
+
+        menu.add(support_localization);
 
         return menu;
     }


### PR DESCRIPTION
## Description

Fixes gephi/gephi#2454

Adds a menu item with the text “Support localization…” to the language menu. When clicked, opens the contributing page (https://hosted.weblate.org/projects/gephi/) in the system default browser.

Test this change: Just click the new button in the language menu

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed
