### PR TITLE
Fix #3034 edge pencil panel doesn't use weight

### DIFF
--- a/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
@@ -151,6 +151,7 @@ public class EdgePencil implements Tool {
                     boolean directed = edgePencilPanel.isDirected;
                     Edge edge =
                         Lookup.getDefault().lookup(GraphElementsController.class).createEdge(sourceNode, n, directed);
+                    edge.setWeight(weight);
                     edge.setColor(color);
                     sourceNode = null;
                     edgePencilPanel.setStatus(NbBundle.getMessage(EdgePencil.class, "EdgePencil.status1"));

--- a/modules/ToolsPlugin/src/main/java/org/gephi/ui/tools/plugin/EdgePencilPanel.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/ui/tools/plugin/EdgePencilPanel.java
@@ -93,7 +93,7 @@ public class EdgePencilPanel extends javax.swing.JPanel {
     }
 
     public void setWeight(float weight) {
-        weightSpinner.getModel().setValue(new Float(weight));
+        weightSpinner.getModel().setValue(weight);
     }
 
     public void setType(boolean directed) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description

Fix #3034

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren’t needed
