### PR TITLE
Fix project load crash when .gephi file has missing or empty name attribute

### DIFF
--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/GephiReader.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/GephiReader.java
@@ -74,6 +74,9 @@ public class GephiReader {
                     }
                 } else if ("project".equalsIgnoreCase(name)) {
                     String projectName = reader.getAttributeValue(null, "name");
+                    if (projectName == null || projectName.trim().isEmpty()) {
+                        projectName = "Untitled";
+                    }
                     String projectId = reader.getAttributeValue(null, "id");
                     if (projectId == null) {
                         // Before 0.10 version we didn't have unique project ids


### PR DESCRIPTION
Fixes GEPHI-5QD (1 user affected).

`GephiReader.readProject` passed the `name` XML attribute directly to `ProjectImpl`, which enforces non-null/non-empty. Files with a missing or blank `name` attribute (older Gephi versions, externally edited files) crashed the load with `IllegalArgumentException: Project name cannot be null or empty`.

Fall back to `"Untitled"` when the attribute is missing or blank.