### PR TITLE
Fix cryptic ZipException when opening empty .gephi project file

### DIFF
--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/LoadTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/LoadTask.java
@@ -116,6 +116,10 @@ public class LoadTask implements LongTask {
                 if (!file.exists()) {
                     throw new FileNotFoundException("File " + file.getPath() + " not found");
                 }
+                if (file.length() == 0) {
+                    throw new GephiFormatException(
+                        "The project file is empty and may be corrupt: " + file.getName());
+                }
                 zip = new ZipFile(file);
 
                 ProjectImpl project = readProject(zip, projects);


### PR DESCRIPTION
Fixes GEPHI-5K5 (2 users affected).

`LoadTask` opened the `.gephi` ZIP directly without checking the file size first. If the file was 0 bytes (e.g. from a previous crashed save), `ZipFile` threw a cryptic `ZipException: zip file is empty`, surfaced to the user as a generic `GephiFormatException`.

Added a `file.length() == 0` pre-check that throws a `GephiFormatException` with a clear message before attempting to open the ZIP.