### PR TITLE
Layout Presets edition improvements

### DIFF
--- a/modules/DesktopLayout/pom.xml
+++ b/modules/DesktopLayout/pom.xml
@@ -80,6 +80,18 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-settings</artifactId>
         </dependency>
+
+        <!-- Test only -->
+        <dependency>
+            <groupId>org.gephi</groupId>
+            <artifactId>layout-plugin</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.modules</groupId>
+            <artifactId>org-netbeans-modules-masterfs</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPanel.java
+++ b/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPanel.java
@@ -59,13 +59,15 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import javax.swing.DefaultComboBoxModel;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
-import org.gephi.desktop.layout.LayoutPresetPersistence.Preset;
 import org.gephi.layout.api.LayoutController;
 import org.gephi.layout.api.LayoutModel;
+import org.gephi.layout.spi.Layout;
 import org.gephi.layout.spi.LayoutBuilder;
 import org.gephi.layout.spi.LayoutUI;
 import org.gephi.ui.components.richtooltip.RichTooltip;
@@ -148,20 +150,71 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
                 JPopupMenu menu = new JPopupMenu();
                 List<Preset> presets = layoutPresetPersistence.getPresets(model.getSelectedLayout());
                 if (presets != null && !presets.isEmpty()) {
+                    // One item per present to apply
                     for (final Preset p : presets) {
                         JMenuItem item = new JMenuItem(p.toString());
                         item.addActionListener(new ActionListener() {
                             @Override
                             public void actionPerformed(ActionEvent e) {
-                                layoutPresetPersistence.loadPreset(p, model.getSelectedLayout());
+                                Preset appliedPreset = layoutPresetPersistence.loadPreset(p, model.getSelectedLayout());
                                 refreshProperties();
-                                StatusDisplayer.getDefault().setStatusText(NbBundle
-                                    .getMessage(LayoutPanel.class, "LayoutPanel.status.loadPreset",
-                                        model.getSelectedBuilder().getName(), p.toString()));
+                                if (appliedPreset != null) {
+                                    StatusDisplayer.getDefault().setStatusText(NbBundle
+                                        .getMessage(LayoutPanel.class, "LayoutPanel.status.loadPreset",
+                                            model.getSelectedBuilder().getName(), p.toString()));
+                                }
                             }
                         });
                         menu.add(item);
                     }
+
+                    JMenu setDefault = new JMenu(NbBundle.getMessage(LayoutPanel.class, "LayoutPanel.presetsButton.setDefault"));
+                    if (layoutPresetPersistence.hasDefaultPreset(model.getSelectedLayout())) {
+                        JMenuItem item = new JMenuItem(NbBundle.getMessage(LayoutPanel.class, "LayoutPanel.presetsButton.setDefault.remove"));
+                        item.addActionListener(new ActionListener() {
+                            @Override
+                            public void actionPerformed(ActionEvent e) {
+                                layoutPresetPersistence.setDefaultPresent(null, model.getSelectedLayout());
+                                StatusDisplayer.getDefault().setStatusText(NbBundle
+                                    .getMessage(LayoutPanel.class, "LayoutPanel.status.removeDefaultPreset",
+                                        model.getSelectedBuilder().getName()));
+                            }
+                        });
+                        setDefault.add(item);
+                    }
+                    for (final Preset p : presets) {
+                        boolean isDefault = layoutPresetPersistence.isDefaultPreset(p.toString(), model.getSelectedLayout());
+                        JCheckBoxMenuItem item = new JCheckBoxMenuItem(p.toString(), isDefault);
+                        item.addActionListener(new ActionListener() {
+                            @Override
+                            public void actionPerformed(ActionEvent e) {
+                                layoutPresetPersistence.setDefaultPresent(p.toString(), model.getSelectedLayout());
+                                StatusDisplayer.getDefault().setStatusText(NbBundle
+                                    .getMessage(LayoutPanel.class, "LayoutPanel.status.setDefaultPreset",
+                                        model.getSelectedBuilder().getName(), p.toString()));
+                            }
+                        });
+                        setDefault.add(item);
+                    }
+                    menu.add(new JSeparator());
+                    menu.add(setDefault);
+
+                    JMenu deletePresets = new JMenu(NbBundle.getMessage(LayoutPanel.class, "LayoutPanel.presetsButton.deletePresets"));
+                    for (final Preset p : presets) {
+                        JMenuItem item = new JMenuItem(p.toString());
+                        item.addActionListener(new ActionListener() {
+                            @Override
+                            public void actionPerformed(ActionEvent e) {
+                                layoutPresetPersistence.deletePreset(p);
+                                StatusDisplayer.getDefault().setStatusText(NbBundle
+                                    .getMessage(LayoutPanel.class, "LayoutPanel.status.deletePreset",
+                                        model.getSelectedBuilder().getName(), p.toString()));
+                            }
+                        });
+                        deletePresets.add(item);
+                    }
+                    menu.add(new JSeparator());
+                    menu.add(deletePresets);
                 } else {
                     menu.add(
                         "<html><i>" + NbBundle.getMessage(LayoutPanel.class, "LayoutPanel.presetsButton.nopreset") +
@@ -182,6 +235,18 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
                         if (DialogDisplayer.getDefault().notify(question) == NotifyDescriptor.OK_OPTION) {
                             String input = question.getInputText();
                             if (input != null && !input.isEmpty()) {
+                                if (layoutPresetPersistence.hasPreset(input, model.getSelectedLayout().getClass().getName())) {
+                                    String message =
+                                        NbBundle.getMessage(LayoutPanel.class, "LayoutPanel.presetsButton.savePresetReplace.text");
+                                    String title = NbBundle.getMessage(LayoutPanel.class, "LayoutPanel.presetsButton.savePresetReplace.title");
+                                    NotifyDescriptor dd = new NotifyDescriptor(message, title,
+                                        NotifyDescriptor.YES_NO_OPTION,
+                                        NotifyDescriptor.QUESTION_MESSAGE, null, null);
+                                    Object retType = DialogDisplayer.getDefault().notify(dd);
+                                    if (retType == NotifyDescriptor.NO_OPTION) {
+                                        return;
+                                    }
+                                }
                                 layoutPresetPersistence.savePreset(input, model.getSelectedLayout());
                                 StatusDisplayer.getDefault().setStatusText(NbBundle
                                     .getMessage(LayoutPanel.class, "LayoutPanel.status.savePreset",
@@ -214,6 +279,21 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
             refreshModel();
         } else if (evt.getPropertyName().equals(LayoutModel.RUNNING)) {
             refreshModel();
+        } else if (evt.getPropertyName().equals(LayoutModel.DEFAULTS_APPLIED)) {
+            loadDefaultProperties();
+        }
+    }
+
+    private void loadDefaultProperties() {
+        Layout layout = model.getSelectedLayout();
+        if (layout != null) {
+            Preset appliedPreset = layoutPresetPersistence.loadDefaultPreset(layout);
+            if (appliedPreset != null) {
+                StatusDisplayer.getDefault().setStatusText(NbBundle
+                    .getMessage(LayoutPanel.class, "LayoutPanel.status.loadPreset",
+                        model.getSelectedBuilder().getName(), appliedPreset.toString()));
+            }
+            refreshProperties();
         }
     }
 
@@ -307,13 +387,17 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
     }
 
     private void setSelectedLayout(LayoutBuilder builder) {
-        controller.setLayout(builder != null ? model.getLayout(builder) : null);
+        Layout layout = builder != null ? builder.buildLayout() : null;
+        controller.setLayout(layout);
     }
 
     private void reset() {
         if (model.getSelectedLayout() != null) {
-            model.getSelectedLayout().resetPropertiesValues();
+            layoutPresetPersistence.loadDefaultPreset(model.getSelectedLayout());
             refreshProperties();
+            StatusDisplayer.getDefault().setStatusText(NbBundle
+                .getMessage(LayoutPanel.class, "LayoutPanel.status.reset",
+                    model.getSelectedBuilder().getName()));
         }
     }
 
@@ -504,7 +588,6 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
         private static final int IMAGE_RIGHT_MARIN = 10;
         private final Image greenIcon;
         private final Image grayIcon;
-        private Graphics g;
         private final String qualityStr;
         private final String speedStr;
         private int textMaxSize;
@@ -537,7 +620,7 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
 
             //Paint
             BufferedImage img = new BufferedImage(imageWidth, 100, BufferedImage.TYPE_INT_ARGB);
-            this.g = img.getGraphics();
+            Graphics g = img.getGraphics();
             paint(g);
             return img;
         }

--- a/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPresetPersistence.java
+++ b/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPresetPersistence.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
@@ -65,10 +66,8 @@ import org.gephi.layout.spi.Layout;
 import org.gephi.layout.spi.LayoutProperty;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.NbPreferences;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * @author Mathieu Bastian
@@ -76,9 +75,54 @@ import org.w3c.dom.NodeList;
 public class LayoutPresetPersistence {
 
     private final Map<String, List<Preset>> presets = new HashMap<>();
+    private final Map<String, String> defaultPresets = new HashMap<>();
 
     public LayoutPresetPersistence() {
         loadPresets();
+
+        // Load defaults from preferences
+        for(String layoutClassName : presets.keySet()) {
+            String defaultPreset = NbPreferences.forModule(LayoutPresetPersistence.class).get("LayoutPresetPersistence_defaultPreset_"+layoutClassName, null);
+            if (defaultPreset != null && hasPreset(defaultPreset, layoutClassName)) {
+                defaultPresets.put(layoutClassName, defaultPreset);
+                Logger.getLogger(LayoutPresetPersistence.class.getName()).log(Level.INFO, "Default preset for {0} loaded: {1}", new Object[]{layoutClassName, defaultPreset});
+            }
+        }
+    }
+
+    public boolean hasPreset(String name, String layoutClassName) {
+        List<Preset> layoutPresets = presets.get(layoutClassName);
+        return layoutPresets != null && layoutPresets.stream().anyMatch(p -> p.name.equals(name));
+    }
+
+    public Preset getPreset(String name, Layout layout) {
+        List<Preset> layoutPresets = presets.get(layout.getClass().getName());
+        if (layoutPresets == null) {
+            return null;
+        }
+        Optional<Preset> preset = layoutPresets.stream()
+            .filter(p -> p.name.equals(name))
+            .findFirst();
+        return preset.orElse(null);
+    }
+
+    public void setDefaultPresent(String name, Layout layout) {
+        if (name == null) {
+            defaultPresets.remove(layout.getClass().getName());
+            NbPreferences.forModule(LayoutPresetPersistence.class).remove("LayoutPresetPersistence_defaultPreset_"+layout.getClass().getName());
+        } else {
+            defaultPresets.put(layout.getClass().getName(), name);
+            NbPreferences.forModule(LayoutPresetPersistence.class).put("LayoutPresetPersistence_defaultPreset_"+layout.getClass().getName(), name);
+        }
+    }
+
+    public boolean hasDefaultPreset(Layout layout) {
+        return defaultPresets.containsKey(layout.getClass().getName());
+    }
+
+    public boolean isDefaultPreset(String name, Layout layout) {
+        String defaultPreset = defaultPresets.get(layout.getClass().getName());
+        return defaultPreset != null && defaultPreset.equals(name);
     }
 
     public void savePreset(String name, Layout layout) {
@@ -123,7 +167,40 @@ public class LayoutPresetPersistence {
         }
     }
 
-    public void loadPreset(Preset preset, Layout layout) {
+    public void deletePreset(Preset preset) {
+        // Remove default preset if needed
+        if (defaultPresets.containsKey(preset.layoutClassName) && defaultPresets.get(preset.layoutClassName).equals(preset.name)) {
+            defaultPresets.remove(preset.layoutClassName);
+        }
+        List<Preset> layoutPresets = presets.get(preset.layoutClassName);
+        layoutPresets.remove(preset);
+        FileObject folder = FileUtil.getConfigFile("layoutpresets");
+        if (folder != null) {
+            FileObject file = folder.getFileObject(preset.name + ".xml");
+            if (file != null) {
+                try {
+                    file.delete();
+                } catch (IOException ex) {
+                    Logger.getLogger("").log(Level.SEVERE, "Error while deleting preset file", ex);
+                }
+            }
+        }
+    }
+
+    public Preset loadDefaultPreset(Layout layout) {
+        String defaultPreset = defaultPresets.get(layout.getClass().getName());
+        if (defaultPreset != null) {
+            Preset preset = getPreset(defaultPreset, layout);
+            if (preset != null) {
+                return loadPreset(preset, layout);
+            }
+        } else {
+            layout.resetPropertiesValues();
+        }
+        return null;
+    }
+
+    public Preset loadPreset(Preset preset, Layout layout) {
         for (LayoutProperty p : layout.getProperties()) {
             for (int i = 0; i < preset.propertyNames.size(); i++) {
                 if (p.getCanonicalName().equalsIgnoreCase(preset.propertyNames.get(i))
@@ -137,6 +214,7 @@ public class LayoutPresetPersistence {
                 }
             }
         }
+        return preset;
     }
 
     public List<Preset> getPresets(Layout layout) {
@@ -164,11 +242,7 @@ public class LayoutPresetPersistence {
     }
 
     private Preset addPreset(Preset preset) {
-        List<Preset> layoutPresets = presets.get(preset.layoutClassName);
-        if (layoutPresets == null) {
-            layoutPresets = new ArrayList<>();
-            presets.put(preset.layoutClassName, layoutPresets);
-        }
+        List<Preset> layoutPresets = presets.computeIfAbsent(preset.layoutClassName, k -> new ArrayList<>());
         for (Preset p : layoutPresets) {
             if (p.equals(preset)) {
                 return p;
@@ -178,125 +252,4 @@ public class LayoutPresetPersistence {
         return preset;
     }
 
-    protected static class Preset {
-
-        private final List<String> propertyNames = new ArrayList<>();
-        private final List<Object> propertyValues = new ArrayList<>();
-        private String layoutClassName;
-        private String name;
-
-        private Preset(String name, Layout layout) {
-            this.name = name;
-            this.layoutClassName = layout.getClass().getName();
-            for (LayoutProperty p : layout.getProperties()) {
-                try {
-                    Object value = p.getProperty().getValue();
-                    if (value != null) {
-                        propertyNames.add(p.getCanonicalName());
-                        propertyValues.add(value);
-                    }
-                } catch (Exception e) {
-                }
-            }
-        }
-
-        private Preset(Document document) {
-            readXML(document);
-        }
-
-        public void readXML(Document document) {
-            NodeList propertiesList = document.getDocumentElement().getElementsByTagName("properties");
-            if (propertiesList.getLength() > 0) {
-                for (int j = 0; j < propertiesList.getLength(); j++) {
-                    Node m = propertiesList.item(j);
-                    if (m.getNodeType() == Node.ELEMENT_NODE) {
-                        Element propertiesE = (Element) m;
-                        layoutClassName = propertiesE.getAttribute("layoutClassName");
-                        name = propertiesE.getAttribute("name");
-                        NodeList propertyList = propertiesE.getElementsByTagName("property");
-                        for (int i = 0; i < propertyList.getLength(); i++) {
-                            Node n = propertyList.item(i);
-                            if (n.getNodeType() == Node.ELEMENT_NODE) {
-                                Element propertyE = (Element) n;
-                                String propStr = propertyE.getAttribute("property");
-                                String classStr = propertyE.getAttribute("class");
-                                String valStr = propertyE.getTextContent();
-                                Object value = parse(classStr, valStr);
-                                if (value != null) {
-                                    propertyNames.add(propStr);
-                                    propertyValues.add(value);
-                                }
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-
-        private Object parse(String classStr, String str) {
-            try {
-                Class c = Class.forName(classStr);
-                if (c.equals(Boolean.class)) {
-                    return new Boolean(str);
-                } else if (c.equals(Integer.class)) {
-                    return new Integer(str);
-                } else if (c.equals(Float.class)) {
-                    return new Float(str);
-                } else if (c.equals(Double.class)) {
-                    return new Double(str);
-                } else if (c.equals(Long.class)) {
-                    return new Long(str);
-                } else if (c.equals(String.class)) {
-                    return str;
-                }
-            } catch (ClassNotFoundException ex) {
-                return null;
-            }
-            return null;
-        }
-
-        public void writeXML(Document document) {
-            Element rootE = document.createElement("layoutproperties");
-
-            //Properties
-            Element propertiesE = document.createElement("properties");
-            propertiesE.setAttribute("layoutClassName", layoutClassName);
-            propertiesE.setAttribute("name", name);
-            propertiesE.setAttribute("version", "0.7");
-            for (int i = 0; i < propertyNames.size(); i++) {
-                Element propertyE = document.createElement("property");
-                propertyE.setAttribute("property", propertyNames.get(i));
-                propertyE.setAttribute("class", propertyValues.get(i).getClass().getName());
-                propertyE.setTextContent(propertyValues.get(i).toString());
-                propertiesE.appendChild(propertyE);
-            }
-            rootE.appendChild(propertiesE);
-            document.appendChild(rootE);
-        }
-
-        @Override
-        public String toString() {
-            return name;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            final Preset other = (Preset) obj;
-            return (this.name == null) ? (other.name == null) : this.name.equals(other.name);
-        }
-
-        @Override
-        public int hashCode() {
-            int hash = 3;
-            hash = 37 * hash + (this.name != null ? this.name.hashCode() : 0);
-            return hash;
-        }
-    }
 }

--- a/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/Preset.java
+++ b/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/Preset.java
@@ -1,0 +1,134 @@
+package org.gephi.desktop.layout;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.gephi.layout.spi.Layout;
+import org.gephi.layout.spi.LayoutProperty;
+import org.openide.util.Exceptions;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class Preset {
+
+    protected final List<String> propertyNames = new ArrayList<>();
+    protected final List<Object> propertyValues = new ArrayList<>();
+    protected String layoutClassName;
+    protected String name;
+
+    Preset(String name, Layout layout) {
+        this.name = name;
+        this.layoutClassName = layout.getClass().getName();
+        for (LayoutProperty p : layout.getProperties()) {
+            try {
+                Object value = p.getProperty().getValue();
+                if (value != null) {
+                    propertyNames.add(p.getCanonicalName());
+                    propertyValues.add(value);
+                }
+            } catch (Exception e) {
+                Exceptions.printStackTrace(e);
+            }
+        }
+    }
+
+    Preset(Document document) {
+        readXML(document);
+    }
+
+    public void readXML(Document document) {
+        NodeList propertiesList = document.getDocumentElement().getElementsByTagName("properties");
+        if (propertiesList.getLength() > 0) {
+            for (int j = 0; j < propertiesList.getLength(); j++) {
+                Node m = propertiesList.item(j);
+                if (m.getNodeType() == Node.ELEMENT_NODE) {
+                    Element propertiesE = (Element) m;
+                    layoutClassName = propertiesE.getAttribute("layoutClassName");
+                    name = propertiesE.getAttribute("name");
+                    NodeList propertyList = propertiesE.getElementsByTagName("property");
+                    for (int i = 0; i < propertyList.getLength(); i++) {
+                        Node n = propertyList.item(i);
+                        if (n.getNodeType() == Node.ELEMENT_NODE) {
+                            Element propertyE = (Element) n;
+                            String propStr = propertyE.getAttribute("property");
+                            String classStr = propertyE.getAttribute("class");
+                            String valStr = propertyE.getTextContent();
+                            Object value = parse(classStr, valStr);
+                            if (value != null) {
+                                propertyNames.add(propStr);
+                                propertyValues.add(value);
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    private Object parse(String classStr, String str) {
+        try {
+            Class<?> c = Class.forName(classStr);
+            if (c.equals(Boolean.class)) {
+                return Boolean.parseBoolean(str);
+            } else if (c.equals(Integer.class)) {
+                return Integer.parseInt(str);
+            } else if (c.equals(Float.class)) {
+                return Float.parseFloat(str);
+            } else if (c.equals(Double.class)) {
+                return Double.parseDouble(str);
+            } else if (c.equals(Long.class)) {
+                return Long.parseLong(str);
+            } else if (c.equals(String.class)) {
+                return str;
+            }
+        } catch (ClassNotFoundException ex) {
+            return null;
+        }
+        return null;
+    }
+
+    public void writeXML(Document document) {
+        Element rootE = document.createElement("layoutproperties");
+
+        //Properties
+        Element propertiesE = document.createElement("properties");
+        propertiesE.setAttribute("layoutClassName", layoutClassName);
+        propertiesE.setAttribute("name", name);
+        propertiesE.setAttribute("version", "0.7");
+        for (int i = 0; i < propertyNames.size(); i++) {
+            Element propertyE = document.createElement("property");
+            propertyE.setAttribute("property", propertyNames.get(i));
+            propertyE.setAttribute("class", propertyValues.get(i).getClass().getName());
+            propertyE.setTextContent(propertyValues.get(i).toString());
+            propertiesE.appendChild(propertyE);
+        }
+        rootE.appendChild(propertiesE);
+        document.appendChild(rootE);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Preset other = (Preset) obj;
+        return (this.name == null) ? (other.name == null) : this.name.equals(other.name);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 37 * hash + (this.name != null ? this.name.hashCode() : 0);
+        return hash;
+    }
+}

--- a/modules/DesktopLayout/src/main/resources/org/gephi/desktop/layout/Bundle.properties
+++ b/modules/DesktopLayout/src/main/resources/org/gephi/desktop/layout/Bundle.properties
@@ -20,7 +20,16 @@ LayoutPanel.presetsButton.text=Presets...
 LayoutPanel.presetsButton.savePreset=Save preset...
 LayoutPanel.presetsButton.savePreset.input = Name
 LayoutPanel.presetsButton.savePreset.input.name = Preset name
+LayoutPanel.presetsButton.savePresetReplace.title = Preset exists
+LayoutPanel.presetsButton.savePresetReplace.text = A preset with the same name already exists. Do you want to replace it?
 LayoutPanel.presetsButton.nopreset=No preset
+LayoutPanel.presetsButton.deletePresets=Delete presets...
+LayoutPanel.presetsButton.setDefault=Set default...
+LayoutPanel.presetsButton.setDefault.remove=Remove default
 
 LayoutPanel.status.savePreset= {0} preset "{1}" saved
 LayoutPanel.status.loadPreset= {0} preset "{1}" loaded
+LayoutPanel.status.reset=Defaults reloaded for {0}
+LayoutPanel.status.deletePreset= {0} preset "{1}" deleted
+LayoutPanel.status.setDefaultPreset=Default preset for {0} set to "{1}"
+LayoutPanel.status.removeDefaultPreset=Default preset for {0} removed, Gephi default will be used

--- a/modules/DesktopLayout/src/test/java/org/gephi/desktop/layout/LayoutPresetPersistenceTest.java
+++ b/modules/DesktopLayout/src/test/java/org/gephi/desktop/layout/LayoutPresetPersistenceTest.java
@@ -1,0 +1,20 @@
+package org.gephi.desktop.layout;
+
+import org.gephi.layout.plugin.forceAtlas.ForceAtlas;
+import org.gephi.layout.plugin.fruchterman.FruchtermanReingold;
+import org.gephi.layout.plugin.fruchterman.FruchtermanReingoldBuilder;
+import org.gephi.layout.plugin.scale.Contract;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LayoutPresetPersistenceTest {
+
+    private static final Contract BUILDER = new Contract();
+
+    @Test
+    public void testEmpty() {
+        LayoutPresetPersistence persistence = new LayoutPresetPersistence();
+        Assert.assertNull(persistence.getPresets(BUILDER.buildLayout()));
+    }
+
+}

--- a/modules/DesktopLayout/src/test/java/org/gephi/desktop/layout/LayoutPresetPersistenceTest.java
+++ b/modules/DesktopLayout/src/test/java/org/gephi/desktop/layout/LayoutPresetPersistenceTest.java
@@ -1,20 +1,57 @@
 package org.gephi.desktop.layout;
 
-import org.gephi.layout.plugin.forceAtlas.ForceAtlas;
-import org.gephi.layout.plugin.fruchterman.FruchtermanReingold;
-import org.gephi.layout.plugin.fruchterman.FruchtermanReingoldBuilder;
 import org.gephi.layout.plugin.scale.Contract;
+import org.gephi.layout.plugin.scale.ContractLayout;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class LayoutPresetPersistenceTest {
 
     private static final Contract BUILDER = new Contract();
+    private LayoutPresetPersistence persistence;
+
+    @Before
+    public void setUp() {
+        persistence = new LayoutPresetPersistence();
+    }
+
+    @After
+    public void tearDown() {
+        persistence.reset();
+    }
 
     @Test
     public void testEmpty() {
-        LayoutPresetPersistence persistence = new LayoutPresetPersistence();
         Assert.assertNull(persistence.getPresets(BUILDER.buildLayout()));
     }
 
+    @Test
+    public void testSave() {
+        persistence.savePreset("preset1", BUILDER.buildLayout());
+        Assert.assertEquals(1, persistence.getPresets(BUILDER.buildLayout()).size());
+        Assert.assertTrue(persistence.hasPreset("preset1", BUILDER.buildLayout().getClass().getName()));
+    }
+
+    @Test
+    public void testSaveMultiple() {
+        persistence.savePreset("preset1", BUILDER.buildLayout());
+        persistence.savePreset("preset2", BUILDER.buildLayout());
+        Assert.assertEquals(2, persistence.getPresets(BUILDER.buildLayout()).size());
+        Assert.assertTrue(persistence.hasPreset("preset2", BUILDER.buildLayout().getClass().getName()));
+    }
+
+    @Test
+    public void testLoad() {
+        ContractLayout layout = BUILDER.buildLayout();
+        layout.setScale(42.0);
+        persistence.savePreset("42", layout);
+
+        layout.resetPropertiesValues();
+        Preset preset = persistence.getPreset("42", layout);
+        Assert.assertNotNull(preset);
+        persistence.loadPreset(preset, layout);
+        Assert.assertEquals(42.0, layout.getScale(), 0.0001);
+    }
 }

--- a/modules/LayoutAPI/src/main/java/org/gephi/layout/api/LayoutModel.java
+++ b/modules/LayoutAPI/src/main/java/org/gephi/layout/api/LayoutModel.java
@@ -52,7 +52,12 @@ import org.gephi.project.api.Workspace;
  * user interface. There is one model per {@link Workspace}
  * <p>
  * <code>PropertyChangeListener</code> can be used to receive events about
- * a change in the model.
+ * a change in the model. The events are the following:
+ * <ul>
+ *     <li><code>SELECTED_LAYOUT</code> : when the selected layout changes</li>
+ *     <li><code>RUNNING</code> : when the running flag changes</li>
+ *     <li><code>DEFAULTS_APPLIED</code> : when the default properties are applied to the layout</li>
+ * </ul>
  *
  * @author Mathieu Bastian
  */
@@ -60,6 +65,7 @@ public interface LayoutModel {
 
     String SELECTED_LAYOUT = "selectedLayout";
     String RUNNING = "running";
+    String DEFAULTS_APPLIED = "defaultsApplied";
 
     /**
      * Returns the currently selected layout or <code>null</code> if no

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/random/RandomLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/random/RandomLayout.java
@@ -121,6 +121,7 @@ public class RandomLayout extends AbstractLayout implements Layout {
 
     @Override
     public void resetPropertiesValues() {
+        setSize(50.0);
     }
 
     public Double getSize() {

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/rotate/RotateLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/rotate/RotateLayout.java
@@ -104,6 +104,7 @@ public class RotateLayout extends AbstractLayout implements Layout {
 
     @Override
     public void resetPropertiesValues() {
+        setAngle(90.0);
     }
 
     @Override

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/scale/AbstractScaleLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/scale/AbstractScaleLayout.java
@@ -122,10 +122,6 @@ public abstract class AbstractScaleLayout extends AbstractLayout implements Layo
         return properties.toArray(new LayoutProperty[0]);
     }
 
-    @Override
-    public void resetPropertiesValues() {
-    }
-
     /**
      * @return the scale
      */

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/scale/ContractLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/scale/ContractLayout.java
@@ -50,4 +50,8 @@ public class ContractLayout extends AbstractScaleLayout {
         super(layoutBuilder, scale);
     }
 
+    @Override
+    public void resetPropertiesValues() {
+        setScale(0.8);
+    }
 }

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/scale/ExpandLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/scale/ExpandLayout.java
@@ -50,4 +50,8 @@ public class ExpandLayout extends AbstractScaleLayout {
         super(layoutBuilder, scale);
     }
 
+    @Override
+    public void resetPropertiesValues() {
+        setScale(1.2);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -969,6 +969,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>--add-opens java.base/java.net=ALL-UNNAMED</argLine>
                     <skipTests>true</skipTests>
                     <trimStackTrace>false</trimStackTrace>                                                              
                 </configuration>


### PR DESCRIPTION
## Description

Makes several improvements to the Layout preset features:
- Deletion of presets (requested in #1533)
- When an existing preset with the same name exists, a dialog asks whether they want to override (requested in #2607)
- A preset can be set as "default". This will be applied as the default instead of Gephi's default. It's configurable via the UI. (requested in #2071)

## Checklist

- [X] Merged with master beforehand

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [X] 🙅 no, because they aren’t needed

UI overview:
<img width="488" alt="Screenshot 2024-09-07 at 16 57 45" src="https://github.com/user-attachments/assets/6d752ba7-154b-41aa-a33f-c7970cc45981">
<img width="289" alt="Screenshot 2024-09-07 at 16 57 36" src="https://github.com/user-attachments/assets/92de32fb-b86b-4269-8628-1cded54ff114">
