### PR TITLE
Unecessary use of Node Generator within initBuffer as it's instancied in the AbstractNodeData constructor

### DIFF
--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractNodeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractNodeData.java
@@ -128,10 +128,6 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
     }
 
     protected void initCirclesGLVertexBuffer(GL gl, final int bufferName) {
-        final NodeDiskVertexDataGenerator generator64 = new NodeDiskVertexDataGenerator(64);
-        final NodeDiskVertexDataGenerator generator32 = new NodeDiskVertexDataGenerator(32);
-        final NodeDiskVertexDataGenerator generator16 = new NodeDiskVertexDataGenerator(16);
-        final NodeDiskVertexDataGenerator generator8 = new NodeDiskVertexDataGenerator(8);
 
         final float[] circleVertexData = new float[
                 generator64.getVertexData().length


### PR DESCRIPTION

<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description

<!--
Please include a summary of the code changes. Please also link the GitHub issue if it exists.
-->

## Checklist

- [ ] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed
