### PR TITLE
AbstractNodeData.BORDER_SIZE not needed as it moved to Constants class

### DIFF
--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractNodeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractNodeData.java
@@ -40,9 +40,6 @@ import org.gephi.viz.engine.util.structure.NodesCallback;
  */
 public abstract class AbstractNodeData extends AbstractSelectionData {
 
-    protected static final float BORDER_SIZE = 0.16f;
-    protected static final float INSIDE_CIRCLE_SIZE = 1 - BORDER_SIZE;
-
     protected static final int OBSERVED_SIZE_LOD_THRESHOLD_64 = 128;
     protected static final int OBSERVED_SIZE_LOD_THRESHOLD_32 = 16;
     protected static final int OBSERVED_SIZE_LOD_THRESHOLD_16 = 2;


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description

<!--
Please include a summary of the code changes. Please also link the GitHub issue if it exists.
-->

## Checklist

- [ ] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed
