### PR TITLE
Adapt ImportAPI to properly set GraphModel's configuration at creation time, and clarify process() workspace management

### DIFF
--- a/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/DesktopImportControllerUI.java
+++ b/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/DesktopImportControllerUI.java
@@ -76,6 +76,7 @@ import org.gephi.io.importer.spi.ImporterUI;
 import org.gephi.io.importer.spi.ImporterWizardUI;
 import org.gephi.io.importer.spi.WizardImporter;
 import org.gephi.io.processor.spi.Processor;
+import org.gephi.io.processor.spi.ProcessorConfigurationException;
 import org.gephi.io.processor.spi.ProcessorUI;
 import org.gephi.lib.validation.DialogDescriptorWithValidation;
 import org.gephi.project.api.Project;
@@ -86,6 +87,7 @@ import org.gephi.utils.TempDirUtils;
 import org.gephi.utils.longtask.api.LongTaskErrorHandler;
 import org.gephi.utils.longtask.api.LongTaskExecutor;
 import org.gephi.utils.longtask.spi.LongTask;
+import org.gephi.utils.progress.Progress;
 import org.gephi.utils.progress.ProgressTicket;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
@@ -643,14 +645,6 @@ public class DesktopImportControllerUI implements ImportControllerUI {
                 final Processor processor = reportPanel.getProcessor();
                 processor.setProgressTicket(progressTicket);
 
-                //Project
-                Workspace workspace = null;
-                ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-                if (pc.getCurrentProject() == null) {
-                    Project project = pc.newProject();
-                    workspace = project.getCurrentWorkspace();
-                }
-
                 //Process
                 final ProcessorUI pui = getProcessorUI(processor);
                 final ValidResult validResult = new ValidResult();
@@ -683,7 +677,17 @@ public class DesktopImportControllerUI implements ImportControllerUI {
                 }
 
                 if (validResult.isResult()) {
-                    controller.process(containers.toArray(new Container[0]), processor, workspace);
+                    // We don't pre-create the workspace
+                    // This is now required because GraphModel's configuration needs to be final
+                    // at the time of creation, and therefore if we were to create a workspace now
+                    // it could have conflicting configuration
+                    try {
+                        controller.process(containers.toArray(new Container[0]), processor, null);
+                    } catch (ProcessorConfigurationException e) {
+                        // Configuration mismatch is already captured as a SEVERE issue in the processor report
+                    } finally {
+                        Progress.finish(progressTicket);
+                    }
 
                     Report report = processor.getReport();
                     if (report != null && !report.isEmpty()) {

--- a/modules/GraphAPI/src/main/java/org/gephi/graph/GraphControllerImpl.java
+++ b/modules/GraphAPI/src/main/java/org/gephi/graph/GraphControllerImpl.java
@@ -79,6 +79,9 @@ public class GraphControllerImpl implements GraphController {
         Configuration config = workspace.getLookup().lookup(Configuration.class);
         if (config == null) {
             config = getDefaultConfigurationBuilder().build();
+        } else {
+            // Clean config as we don't need it after creating the graph model
+            workspace.remove(config);
         }
         GraphModel graphModelImpl = GraphModel.Factory.newInstance(config);
         workspace.add(graphModelImpl);

--- a/modules/GraphAPI/src/main/java/org/gephi/graph/api/GraphController.java
+++ b/modules/GraphAPI/src/main/java/org/gephi/graph/api/GraphController.java
@@ -79,7 +79,6 @@ public interface GraphController {
      * @return a new configuration builder with default values
      */
     default Configuration.Builder getDefaultConfigurationBuilder() {
-        return Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL)
-            .enableSpatialIndex(true);
+        return Configuration.builder().timeRepresentation(TimeRepresentation.INTERVAL);
     }
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/AbstractDatabase.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/AbstractDatabase.java
@@ -46,6 +46,8 @@ import org.gephi.io.database.drivers.SQLDriver;
 import org.gephi.io.database.drivers.SQLUtils;
 
 /**
+ * Abstract base implementation of {@link Database}, providing storage for standard connection parameters.
+ *
  * @author Mathieu Bastian
  */
 public abstract class AbstractDatabase implements Database {

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerLoader.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerLoader.java
@@ -292,16 +292,57 @@ public interface ContainerLoader {
      */
     void setMetadata(MetadataDraft metadata);
 
-    //PARAMETERS SETTERS
+    /**
+     * Sets whether self-loops are allowed in this container.
+     * <p>
+     * Default is {@code true}.
+     *
+     * @param value true to allow self-loops, false otherwise
+     */
     void setAllowSelfLoop(boolean value);
 
+    /**
+     * Sets whether nodes are automatically created from edges when the source or target is not declared.
+     * <p>
+     * Default is {@code true}.
+     *
+     * @param value true to allow auto-node creation, false otherwise
+     */
     void setAllowAutoNode(boolean value);
 
+    /**
+     * Sets whether parallel edges (multiple edges between the same pair of nodes) are allowed.
+     * <p>
+     * Default is {@code true}.
+     *
+     * @param value true to allow parallel edges, false otherwise
+     */
     void setAllowParallelEdge(boolean value);
 
+    /**
+     * Sets whether auto-scaling is enabled.
+     * <p>
+     * When enabled, node positions are scaled to fit the default viewport after import. Default is {@code true}.
+     *
+     * @param autoscale true to enable auto-scaling, false otherwise
+     */
     void setAutoScale(boolean autoscale);
 
+    /**
+     * Sets whether node labels should be filled with the node id when no label is explicitly set.
+     * <p>
+     * Default is {@code false}.
+     *
+     * @param value true to fill labels with ids, false otherwise
+     */
     void setFillLabelWithId(boolean value);
 
+    /**
+     * Sets the strategy used to merge weights of parallel edges.
+     * <p>
+     * This setting only applies when parallel edges exist and are merged. Default is {@link EdgeMergeStrategy#SUM}.
+     *
+     * @param edgesMergeStrategy the merge strategy to use
+     */
     void setEdgesMergeStrategy(EdgeMergeStrategy edgesMergeStrategy);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerUnloader.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerUnloader.java
@@ -62,12 +62,32 @@ import java.time.ZoneId;
  */
 public interface ContainerUnloader {
 
+    /**
+     * Returns all nodes in this container.
+     *
+     * @return an iterable of all node drafts
+     */
     Iterable<NodeDraft> getNodes();
 
+    /**
+     * Returns the number of nodes in this container.
+     *
+     * @return node count
+     */
     int getNodeCount();
 
+    /**
+     * Returns all edges in this container.
+     *
+     * @return an iterable of all edge drafts
+     */
     Iterable<EdgeDraft> getEdges();
 
+    /**
+     * Returns the number of edges in this container.
+     *
+     * @return edge count
+     */
     int getEdgeCount();
 
     /**
@@ -77,8 +97,20 @@ public interface ContainerUnloader {
      */
     int getMutualEdgeCount();
 
+    /**
+     * Returns true if a node column with the given key exists in this container.
+     *
+     * @param key node column identifier
+     * @return true if the column exists, false otherwise
+     */
     boolean hasNodeColumn(String key);
 
+    /**
+     * Returns true if an edge column with the given key exists in this container.
+     *
+     * @param key edge column identifier
+     * @return true if the column exists, false otherwise
+     */
     boolean hasEdgeColumn(String key);
 
     /**
@@ -104,41 +136,133 @@ public interface ContainerUnloader {
      */
     ColumnDraft getEdgeColumn(String key);
 
+    /**
+     * Returns all node columns in this container.
+     *
+     * @return an iterable of all node column drafts
+     */
     Iterable<ColumnDraft> getNodeColumns();
 
+    /**
+     * Returns all edge columns in this container.
+     *
+     * @return an iterable of all edge column drafts
+     */
     Iterable<ColumnDraft> getEdgeColumns();
 
+    /**
+     * Returns the default edge direction setting for this container.
+     *
+     * @return edge direction default
+     */
     EdgeDirectionDefault getEdgeDefault();
 
+    /**
+     * Returns the time format used for dynamic data in this container.
+     *
+     * @return time format
+     */
     TimeFormat getTimeFormat();
 
+    /**
+     * Returns the time representation used for dynamic data in this container, either {@code TIMESTAMP} or
+     * {@code INTERVAL}.
+     *
+     * @return time representation
+     */
     TimeRepresentation getTimeRepresentation();
 
+    /**
+     * Returns the time zone used to parse date and time values in this container.
+     *
+     * @return time zone
+     */
     ZoneId getTimeZone();
 
+    /**
+     * Returns the source of the data in this container (e.g. a file name), or {@code null} if not set.
+     *
+     * @return source or null
+     */
     String getSource();
 
+    /**
+     * Returns the class used for edge type labels, or {@code null} if the default (null label) is used.
+     *
+     * @return edge type label class or null
+     */
     Class getEdgeTypeLabelClass();
 
+    /**
+     * Returns the graph-level timestamp applied to all elements in this container, or {@code null} if not set.
+     *
+     * @return graph timestamp or null
+     */
     Double getTimestamp();
 
+    /**
+     * Returns the graph-level interval applied to all elements in this container, or {@code null} if not set.
+     *
+     * @return graph interval or null
+     */
     Interval getInterval();
 
+    /**
+     * Returns the element id type used by this container.
+     *
+     * @return element id type
+     */
     ElementIdType getElementIdType();
 
+    /**
+     * Returns the graph metadata in this container, or {@code null} if not set.
+     *
+     * @return metadata or null
+     */
     MetadataDraft getMetadata();
 
-    //PARAMETERS GETTERS
+    /**
+     * Returns whether self-loops are allowed in this container.
+     *
+     * @return true if self-loops are allowed, false otherwise
+     */
     boolean allowSelfLoop();
 
+    /**
+     * Returns whether nodes are automatically created from edges when the source or target node is not declared.
+     *
+     * @return true if auto-node creation is allowed, false otherwise
+     */
     boolean allowAutoNode();
 
+    /**
+     * Returns whether parallel edges (multiple edges between the same pair of nodes) are allowed.
+     *
+     * @return true if parallel edges are allowed, false otherwise
+     */
     boolean allowParallelEdges();
 
+    /**
+     * Returns whether auto-scaling is enabled for this container.
+     * <p>
+     * When enabled, node positions are scaled to fit the default viewport after import.
+     *
+     * @return true if auto-scaling is enabled, false otherwise
+     */
     boolean isAutoScale();
 
+    /**
+     * Returns whether node labels should be filled with the node id when no label is set.
+     *
+     * @return true if labels should be filled with ids, false otherwise
+     */
     boolean isFillLabelWithId();
 
+    /**
+     * Returns the strategy used for merging parallel edge weights.
+     *
+     * @return edge merge strategy
+     */
     EdgeMergeStrategy getEdgesMergeStrategy();
 
     /**

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerUnloader.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ContainerUnloader.java
@@ -140,4 +140,23 @@ public interface ContainerUnloader {
     boolean isFillLabelWithId();
 
     EdgeMergeStrategy getEdgesMergeStrategy();
+
+    /**
+     * Returns true if this container contains a dynamic graph.
+     * <p>
+     * A dynamic graph has elements that appear or disappear over time.
+     *
+     * @return true if dynamic, false otherwise
+     */
+    boolean isDynamicGraph();
+
+    /**
+     * Returns true if this container contains elements that have dynamic
+     * attributes.
+     * <p>
+     * Dynamic attributes are attributes with different values over time.
+     *
+     * @return true if dynamic attributes, false otherwise
+     */
+    boolean hasDynamicAttributes();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Database.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Database.java
@@ -52,33 +52,108 @@ import org.gephi.io.database.drivers.SQLDriver;
  */
 public interface Database extends Serializable {
 
+    /**
+     * Returns the name of this database connection configuration.
+     *
+     * @return connection name
+     */
     String getName();
 
+    /**
+     * Sets the name of this database connection configuration.
+     *
+     * @param name connection name
+     */
     void setName(String name);
 
+    /**
+     * Returns the SQL driver used for this database connection.
+     *
+     * @return SQL driver
+     */
     SQLDriver getSQLDriver();
 
+    /**
+     * Sets the SQL driver used for this database connection.
+     *
+     * @param driver SQL driver
+     */
     void setSQLDriver(SQLDriver driver);
 
+    /**
+     * Returns the database server host name or IP address.
+     *
+     * @return host
+     */
     String getHost();
 
+    /**
+     * Sets the database server host name or IP address.
+     *
+     * @param host host name or IP address
+     */
     void setHost(String host);
 
+    /**
+     * Returns the database server port number.
+     *
+     * @return port number
+     */
     int getPort();
 
+    /**
+     * Sets the database server port number.
+     *
+     * @param port port number
+     */
     void setPort(int port);
 
+    /**
+     * Returns the username used for authentication.
+     *
+     * @return username
+     */
     String getUsername();
 
+    /**
+     * Sets the username used for authentication.
+     *
+     * @param username username
+     */
     void setUsername(String username);
 
+    /**
+     * Returns the password used for authentication.
+     *
+     * @return password
+     */
     String getPasswd();
 
+    /**
+     * Sets the password used for authentication.
+     *
+     * @param passwd password
+     */
     void setPasswd(String passwd);
 
+    /**
+     * Returns the name of the target database (schema) on the server.
+     *
+     * @return database name
+     */
     String getDBName();
 
+    /**
+     * Sets the name of the target database (schema) on the server.
+     *
+     * @param dbName database name
+     */
     void setDBName(String dbName);
 
+    /**
+     * Returns the column-to-property associations configured for this database.
+     *
+     * @return properties associations
+     */
     PropertiesAssociations getPropertiesAssociations();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeMergeStrategy.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EdgeMergeStrategy.java
@@ -43,9 +43,25 @@
 package org.gephi.io.importer.api;
 
 /**
- * Defines the way edge weights are merged.
+ * Defines the strategy used to merge the weights of parallel edges.
+ * <p>
+ * When a container allows parallel edges but a processor merges them into a single edge, this strategy determines
+ * how the resulting weight is computed.
  */
 public enum EdgeMergeStrategy {
 
-    SUM, AVG, MAX, MIN, FIRST, LAST, NO_MERGE
+    /** Sum all parallel edge weights. */
+    SUM,
+    /** Average the parallel edge weights. */
+    AVG,
+    /** Keep the maximum parallel edge weight. */
+    MAX,
+    /** Keep the minimum parallel edge weight. */
+    MIN,
+    /** Keep the weight of the first parallel edge encountered. */
+    FIRST,
+    /** Keep the weight of the last parallel edge encountered. */
+    LAST,
+    /** Do not merge parallel edges; keep them as separate edges. */
+    NO_MERGE
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ElementDraft.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ElementDraft.java
@@ -330,24 +330,78 @@ public interface ElementDraft {
      */
     void setLabelColor(int r, int g, int b);
 
+    /**
+     * Adds a timestamp to this element's time set, marking it as present at the given double timestamp.
+     *
+     * @param timestamp timestamp value
+     */
     void addTimestamp(double timestamp);
 
+    /**
+     * Adds a timestamp to this element's time set by parsing the given date or datetime string.
+     *
+     * @param dateTime date or datetime string
+     */
     void addTimestamp(String dateTime);
 
+    /**
+     * Parses and adds multiple timestamps to this element's time set from a string representation.
+     *
+     * @param timestamps timestamps string (e.g. {@code "[1.0, 2.0, 3.0]"})
+     */
     void addTimestamps(String timestamps);
 
+    /**
+     * Adds an interval to this element's time set, marking it as present during {@code [start, end]}.
+     *
+     * @param start interval start
+     * @param end   interval end
+     */
     void addInterval(double start, double end);
 
+    /**
+     * Adds an interval to this element's time set by parsing the given start and end datetime strings.
+     *
+     * @param startDateTime interval start as a date or datetime string
+     * @param endDateTime   interval end as a date or datetime string
+     */
     void addInterval(String startDateTime, String endDateTime);
 
+    /**
+     * Parses and adds multiple intervals to this element's time set from a string representation.
+     *
+     * @param intervals intervals string (e.g. {@code "[[1.0, 2.0]; [3.0, 4.0]]"})
+     */
     void addIntervals(String intervals);
 
+    /**
+     * Returns this element's time set, or {@code null} if the element has no time information.
+     *
+     * @return time set or null
+     */
     TimeSet getTimeSet();
 
+    /**
+     * Returns the columns that have a value set on this element.
+     *
+     * @return an iterable of column drafts with values on this element
+     */
     Iterable<ColumnDraft> getColumns();
 
+    /**
+     * Returns the graph-level timestamp that will be applied to this element during processing, or {@code null} if
+     * not set.
+     *
+     * @return graph timestamp or null
+     */
     Double getGraphTimestamp();
 
+    /**
+     * Returns the graph-level interval that will be applied to this element during processing, or {@code null} if
+     * not set.
+     *
+     * @return graph interval or null
+     */
     Interval getGraphInterval();
 
     /**

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ElementIdType.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ElementIdType.java
@@ -49,8 +49,11 @@ package org.gephi.io.importer.api;
  */
 public enum ElementIdType {
 
+    /** Element ids are stored as {@link String}. */
     STRING(String.class),
+    /** Element ids are stored as {@link Integer}. */
     INTEGER(Integer.class),
+    /** Element ids are stored as {@link Long}. */
     LONG(Long.class);
 
     private final Class cls;
@@ -59,6 +62,11 @@ public enum ElementIdType {
         this.cls = cls;
     }
 
+    /**
+     * Returns the Java class corresponding to this id type.
+     *
+     * @return id type class
+     */
     public Class getTypeClass() {
         return cls;
     }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/FileType.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/FileType.java
@@ -55,24 +55,51 @@ public final class FileType {
     private final String[] extensions;
     private final String name;
 
+    /**
+     * Creates a file type with a single extension.
+     *
+     * @param extension file extension (e.g. {@code ".gexf"})
+     * @param name      human-readable name of the file type
+     */
     public FileType(String extension, String name) {
         this.extensions = new String[] {extension};
         this.name = name;
     }
 
+    /**
+     * Creates a file type with multiple extensions.
+     *
+     * @param extensions file extensions (e.g. {@code {".gexf", ".xml"}})
+     * @param name       human-readable name of the file type
+     */
     public FileType(String[] extensions, String name) {
         this.extensions = extensions;
         this.name = name;
     }
 
+    /**
+     * Returns the first (primary) file extension for this file type.
+     *
+     * @return primary file extension
+     */
     public String getExtension() {
         return extensions[0];
     }
 
+    /**
+     * Returns all file extensions for this file type.
+     *
+     * @return array of file extensions
+     */
     public String[] getExtensions() {
         return extensions;
     }
 
+    /**
+     * Returns the human-readable name of this file type.
+     *
+     * @return file type name
+     */
     public String getName() {
         return name;
     }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportController.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportController.java
@@ -66,35 +66,165 @@ import org.openide.filesystems.FileObject;
  */
 public interface ImportController {
 
+    /**
+     * Imports a file by automatically detecting the appropriate importer based on the file extension.
+     * <p>
+     * If the file is a supported archive (zip, gz, bz2), it is extracted first and the content file is imported.
+     *
+     * @param file the file to import
+     * @return the container holding the imported data, or {@code null} if no matching importer was found
+     * @throws FileNotFoundException if the file does not exist
+     */
     Container importFile(File file) throws FileNotFoundException;
 
+    /**
+     * Imports a file using the specified importer.
+     * <p>
+     * If the file is a supported archive (zip, gz, bz2), it is extracted first and the content file is imported.
+     *
+     * @param file     the file to import
+     * @param importer the importer to use
+     * @return the container holding the imported data, or {@code null} if the import failed
+     * @throws FileNotFoundException if the file does not exist
+     */
     Container importFile(File file, FileImporter importer) throws FileNotFoundException;
 
+    /**
+     * Imports data from a reader using the specified importer.
+     *
+     * @param reader   the reader providing the data to import
+     * @param importer the importer to use
+     * @return the container holding the imported data, or {@code null} if the import failed
+     */
     Container importFile(Reader reader, FileImporter importer);
 
+    /**
+     * Imports data from an input stream using the specified importer.
+     *
+     * @param stream   the input stream providing the data to import
+     * @param importer the importer to use
+     * @return the container holding the imported data, or {@code null} if the import failed
+     */
     Container importFile(InputStream stream, FileImporter importer);
 
+    /**
+     * Imports data using the specified wizard importer.
+     * <p>
+     * Wizard importers generate data without requiring a file or database source, for example from user input or
+     * generated content.
+     *
+     * @param importer the wizard importer to execute
+     * @return the container holding the imported data, or {@code null} if the import failed
+     */
     Container importWizard(WizardImporter importer);
 
+    /**
+     * Returns a file importer that matches the given file object, or {@code null} if none is found.
+     * <p>
+     * If the file object represents a supported archive, it is extracted first and the content file is matched.
+     *
+     * @param fileObject the file object to match an importer for
+     * @return a matching {@link FileImporter}, or {@code null} if none was found
+     */
     FileImporter getFileImporter(FileObject fileObject);
 
+    /**
+     * Returns a file importer that matches the given file, or {@code null} if none is found.
+     *
+     * @param file the file to match an importer for
+     * @return a matching {@link FileImporter}, or {@code null} if none was found
+     */
     FileImporter getFileImporter(File file);
 
+    /**
+     * Returns a file importer matching the given importer name or file extension, or {@code null} if none is found.
+     * <p>
+     * The {@code importerName} can be either a file extension (with or without a leading dot) or the name of a
+     * registered importer.
+     *
+     * @param importerName the importer name or file extension to look up
+     * @return a matching {@link FileImporter}, or {@code null} if none was found
+     */
     FileImporter getFileImporter(String importerName);
 
+    /**
+     * Imports data from a database using the specified database importer.
+     *
+     * @param database the database connection parameters
+     * @param importer the database importer to use
+     * @return the container holding the imported data, or {@code null} if the import failed
+     */
     Container importDatabase(Database database, DatabaseImporter importer);
 
-    void process(Container container);
+    /**
+     * Processes a container using the default processor and creates a new workspace.
+     * <p>
+     * The default processor is retrieved from the global Lookup.
+     *
+     * @param container the container with imported data to process
+     * @return the workspace created by the processor
+     * @throws RuntimeException if no default processor is found or the processor fails
+     */
+    Workspace process(Container container);
 
-    void process(Container container, Processor processor, Workspace workspace);
+    /**
+     * Processes a container using the specified processor and workspace.
+     * <p>
+     * If {@code workspace} is {@code null}, the processor will create a new workspace. Auto-scaling is applied to the
+     * container if enabled.
+     *
+     * @param container the container with imported data to process
+     * @param processor the processor to use
+     * @param workspace the target workspace, or {@code null} to let the processor create one
+     * @return the workspace populated by the processor
+     * @throws RuntimeException if the processor does not return exactly one workspace
+     */
+    Workspace process(Container container, Processor processor, Workspace workspace);
 
-    void process(Container[] containers, Processor processor, Workspace workspace);
+    /**
+     * Processes multiple containers using the specified processor and workspace.
+     * <p>
+     * If {@code workspace} is {@code null}, the processor will create new workspaces. Auto-scaling is applied to each
+     * container individually if enabled.
+     *
+     * @param containers the containers with imported data to process
+     * @param processor  the processor to use
+     * @param workspace  the target workspace, or {@code null} to let the processor create workspaces
+     * @return the workspaces populated by the processor
+     * @throws RuntimeException if the processor does not return any workspace
+     */
+    Workspace[] process(Container[] containers, Processor processor, Workspace workspace);
 
+    /**
+     * Returns all file types supported by the registered file importers.
+     *
+     * @return an array of supported {@link FileType} instances
+     */
     FileType[] getFileTypes();
 
+    /**
+     * Returns whether the given file is supported by any registered file importer.
+     * <p>
+     * Archive files (zip, gz, bz2) are always considered supported.
+     *
+     * @param file the file to check
+     * @return {@code true} if the file is supported, {@code false} otherwise
+     */
     boolean isFileSupported(File file);
 
+    /**
+     * Returns the UI component associated with the given importer, or {@code null} if none is registered.
+     *
+     * @param importer the importer to look up a UI for
+     * @return the matching {@link ImporterUI}, or {@code null} if none was found
+     */
     ImporterUI getUI(Importer importer);
 
+    /**
+     * Returns the wizard UI component associated with the given importer, or {@code null} if none is registered.
+     *
+     * @param importer the importer to look up a wizard UI for
+     * @return the matching {@link ImporterWizardUI}, or {@code null} if none was found
+     */
     ImporterWizardUI getWizardUI(Importer importer);
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportUtils.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportUtils.java
@@ -75,6 +75,8 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
+ * Utility methods for importers, providing readers, XML parsers, archive extraction, and color parsing.
+ *
  * @author Mathieu Bastian
  */
 public final class ImportUtils {
@@ -786,6 +788,15 @@ public final class ImportUtils {
         }
     }
 
+    /**
+     * Parses a color string and returns the corresponding {@link Color}, or {@code null} if unrecognized.
+     * <p>
+     * Accepts Java color names (e.g. {@code "yellow"}), extended color names (e.g. {@code "navyblue"}),
+     * octal notation (e.g. {@code "0xFF0096"}), and hexadecimal notation (e.g. {@code "#FF0096"}).
+     *
+     * @param colorString the color string to parse
+     * @return the parsed color, or {@code null} if the string could not be parsed
+     */
     public static Color parseColor(String colorString) {
         colorString = colorString.toLowerCase().replace(" ", "");
 
@@ -833,11 +844,24 @@ public final class ImportUtils {
         return reader;
     }
 
+    /**
+     * Wraps the given reader in a {@link LineNumberReader}.
+     *
+     * @param reader the reader to wrap
+     * @return a {@link LineNumberReader} wrapping the given reader
+     */
     public static LineNumberReader getTextReader(Reader reader) {
         LineNumberReader lineNumberReader = new LineNumberReader(reader);
         return lineNumberReader;
     }
 
+    /**
+     * Parses an XML document from the given input stream.
+     *
+     * @param stream the input stream to parse
+     * @return the parsed {@link Document}
+     * @throws RuntimeException if the XML cannot be parsed or the stream cannot be read
+     */
     public static Document getXMLDocument(InputStream stream) throws RuntimeException {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -856,6 +880,13 @@ public final class ImportUtils {
         }
     }
 
+    /**
+     * Parses an XML document from the given reader.
+     *
+     * @param reader the reader to parse
+     * @return the parsed {@link Document}
+     * @throws RuntimeException if the XML cannot be parsed or the reader cannot be read
+     */
     public static Document getXMLDocument(Reader reader) throws RuntimeException {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -874,6 +905,13 @@ public final class ImportUtils {
         }
     }
 
+    /**
+     * Parses an XML document from the given file object.
+     *
+     * @param fileObject the file object to parse
+     * @return the parsed {@link Document}
+     * @throws RuntimeException if the file cannot be found or the XML cannot be parsed
+     */
     public static Document getXMLDocument(FileObject fileObject) throws RuntimeException {
         try {
             InputStream stream = fileObject.getInputStream();
@@ -883,6 +921,15 @@ public final class ImportUtils {
         }
     }
 
+    /**
+     * Creates a streaming XML reader from the given reader.
+     * <p>
+     * Validation is disabled for performance.
+     *
+     * @param reader the reader to read XML from
+     * @return a configured {@link XMLStreamReader}
+     * @throws RuntimeException if the XML stream cannot be created
+     */
     public static XMLStreamReader getXMLReader(Reader reader) {
         try {
             XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -904,6 +951,14 @@ public final class ImportUtils {
         }
     }
 
+    /**
+     * Returns true if the given file object is a supported archive (zip, jar, gz, bz2).
+     * <p>
+     * Excel files ({@code .xls*}) are explicitly excluded even though they are technically ZIP archives.
+     *
+     * @param fileObject the file object to check
+     * @return true if the file is a supported archive, false otherwise
+     */
     public static boolean isArchiveFile(FileObject fileObject) {
         if (fileObject == null) {
             return false;
@@ -923,6 +978,15 @@ public final class ImportUtils {
         return FileUtil.isArchiveFile(fileObject);
     }
 
+    /**
+     * Returns the content file object extracted from an archive, or the original file object if it is not an archive.
+     * <p>
+     * Supports zip, jar, gz, bz2, and tar.gz / tar.bz2 archives. Extracted files are written to a temporary
+     * directory and deleted on JVM exit.
+     *
+     * @param fileObject the file object to extract if it is an archive
+     * @return the content file object, or the original file object if not an archive or extraction failed
+     */
     public static FileObject getArchivedFile(final FileObject fileObject) {
         if (!isArchiveFile(fileObject)) {
             return fileObject;
@@ -987,6 +1051,15 @@ public final class ImportUtils {
         return result;
     }
 
+    /**
+     * Decompresses a bzip2-compressed file to the specified output file.
+     *
+     * @param in    the bzip2-compressed source file object
+     * @param out   the destination file to write the decompressed content to
+     * @param isTar true if the compressed content is a tar archive (tar header is skipped)
+     * @return the output file
+     * @throws IOException if an I/O error occurs during decompression
+     */
     public static File getBzipFile(FileObject in, File out, boolean isTar) throws IOException {
 
         // Stream buffer
@@ -1045,6 +1118,15 @@ public final class ImportUtils {
         return out;
     }
 
+    /**
+     * Decompresses a gzip-compressed file to the specified output file.
+     *
+     * @param in    the gzip-compressed source file object
+     * @param out   the destination file to write the decompressed content to
+     * @param isTar true if the compressed content is a tar archive (tar header is skipped)
+     * @return the output file
+     * @throws IOException if an I/O error occurs during decompression
+     */
     public static File getGzFile(FileObject in, File out, boolean isTar) throws IOException {
 
         // Stream buffer

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Issue.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Issue.java
@@ -133,16 +133,29 @@ public final class Issue {
 
     public enum Level {
 
+        /** Informational message; does not indicate a problem. */
         INFO(100),
+        /** A potential problem that does not prevent the import from completing. */
         WARNING(200),
+        /** A significant problem that may affect the import result. */
         SEVERE(500),
+        /**
+         * A fatal problem that, by default, causes the import to be aborted by throwing a
+         * {@link RuntimeException}.
+         */
         CRITICAL(1000);
+
         private final int levelInt;
 
         Level(int levelInt) {
             this.levelInt = levelInt;
         }
 
+        /**
+         * Returns the integer value of this level, used for severity comparisons.
+         *
+         * @return integer severity value
+         */
         public int toInteger() {
             return levelInt;
         }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/PropertiesAssociations.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/PropertiesAssociations.java
@@ -46,35 +46,62 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Maps column titles to known node and edge properties for database importers.
+ * <p>
+ * This allows importers to declare which database column corresponds to which graph property (e.g. id, label,
+ * color, position).
+ */
 public final class PropertiesAssociations implements Serializable {
 
     private final Map<String, NodeProperties> titleToNodeProperty = new HashMap<>();
     private final Map<String, EdgeProperties> titleToEdgeProperty = new HashMap<>();
 
+    /**
+     * Associates a column title with a node property.
+     *
+     * @param property the node property to associate
+     * @param title    the column title that maps to this property
+     */
     public void addNodePropertyAssociation(NodeProperties property, String title) {
         titleToNodeProperty.put(title, property);
     }
 
+    /**
+     * Associates a column title with an edge property.
+     *
+     * @param property the edge property to associate
+     * @param title    the column title that maps to this property
+     */
     public void addEdgePropertyAssociation(EdgeProperties property, String title) {
         titleToEdgeProperty.put(title, property);
     }
 
+    /**
+     * Returns the node property associated with the given column title, or {@code null} if none is found.
+     *
+     * @param title column title
+     * @return node property or null
+     */
     public NodeProperties getNodeProperty(String title) {
-        if (titleToNodeProperty.containsKey(title)) {
-            return titleToNodeProperty.get(title);
-        } else {
-            return null;
-        }
+        return titleToNodeProperty.getOrDefault(title, null);
     }
 
+    /**
+     * Returns the edge property associated with the given column title, or {@code null} if none is found.
+     *
+     * @param title column title
+     * @return edge property or null
+     */
     public EdgeProperties getEdgeProperty(String title) {
-        if (titleToEdgeProperty.containsKey(title)) {
-            return titleToEdgeProperty.get(title);
-        } else {
-            return null;
-        }
+        return titleToEdgeProperty.getOrDefault(title, null);
     }
 
+    /**
+     * Returns a human-readable summary of all node and edge property associations.
+     *
+     * @return formatted string listing all associations
+     */
     public String getInfos() {
         StringBuilder builder = new StringBuilder("***Node Properties Associations***\n");
         for (Map.Entry<String, NodeProperties> entry : titleToNodeProperty.entrySet()) {

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Report.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/Report.java
@@ -89,10 +89,20 @@ public final class Report {
         }
     }
 
+    /**
+     * Returns true if this report has no entries at all (neither messages nor issues).
+     *
+     * @return true if the report is empty, false otherwise
+     */
     public boolean isEmpty() {
         return empty;
     }
 
+    /**
+     * Returns true if at least one issue has been logged in this report.
+     *
+     * @return true if the report contains issues, false otherwise
+     */
     public boolean hasIssues() {
         return hasIssues;
     }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ElementDraftImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ElementDraftImpl.java
@@ -324,6 +324,12 @@ public abstract class ElementDraftImpl implements ElementDraft {
     @Override
     public void parseAndSetValue(String key, String value) {
         ColumnDraft column = getColumn(key);
+        if (column == null) {
+            String message = NbBundle.getMessage(ElementDraftImpl.class,
+                "ElementDraftException_ColumnNotFound", key, id, getElementClassName());
+            container.getReport().logIssue(new Issue(message, Issue.Level.SEVERE));
+            return;
+        }
         if (column.isDynamic()) {
             if (container.getTimeRepresentation().equals(TimeRepresentation.INTERVAL)) {
                 if (container.getInterval() != null) {
@@ -356,6 +362,12 @@ public abstract class ElementDraftImpl implements ElementDraft {
     @Override
     public void parseAndSetValue(String key, String value, double timestamp) {
         ColumnDraft column = getColumn(key);
+        if (column == null) {
+            String message = NbBundle.getMessage(ElementDraftImpl.class,
+                "ElementDraftException_ColumnNotFound", key, id, getElementClassName());
+            container.getReport().logIssue(new Issue(message, Issue.Level.SEVERE));
+            return;
+        }
         setValue(key, parseValue(value, column.getTypeClass()), timestamp);
     }
 
@@ -382,6 +394,12 @@ public abstract class ElementDraftImpl implements ElementDraft {
     @Override
     public void parseAndSetValue(String key, String value, double start, double end) {
         ColumnDraft column = getColumn(key);
+        if (column == null) {
+            String message = NbBundle.getMessage(ElementDraftImpl.class,
+                "ElementDraftException_ColumnNotFound", key, id, getElementClassName());
+            container.getReport().logIssue(new Issue(message, Issue.Level.SEVERE));
+            return;
+        }
         setValue(key, parseValue(value, column.getTypeClass()), start, end);
     }
 

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportContainerImpl.java
@@ -222,8 +222,11 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
     public boolean edgeExists(String source, String target) {
         checkId(source);
         checkId(target);
-        NodeDraftImpl sourceNode = getNode(source);
-        NodeDraftImpl targetNode = getNode(target);
+        if (!nodeExists(source) || !nodeExists(target)) {
+            return false;
+        }
+        NodeDraftImpl sourceNode = nodeList.get(nodeMap.getInt(source));
+        NodeDraftImpl targetNode = nodeList.get(nodeMap.getInt(target));
         if (sourceNode != null && targetNode != null) {
             boolean undirected = edgeDefault.equals(EdgeDirectionDefault.UNDIRECTED) ||
                 (undirectedEdgesCount > 0 && directedEdgesCount == 0);
@@ -401,9 +404,8 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
                     }
                 }
                 edgeTypeSet.put(sourceTargetLong, newEdges);
-            } else {
-                edgeTypeSet.put(sourceTargetLong, new int[0]);
             }
+            // else: key was already removed above; don't re-insert an empty array
         }
 
         //Remove edge
@@ -703,6 +705,9 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
         if (elementIdType.equals(ElementIdType.INTEGER) || elementIdType.equals(ElementIdType.LONG)) {
             try {
                 for (NodeDraftImpl node : nodeList) {
+                    if (node == null) {
+                        continue;
+                    }
                     if (elementIdType.equals(ElementIdType.INTEGER)) {
                         Integer.parseInt(node.getId());
                     } else if (elementIdType.equals(ElementIdType.LONG)) {
@@ -1199,6 +1204,7 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
 
         private final Iterator<T> itr;
         private T pointer;
+        private boolean hasNext = false;
 
         public NullFilterIterator(Collection<T> elementCollection) {
             this.itr = elementCollection.iterator();
@@ -1206,9 +1212,13 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
 
         @Override
         public boolean hasNext() {
+            if (hasNext) {
+                return true;
+            }
             while (itr.hasNext()) {
                 pointer = itr.next();
                 if (pointer != null) {
+                    hasNext = true;
                     return true;
                 }
             }
@@ -1217,6 +1227,10 @@ public class ImportContainerImpl implements Container, ContainerLoader, Containe
 
         @Override
         public T next() {
+            if (!hasNext) {
+                hasNext();
+            }
+            hasNext = false;
             return pointer;
         }
 

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
@@ -298,18 +298,17 @@ public class ImportControllerImpl implements ImportController {
     }
 
     @Override
-    public void process(Container container) {
+    public Workspace process(Container container) {
         Processor processor = Lookup.getDefault().lookup(Processor.class);
         if (processor == null) {
-            throw new RuntimeException("Impossible to find Default Processor");
+            throw new RuntimeException("Impossible to find a default processor");
         }
-        process(container, processor, null);
+        return process(container, processor, null);
     }
 
     @Override
-    public void process(Container container, Processor processor, Workspace workspace) {
+    public Workspace process(Container container, Processor processor, Workspace workspace) {
         processor.setContainers(new ContainerUnloader[] {container.getUnloader()});
-        processor.setWorkspace(workspace);
 
         container.setReport(processor.getReport());
         container.closeLoader();
@@ -320,12 +319,22 @@ public class ImportControllerImpl implements ImportController {
             }
         }
 
-        processor.process();
+        if (workspace != null) {
+            processor.setWorkspace(workspace);
+        }
+        Workspace[] workspaces = processor.process();
+        if (workspaces == null || workspaces.length == 0) {
+            throw new RuntimeException("The processor "+processor.getClass().getSimpleName()+" didn't return any workspace");
+        } else if (workspaces.length > 1) {
+            throw new RuntimeException("The processor "+processor.getClass().getSimpleName()+" returned more than one workspace");
+        }
+        return workspaces[0];
     }
 
     @Override
-    public void process(Container[] containers, Processor processor, Workspace workspace) {
-        processor.setContainers(Arrays.stream(containers).map(Container::getUnloader).toArray(ContainerUnloader[]::new));
+    public Workspace[] process(Container[] containers, Processor processor, Workspace workspace) {
+        processor.setContainers(
+            Arrays.stream(containers).map(Container::getUnloader).toArray(ContainerUnloader[]::new));
         for (Container container : containers) {
             container.setReport(processor.getReport());
             container.closeLoader();
@@ -336,8 +345,15 @@ public class ImportControllerImpl implements ImportController {
                 }
             }
         }
-        processor.setWorkspace(workspace);
-        processor.process();
+        if (workspace != null) {
+            processor.setWorkspace(workspace);
+        }
+        Workspace[] workspaces = processor.process();
+        if (workspaces == null || workspaces.length == 0) {
+            throw new RuntimeException(
+                "The processor " + processor.getClass().getSimpleName() + " didn't return any workspace");
+        }
+        return workspaces;
     }
 
     private FileImporterBuilder getMatchingImporter(FileObject fileObject) {

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
@@ -293,6 +293,8 @@ public class ImportControllerImpl implements ImportController {
             throw ex;
         } catch (Exception ex) {
             throw new RuntimeException(ex);
+        } finally {
+            report.close();
         }
         return null;
     }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/Processor.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/Processor.java
@@ -50,11 +50,11 @@ import org.gephi.project.api.Workspace;
 import org.gephi.utils.progress.ProgressTicket;
 
 /**
- * Interface that define the way data are <b>unloaded</b> from containers and
- * appended to the workspace.
+ * Interface that defines the way data are <b>unloaded</b> from containers and
+ * appended to the workspace(s).
  * <p>
  * The purpose of processors is to unload data from the import containers and
- * push it to the workspace, with various strategies. For instance, a processor
+ * push it to the workspace(s), with various strategies. For instance, a processor
  * could either create a new workspace or append data to the current workspace,
  * managing duplicates.
  *
@@ -64,12 +64,13 @@ import org.gephi.utils.progress.ProgressTicket;
 public interface Processor {
 
     /**
-     * Process data <b>from</b> the container <b>to</b> the workspace. This task
-     * is done after an importer pushed data to the container.
+     * Process data <b>from</b> the container <b>to</b> the workspace(s). It
+     * returns the workspace(s) where data have been pushed.
      *
      * @see Importer
+     * @return the workspace(s) where data have been pushed
      */
-    void process();
+    Workspace[] process();
 
     /**
      * Sets the data containers. The processor's job is to get data from the
@@ -81,7 +82,8 @@ public interface Processor {
 
     /**
      * Sets the destination workspace for the data in the containers. If no
-     * workspace is provided, the current workspace will be used.
+     * workspace is provided, it's up to the processor's implementation to decide where to push data -
+     * for instance, a processor could create a new workspace or append data to the current workspace.
      *
      * @param workspace the workspace where data are to be pushed
      */
@@ -104,7 +106,7 @@ public interface Processor {
     /**
      * Returns the report of the processor after processing is done, with possible warnings and errors.
      *
-     * @return Processor report after processing
+     * @return the processor report after processing
      */
     Report getReport();
 }

--- a/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/ProcessorConfigurationException.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/processor/spi/ProcessorConfigurationException.java
@@ -1,0 +1,59 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.gephi.io.processor.spi;
+
+/**
+ * Exception thrown by a {@link Processor} when the graph configuration of an import container is incompatible
+ * with the existing workspace's graph model configuration.
+ * <p>
+ * This exception is a {@link RuntimeException} to maintain backward compatibility. The error is also logged
+ * as a {@link org.gephi.io.importer.api.Issue.Level#SEVERE} issue in the processor's report.
+ *
+ * @author Mathieu Bastian
+ */
+public class ProcessorConfigurationException extends RuntimeException {
+
+    public ProcessorConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/modules/ImportAPI/src/main/resources/org/gephi/io/importer/impl/Bundle.properties
+++ b/modules/ImportAPI/src/main/resources/org/gephi/io/importer/impl/Bundle.properties
@@ -50,6 +50,7 @@ ElementDraftException_SetValueTimestampError = A problem occurred while setting 
 ElementDraftException_SetValueIntervalError = A problem occurred while setting the value ''{0}'' to the {4} id=''{1}'' at the interval {2}, error: {3}
 ElementDraftException_SetValueIntervalDuplicate = The value {0} has overwritten an existing value for {3} id=''{1}'' at the interval {2}
 ElementDraftException_SetValueTimestampDuplicate = The value {0} has overwritten an existing value for {3} id=''{1}'' at the timestamp {2}
+ElementDraftException_ColumnNotFound = Column ''{0}'' not found for {2} id=''{1}'', value is ignored
 
 
 ImportContainerClose_SelfLoopRemoved = {0} self loops were removed

--- a/modules/ImportAPI/src/test/java/org/gephi/io/importer/impl/ElementDraftTest.java
+++ b/modules/ImportAPI/src/test/java/org/gephi/io/importer/impl/ElementDraftTest.java
@@ -123,4 +123,28 @@ public class ElementDraftTest {
         edge.parseAndSetValue("foo", null);
         Assert.assertNull(edge.getValue("foo"));
     }
+
+    // Bug fix: parseAndSetValue variants were calling getColumn(key) which returns
+    // null for undeclared columns, then dereferencing it without a null check (NPE).
+    @Test
+    public void testParseAndSetValueMissingColumn() {
+        EdgeDraftImpl edge = new EdgeDraftImpl(new ImportContainerImpl(), "0");
+        // "unknown" column was never registered — must log SEVERE, not throw NPE
+        edge.parseAndSetValue("unknown", "value");
+        Utils.assertContainerIssues(edge.container.getReport(), Issue.Level.SEVERE, "unknown");
+    }
+
+    @Test
+    public void testParseAndSetValueMissingColumnTimestamp() {
+        EdgeDraftImpl edge = new EdgeDraftImpl(new ImportContainerImpl(), "0");
+        edge.parseAndSetValue("unknown", "value", 1.0);
+        Utils.assertContainerIssues(edge.container.getReport(), Issue.Level.SEVERE, "unknown");
+    }
+
+    @Test
+    public void testParseAndSetValueMissingColumnInterval() {
+        EdgeDraftImpl edge = new EdgeDraftImpl(new ImportContainerImpl(), "0");
+        edge.parseAndSetValue("unknown", "value", 1.0, 2.0);
+        Utils.assertContainerIssues(edge.container.getReport(), Issue.Level.SEVERE, "unknown");
+    }
 }

--- a/modules/ImportAPI/src/test/java/org/gephi/io/importer/impl/ImportContainerImplTest.java
+++ b/modules/ImportAPI/src/test/java/org/gephi/io/importer/impl/ImportContainerImplTest.java
@@ -48,6 +48,7 @@ import org.gephi.io.importer.api.ColumnDraft;
 import org.gephi.io.importer.api.EdgeDirection;
 import org.gephi.io.importer.api.EdgeDirectionDefault;
 import org.gephi.io.importer.api.EdgeDraft;
+import org.gephi.io.importer.api.ElementIdType;
 import org.gephi.io.importer.api.Issue;
 import org.gephi.io.importer.api.NodeDraft;
 import org.junit.Assert;
@@ -121,6 +122,90 @@ public class ImportContainerImplTest {
 
         Assert.assertTrue(importContainer.verify());
         Assert.assertEquals(1, importContainer.getUnloader().getEdgeCount());
+    }
+
+    // Bug fix: removeEdge was leaving a stale empty int[] in edgeTypeSets, blocking
+    // any subsequent addEdge for the same source/target pair.
+    @Test
+    public void testRemoveEdgeAndReAdd() {
+        ImportContainerImpl importContainer = new ImportContainerImpl();
+        generateTinyGraph(importContainer);
+        importContainer.removeEdge(importContainer.getEdge("1"));
+
+        // Re-add a new edge between the same nodes — must not be rejected
+        NodeDraft node1 = importContainer.getNode("1");
+        NodeDraft node2 = importContainer.getNode("2");
+        EdgeDraft newEdge = importContainer.factory().newEdgeDraft("3");
+        newEdge.setDirection(EdgeDirection.DIRECTED);
+        newEdge.setSource(node1);
+        newEdge.setTarget(node2);
+        importContainer.addEdge(newEdge);
+
+        Assert.assertEquals(2, importContainer.getEdgeCount());
+        Assert.assertNotNull(importContainer.getEdge("3"));
+        Assert.assertFalse(
+            importContainer.getReport().getIssues(1).hasNext()
+        );
+    }
+
+    // Bug fix: verify() was iterating nodeList without null guards in the ID-type
+    // validation section, causing NPE when removed nodes left null tombstones.
+    @Test
+    public void testVerifyWithRemovedNodeIntegerIdType() {
+        ImportContainerImpl importContainer = new ImportContainerImpl();
+        importContainer.setElementIdType(ElementIdType.INTEGER);
+        importContainer.setAllowAutoNode(true);
+
+        // Add a node explicitly and an edge referencing an unknown node (auto-created)
+        NodeDraft node1 = importContainer.factory().newNodeDraft("1");
+        importContainer.addNode(node1);
+        EdgeDraft edge = importContainer.factory().newEdgeDraft("10");
+        edge.setDirection(EdgeDirection.DIRECTED);
+        edge.setSource(node1);
+        edge.setTarget(importContainer.getNode("2")); // auto-creates node "2"
+        importContainer.addEdge(edge);
+
+        // Disabling auto-node and calling closeLoader() removes the auto-created node,
+        // leaving a null tombstone in nodeList.
+        importContainer.setAllowAutoNode(false);
+        importContainer.closeLoader();
+
+        // verify() must not throw NullPointerException when nodeList contains nulls
+        Assert.assertTrue(importContainer.verify());
+    }
+
+    // Bug fix: edgeExists(String, String) was calling getNode() which auto-creates
+    // nodes when allowAutoNode is true, corrupting the container as a side-effect.
+    @Test
+    public void testEdgeExistsNoAutoNodeSideEffect() {
+        ImportContainerImpl importContainer = new ImportContainerImpl();
+        importContainer.setAllowAutoNode(true);
+
+        Assert.assertFalse(importContainer.edgeExists("ghost1", "ghost2"));
+        Assert.assertEquals(0, importContainer.getNodeCount());
+        Assert.assertFalse(importContainer.nodeExists("ghost1"));
+        Assert.assertFalse(importContainer.nodeExists("ghost2"));
+    }
+
+    // Bug fix: NullFilterIterator.hasNext() was advancing the underlying iterator
+    // on every call, so calling it twice without next() skipped an element.
+    @Test
+    public void testNullFilterIteratorHasNextIdempotent() {
+        ImportContainerImpl importContainer = new ImportContainerImpl();
+        NodeDraft node1 = importContainer.factory().newNodeDraft("1");
+        NodeDraft node2 = importContainer.factory().newNodeDraft("2");
+        importContainer.addNode(node1);
+        importContainer.addNode(node2);
+
+        java.util.Iterator<NodeDraft> it = importContainer.getNodes().iterator();
+        // Call hasNext() twice without next() — both calls must report true and
+        // the subsequent next() must return the first node, not skip it.
+        Assert.assertTrue(it.hasNext());
+        Assert.assertTrue(it.hasNext());
+        Assert.assertEquals("1", it.next().getId());
+        Assert.assertTrue(it.hasNext());
+        Assert.assertEquals("2", it.next().getId());
+        Assert.assertFalse(it.hasNext());
     }
 
     @Test

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AbstractProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AbstractProcessor.java
@@ -194,6 +194,11 @@ public abstract class AbstractProcessor implements Processor, LongTask {
             node.setSize(10f);
         }
 
+        //Fixed
+        if(nodeDraft.isFixed()) {
+            node.setFixed(true);
+        }
+
         //Timeset
         if (nodeDraft.getTimeSet() != null) {
             flushTimeSet(nodeDraft.getTimeSet(), node);

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AbstractProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AbstractProcessor.java
@@ -74,6 +74,7 @@ import org.gephi.io.importer.api.Issue;
 import org.gephi.io.importer.api.NodeDraft;
 import org.gephi.io.importer.api.Report;
 import org.gephi.io.processor.spi.Processor;
+import org.gephi.io.processor.spi.ProcessorConfigurationException;
 import org.gephi.project.api.Workspace;
 import org.gephi.utils.Attributes;
 import org.gephi.utils.longtask.spi.LongTask;
@@ -506,19 +507,63 @@ public abstract class AbstractProcessor implements Processor, LongTask {
         return configBuilder.build();
     }
 
-    protected boolean configurationMatchesExisting(Configuration newConfig, Workspace workspace) {
+    protected void validateConfigurationMatchesExisting(ContainerUnloader container, Configuration newConfig,
+                                                        Workspace workspace) {
         GraphController graphController = Lookup.getDefault().lookup(GraphController.class);
         Configuration existingConfig = graphController.getGraphModel(workspace).getConfiguration();
-        if(!newConfig.equals(graphController.getGraphModel(workspace).getConfiguration())) {
+
+        if (container.isDynamicGraph() || container.hasDynamicAttributes()) {
+            if (newConfig.getTimeRepresentation() != existingConfig.getTimeRepresentation()) {
+                String message = NbBundle.getMessage(
+                    AbstractProcessor.class, "AbstractProcessor.error.timeRepresentationMismatch",
+                    newConfig.getTimeRepresentation().name(),
+                    existingConfig.getTimeRepresentation().name()
+                );
+                report.logIssue(new Issue(message, Issue.Level.SEVERE));
+            }
+        }
+
+        if (!newConfig.getEdgeWeightType().equals(existingConfig.getEdgeWeightType())) {
             String message = NbBundle.getMessage(
-                DefaultProcessor.class, "DefaultProcessor.error.configurationChangeForbidden",
-                existingConfig.toString(),
-                newConfig.toString()
+                AbstractProcessor.class, "AbstractProcessor.error.edgeWeightTypeMismatch",
+                newConfig.getEdgeWeightType().getSimpleName(),
+                existingConfig.getEdgeWeightType().getSimpleName()
             );
             report.logIssue(new Issue(message, Issue.Level.SEVERE));
-            return false;
         }
-        return true;
+
+        if (container.getEdgeTypeLabelClass() != null &&
+            !newConfig.getEdgeLabelType().equals(container.getEdgeTypeLabelClass())) {
+            String message = NbBundle.getMessage(
+                AbstractProcessor.class, "AbstractProcessor.error.edgeLabelTypeMismatch",
+                newConfig.getEdgeLabelType().getSimpleName(),
+                container.getEdgeTypeLabelClass().getSimpleName()
+            );
+            report.logIssue(new Issue(message, Issue.Level.SEVERE));
+        }
+
+        if (!newConfig.getNodeIdType().equals(existingConfig.getNodeIdType())) {
+            String message = NbBundle.getMessage(
+                AbstractProcessor.class, "AbstractProcessor.error.nodeIdTypeMismatch",
+                newConfig.getNodeIdType().getSimpleName(),
+                existingConfig.getNodeIdType().getSimpleName()
+            );
+            report.logIssue(new Issue(message, Issue.Level.SEVERE));
+        }
+
+        if (!newConfig.getEdgeIdType().equals(existingConfig.getEdgeIdType())) {
+            String message = NbBundle.getMessage(
+                AbstractProcessor.class, "AbstractProcessor.error.edgeIdTypeMismatch",
+                newConfig.getEdgeIdType().getSimpleName(),
+                existingConfig.getEdgeIdType().getSimpleName()
+            );
+            report.logIssue(new Issue(message, Issue.Level.SEVERE));
+        }
+
+        if (report.hasIssues()) {
+            throw new ProcessorConfigurationException(
+                "Processor configuration does not match existing workspace configuration. See report for details.");
+        }
     }
 
     @Override

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AppendProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AppendProcessor.java
@@ -42,12 +42,13 @@
 
 package org.gephi.io.processor.plugin;
 
+import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.Graph;
 import org.gephi.graph.api.GraphController;
-import org.gephi.graph.api.Configuration;
 import org.gephi.io.importer.api.ContainerUnloader;
 import org.gephi.io.processor.spi.Processor;
 import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
 import org.gephi.utils.progress.Progress;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
@@ -67,8 +68,10 @@ public class AppendProcessor extends DefaultProcessor implements Processor {
     }
 
     @Override
-    public void process() {
+    public Workspace[] process() {
         try {
+
+
             ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
             if (workspace == null) {
                 workspace = pc.getCurrentWorkspace();
@@ -92,19 +95,17 @@ public class AppendProcessor extends DefaultProcessor implements Processor {
             int totalAddedNodes = 0, totalAddedEdges = 0, totalTouchedNodes = 0, totalTouchedEdges = 0;
             for (ContainerUnloader container : containers) {
                 Configuration config = createConfiguration(container);
-                if(configurationMatchesExisting(config, workspace)) {
-                    processMeta(container, workspace);
+                validateConfigurationMatchesExisting(container, config, workspace);
 
-                    if (container.getSource() != null) {
-                        pc.setSource(workspace, container.getSource());
-                    }
+                processMeta(container, workspace);
 
-                    process(container, workspace);
-                    totalTouchedNodes += container.getNodeCount();
-                    totalTouchedEdges += container.getEdgeCount();
-                } else {
-                    Progress.progress(progressTicket, AbstractProcessor.calculateWorkUnits(container));
+                if (container.getSource() != null) {
+                    pc.setSource(workspace, container.getSource());
                 }
+
+                process(container, workspace);
+                totalTouchedNodes += container.getNodeCount();
+                totalTouchedEdges += container.getEdgeCount();
             }
             Progress.finish(progressTicket);
 
@@ -122,6 +123,7 @@ public class AppendProcessor extends DefaultProcessor implements Processor {
                         AppendProcessor.class, "AppendProcessor.info.overlappingEdges", overlappedEdges));
                 }
             }
+            return new Workspace[] {workspace};
         } finally {
             clean();
         }

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/DefaultProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/DefaultProcessor.java
@@ -80,7 +80,7 @@ public class DefaultProcessor extends AbstractProcessor {
     }
 
     @Override
-    public void process() {
+    public Workspace[] process() {
         try {
             if (containers.length > 1) {
                 throw new RuntimeException("This processor can only handle single containers");
@@ -94,9 +94,8 @@ public class DefaultProcessor extends AbstractProcessor {
             ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
             if (workspace == null) {
                 workspace = pc.openNewWorkspace(config);
-            } else if(!configurationMatchesExisting(config, workspace)) {
-                // The configuration check failed, stop processing
-                return;
+            } else {
+                validateConfigurationMatchesExisting(container, config, workspace);
             }
             processMeta(container, workspace);
 
@@ -110,6 +109,7 @@ public class DefaultProcessor extends AbstractProcessor {
             Progress.start(progressTicket, calculateWorkUnits());
             process(container, workspace);
             Progress.finish(progressTicket);
+            return new Workspace[] {workspace};
         } finally {
             clean();
         }

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/MergeProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/MergeProcessor.java
@@ -46,6 +46,7 @@ import org.gephi.graph.api.Configuration;
 import org.gephi.io.importer.api.ContainerUnloader;
 import org.gephi.io.processor.spi.Processor;
 import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
 import org.gephi.utils.progress.Progress;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
@@ -66,7 +67,7 @@ public class MergeProcessor extends DefaultProcessor implements Processor {
     }
 
     @Override
-    public void process() {
+    public Workspace[] process() {
         try {
             if (containers.length <= 1) {
                 throw new RuntimeException("This processor can only handle multiple containers");
@@ -91,13 +92,11 @@ public class MergeProcessor extends DefaultProcessor implements Processor {
             Progress.start(progressTicket, calculateWorkUnits());
             for (ContainerUnloader container : containers) {
                 Configuration config = createConfiguration(container);
-                if(configurationMatchesExisting(config, workspace)) {
-                    process(container, workspace);
-                } else {
-                    Progress.progress(progressTicket, AbstractProcessor.calculateWorkUnits(container));
-                }
+                validateConfigurationMatchesExisting(container, config, workspace);
+                process(container, workspace);
             }
             Progress.finish(progressTicket);
+            return new Workspace[] {workspace};
         } finally {
             clean();
         }

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/MultiProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/MultiProcessor.java
@@ -42,10 +42,11 @@
 
 package org.gephi.io.processor.plugin;
 
+import java.util.Arrays;
 import org.gephi.graph.api.Configuration;
-import org.gephi.io.importer.api.ContainerUnloader;
 import org.gephi.io.processor.spi.Processor;
 import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
 import org.gephi.utils.progress.Progress;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
@@ -61,11 +62,11 @@ public class MultiProcessor extends DefaultProcessor implements Processor {
 
     @Override
     public String getDisplayName() {
-        return NbBundle.getMessage(MergeProcessor.class, "MultiProcessor.displayName");
+        return NbBundle.getMessage(MultiProcessor.class, "MultiProcessor.displayName");
     }
 
     @Override
-    public void process() {
+    public Workspace[] process() {
         try {
             if (containers.length <= 1) {
                 throw new RuntimeException("This processor can only handle multiple containers");
@@ -74,20 +75,31 @@ public class MultiProcessor extends DefaultProcessor implements Processor {
             ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
 
             Progress.start(progressTicket, calculateWorkUnits());
-            for (ContainerUnloader container : containers) {
+            Workspace[] workspaces = Arrays.stream(containers).map(container -> {
                 Configuration config = createConfiguration(container);
-                if (workspace != null && configurationMatchesExisting(config, workspace)) {
-                    pc.openWorkspace(workspace);
-                } else {
-                    workspace = pc.newWorkspace(pc.getCurrentProject(), config);
-                }
+                workspace = pc.openNewWorkspace(config);
                 processMeta(container, workspace);
                 process(container, workspace);
-                workspace = null;
-            }
+
+                if (container.getSource() != null && !container.getSource().isEmpty()) {
+                    pc.setSource(workspace, container.getSource());
+
+                    // Remove extensions
+                    pc.renameWorkspace(workspace, container.getSource().replaceAll("(?<!^)[.].*", ""));
+                }
+
+                Progress.progress(progressTicket);
+                return workspace;
+            }).toArray(Workspace[]::new);
             Progress.finish(progressTicket);
+            return workspaces;
         } finally {
             clean();
         }
+    }
+
+    @Override
+    public void setWorkspace(Workspace workspace) {
+        throw new UnsupportedOperationException("This processor does not support setting the workspace");
     }
 }

--- a/modules/ImportPlugin/src/main/resources/org/gephi/io/processor/plugin/Bundle.properties
+++ b/modules/ImportPlugin/src/main/resources/org/gephi/io/processor/plugin/Bundle.properties
@@ -7,8 +7,11 @@ AbstractProcessor.warning.overlappingIntervals=Cannot completely merge overlappi
 AbstractProcessor.error.columnTypeMismatch=Existing column ''{0}'' in graph with type ''{1}'' is not compatible with imported column type ''{2}''. Keeping original type and values.
 AbstractProcessor.error.columnDefaultValueTypeMismatch=Column ''{0}'' default value ''{1}'' with type ''{2}'' is not compatible with the column type ''{3}''. Using null as default value.
 AbstractProcessor.error.unavailableColumnType=Attribute type ''{0}'' is unavailable for current time representation: {1}. Cannot add column with id ''{2}''.
-
-DefaultProcessor.error.configurationChangeForbidden=Graph configuration should match with the existing workspace, Original configuration: {0}, new wanted configuration: {1}
+AbstractProcessor.error.nodeIdTypeMismatch=Node id type ''{0}'' is not compatible with existing node id type ''{1}'' in the workspace.
+AbstractProcessor.error.edgeIdTypeMismatch=Edge id type ''{0}'' is not compatible with existing edge id type ''{1}'' in the workspace.
+AbstractProcessor.error.timeRepresentationMismatch=Time representation ''{0}'' is not compatible with existing time representation ''{1}'' in the workspace.
+AbstractProcessor.error.edgeWeightTypeMismatch=Edge weight type ''{0}'' is not compatible with existing edge weight type ''{1}'' in the workspace.
+AbstractProcessor.error.edgeLabelTypeMismatch=Edge type ''{0}'' is not compatible with existing edge label type ''{1}'' in the workspace.
 DefaultProcessor.error.incompatibleEdges=No merge strategy was chosen but the edge {0} cannot be created because it can''t exist at the same time with edge {1} (incompatible). Skipping new edge.
 DefaultProcessor.warning.incompatibleEdgeDirectedness=The imported edge {0} cannot be added because it is directionally incompatible with existing edge {1} in the workspace. Skipping.
 AppendProcessor.info.overlappingNodes={0} node(s) from the imported graph had matching IDs with existing nodes in the workspace and were merged.

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DefaultProcessorTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DefaultProcessorTest.java
@@ -2,11 +2,14 @@ package org.gephi.io.processor.plugin;
 
 import org.gephi.graph.api.GraphModel;
 import org.gephi.graph.api.Node;
+import org.gephi.io.importer.api.ElementIdType;
+import org.gephi.io.importer.api.Issue;
 import org.gephi.io.importer.api.MetadataDraft;
 import org.gephi.io.importer.api.NodeDraft;
+import org.gephi.io.importer.api.Report;
 import org.gephi.io.importer.impl.ImportContainerImpl;
 import org.gephi.io.importer.impl.NodeDraftImpl;
-import org.gephi.io.processor.plugin.DefaultProcessor;
+import org.gephi.io.processor.spi.ProcessorConfigurationException;
 import org.gephi.project.api.Workspace;
 import org.gephi.project.api.WorkspaceMetaData;
 import org.gephi.project.impl.WorkspaceImpl;
@@ -46,5 +49,45 @@ public class DefaultProcessorTest {
         WorkspaceMetaData workspaceMetaData = workspace.getWorkspaceMetadata();
         Assert.assertEquals("foo", workspaceMetaData.getDescription());
         Assert.assertEquals("bar", workspaceMetaData.getTitle());
+    }
+
+    @Test(expected = ProcessorConfigurationException.class)
+    public void testConfigurationMismatchThrows() {
+        // Workspace will be initialized with default INTERVAL time representation
+        Workspace workspace = new WorkspaceImpl(null, 1);
+
+        // Container uses TIMESTAMP → incompatible with workspace's INTERVAL config
+        ImportContainerImpl importContainer = new ImportContainerImpl();
+        importContainer.setElementIdType(ElementIdType.INTEGER);
+
+        DefaultProcessor processor = new DefaultProcessor();
+        processor.setContainers(new ImportContainerImpl[] {importContainer});
+        processor.setWorkspace(workspace);
+        processor.process();
+    }
+
+    @Test
+    public void testConfigurationMismatchLogsIssue() {
+        Workspace workspace = new WorkspaceImpl(null, 1);
+
+        ImportContainerImpl importContainer = new ImportContainerImpl();
+        importContainer.setElementIdType(ElementIdType.INTEGER);
+
+        DefaultProcessor processor = new DefaultProcessor();
+        processor.setContainers(new ImportContainerImpl[] {importContainer});
+        processor.setWorkspace(workspace);
+
+        try {
+            processor.process();
+            Assert.fail("Expected ProcessorConfigurationException");
+        } catch (ProcessorConfigurationException e) {
+            // expected
+        }
+
+        Report report = processor.getReport();
+        Assert.assertNotNull(report);
+        boolean hasSevereIssue = report.getIssuesList(Integer.MAX_VALUE).stream()
+            .anyMatch(issue -> issue.getLevel() == Issue.Level.SEVERE);
+        Assert.assertTrue("Report should contain a SEVERE issue for configuration mismatch", hasSevereIssue);
     }
 }

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DynamicEdgeWeightTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DynamicEdgeWeightTest.java
@@ -20,8 +20,8 @@ public class DynamicEdgeWeightTest {
     @Before
     public void setUp() {
         Configuration configuration = Configuration.builder()
-                .edgeWeightType(TimestampDoubleMap.class)
-                    .timeRepresentation(TimeRepresentation.TIMESTAMP).build();
+            .edgeWeightType(TimestampDoubleMap.class)
+            .timeRepresentation(TimeRepresentation.TIMESTAMP).build();
         processor = new Utils.TestProcessor(
             GraphGenerator.build(configuration).generateTinyGraph().getGraphModel()
         );

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/Utils.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/Utils.java
@@ -2,6 +2,7 @@ package org.gephi.io.processor.plugin;
 
 import org.gephi.graph.api.GraphModel;
 import org.gephi.io.importer.impl.ImportContainerImpl;
+import org.gephi.project.api.Workspace;
 
 public class Utils {
 
@@ -17,8 +18,8 @@ public class Utils {
         }
 
         @Override
-        public void process() {
-
+        public Workspace[] process() {
+            return new Workspace[0];
         }
 
         @Override

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -23,13 +23,13 @@
         <h4>Graph API</h4>
         <ul>
             <li>Dependency on <code>Joda-Time</code> has been removed and replaced by <code>java.time</code>. The dependency to the legacy Colt library was also removed.</li>
-            <li>A new configuration builder has been added in <code>Configuration.Builder</code> to facilitate configuration customization. A number of configurations - which previously lived as static fields - have been migrated into it. The <code>GraphModel.setConfiguration()</code> method has been deprecated. Configurations are therefore expected to be defined when <code>GraphModel</code> is created.</li>
+            <li>A new configuration builder has been added in <code>Configuration.Builder</code> to facilitate configuration customization. A number of configurations - which previously lived as static fields - have been migrated into it. The <code>GraphModel.setConfiguration()</code> method has been deprecated. Configurations are therefore expected to be defined when <code>GraphModel</code> is created. This has consequences on the Workspace lifecycle, as once a Workspace is created, its GraphModel is already set and the configuration can't be changed afterward. A configuration can however be passed to <code>openNewWorkspace()</code> to be taken in account when <code>GraphModel</code> is initialized.</li>
             <li>Addition of a <code>getDefaultConfigurationBuilder()</code> method in <code>GraphController</code> that returns the default graph configuration used when creating new <code>GraphModel</code> instances. This should be used as a basis configuration by users willing to create <code>GraphModel</code> with custom configurations.</li>
             <li><code>Instant</code> is now supported as an element type. This allows to store dates and times, but unfortunately it wasn't possible to make the Serialization backward compatible. In other words, if an Instant column is used , it won't be possible to be loaded in previous versions.</li>
-            <li>Addition of <code>Graph.getNodeByStoreId()</code> and <code>Graph.getEdgeByStoreId()</code> methods to retrieve elements based only on their store id. This allows for faster retrieval. Keep in mind though that store ids are re-used when elements are removed. Use those methods in combination with <code>GraphModel.getMaxNodeStoreId()</code> and <code>GraphModel.
+            <li>Addition of <code>Graph.getNodeByStoreId()</code> and <code>Graph.getEdgeByStoreId()</code> methods to retrieve elements based only on their store id. This allows for faster retrieval. Keep in mind, though, that store ids are re-used when elements are removed. Use those methods in combination with <code>GraphModel.getMaxNodeStoreId()</code> and <code>GraphModel.
                 getMaxEdgeStoreId()</code> when you want to store elements based on their store ids.</li>
             <li>Add new <code>SpatialIndex</code> that holds a quadtree-based spatial index of elements. It can be retrieved via <code>Graph.
-                getSpatialIndex()</code>. The spatial index allows to retrieve nodes and edges based on a <code>Rect2D</code>.</li>
+                getSpatialIndex()</code>. The spatial index allows retrieving nodes and edges based on a <code>Rect2D</code>.</li>
             <li>Node/Edge Iterable now have <code>spliterator(), stream() and parallelStream()</code> methods. Therefore, it's possible to iterate/filter over elements in parallel, leading to significant performance gains.</li>
             <li>Add a new <code>createView()</code> method to <code>GraphModel</code> based on predicates, to facilitate view creation.</li>
         </ul>
@@ -62,6 +62,7 @@
         </ul>
         <h4>Import API</h4>
         <ul>
+            <li>Processors function in <code>ImportController</code> now return a <code>Workspace</code> to clarify which worspaces graph data has been pushed to, given that providing a workspace to <code>process()</code> functions isn't required (and sometimes not even allowed, depending on the processor).</li>
             <li>Added <code>hasIssues()</code> to <code>Report</code> class to check if the report contains any issues.</li>
         </ul>
         <h3>0.10.0</h3>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description
- This work is a direct consequence of the change we did in GraphModel's Configuration - requiring the configuration to be set at creation time (can't be changed later).
- Previously we would first create the workspace and then push the data to it, via our processors. This was no longer possible so we refactored how Workspaces creation is handled in ImportAPI. Because processors have different needs in that regard the right choice is to delegate that responsibility to them. For instance, AppendProcessor needs to use an existing workspace, while MultiProcessor needs to create multiple of them. As a result, the logical choice was to make `process()` return the Workspace(s) so that it's also clear what has been happening.
- Also fixed some Javadoc gaps and bugs.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [x] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed
