### PR TITLE
Temporary Directory Hijacking vulnerability

### DIFF
--- a/modules/Utils/src/main/java/org/gephi/utils/TempDirUtils.java
+++ b/modules/Utils/src/main/java/org/gephi/utils/TempDirUtils.java
@@ -44,6 +44,7 @@ package org.gephi.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * @author Mathieu Bastian
@@ -57,17 +58,7 @@ public class TempDirUtils {
     public static File createTempDirectory() throws IOException {
         final File temp;
 
-        temp = File.createTempFile("temp", Long.toString(System.nanoTime()));
-        temp.deleteOnExit();
-
-        if (!(temp.delete())) {
-            throw new IOException("Could not delete temp file: " + temp.getAbsolutePath());
-        }
-
-        if (!(temp.mkdir())) {
-            throw new IOException("Could not create temp directory: " + temp.getAbsolutePath());
-        }
-
+        temp = Files.createTempDirectory("temp" + Long.toString(System.nanoTime())).toFile();
 
         return (temp);
     }


### PR DESCRIPTION
**Description:**
Fixed a high severity (CVSS 7.3) security vulnerability in TempDirUtils.createTempDirectory(). Replaced the insecure pattern of creating/deleting a temp file before making a directory with Java NIO's Files.createTempDirectory(), which is atomic and secure.
This vulnerability could enable attackers to hijack temporary directories through race conditions. The function is actively used in the import controller.

**References:**
Similar fix: https://github.com/UniversaBlockchain/universa/commit/1e34b1804842a7a2ba27fa9f4210a6fcb340d517