### PR TITLE
Fix ArrayIndexOutOfBoundsException crashing project load when restoring filters

### DIFF
--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelPersistenceProvider.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelPersistenceProvider.java
@@ -44,6 +44,8 @@ package org.gephi.filters;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -304,7 +306,16 @@ public class FilterModelPersistenceProvider implements WorkspaceXMLPersistencePr
                     String name = reader.getLocalName();
                     if ("parameter".equalsIgnoreCase(name)) {
                         int index = Integer.parseInt(reader.getAttributeValue(null, "index"));
-                        property = query.getFilter().getProperties()[index];
+                        FilterProperty[] properties = query.getFilter().getProperties();
+                        if (index < 0 || index >= properties.length) {
+                            Logger.getLogger(FilterModelPersistenceProvider.class.getName()).log(
+                                Level.WARNING,
+                                "Skipping filter parameter at index {0}: out of bounds for filter ''{1}'' with {2} properties",
+                                new Object[]{index, query.getFilter().getClass().getName(), properties.length});
+                            property = null;
+                        } else {
+                            property = properties[index];
+                        }
                         textBuffer.setLength(0);
                     }
                 } else if (eventType.equals(XMLStreamReader.CHARACTERS) && property != null) {


### PR DESCRIPTION
Fixes GEPHI-5G2 (1 user affected).

`FilterModelPersistenceProvider.readQuery` accessed `filter.getProperties()[index]` without bounds-checking. A saved filter with an out-of-range parameter index (e.g. from a newer filter version that had more properties) threw `ArrayIndexOutOfBoundsException` and aborted the entire project load.

Added a bounds check: out-of-range indices are logged as `WARNING` and skipped, allowing the rest of the project to load normally.