### PR TITLE
Fix IllegalArgumentException when opening a project with no associated file

### DIFF
--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -365,6 +365,14 @@ public class ProjectControllerUIImpl implements ProjectListener {
     }
 
     public void openProject(Project project) {
+        if (!project.hasFile()) {
+            NotifyDescriptor.Message msg = new NotifyDescriptor.Message(
+                NbBundle.getMessage(ProjectControllerUIImpl.class,
+                    "ProjectControllerUI.error.noFileAssociated", project.getName()),
+                NotifyDescriptor.WARNING_MESSAGE);
+            DialogDisplayer.getDefault().notify(msg);
+            return;
+        }
         longTaskExecutor.execute(null, () -> {
             if (controller.getCurrentProject() != null) {
                 if (!closeCurrentProject()) {

--- a/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/Bundle.properties
+++ b/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/Bundle.properties
@@ -22,6 +22,7 @@ OpenFile_filechooser_graphfilter=Graph Files
 OpenFile_filechooser_zipfilter=Archived Files
 ProjectControllerUI.error.open=The project file couldn't be opened. Please check the file has .gephi extension.
 ProjectControllerUI.error.multipleGephi=Please select a unique .gephi project file
+ProjectControllerUI.error.noFileAssociated=The project file for "{0}" cannot be found. The project may not have been saved to disk.
 
 DeleteWorkspace_confirm_message=Are you sure do you want to delete this workspace ?
 DeleteWorkspace_confirm_title=Close workspace


### PR DESCRIPTION
Fixes GEPHI-5E4 (2 users, 24 events).

`ProjectControllerImpl.openProject` throws `IllegalArgumentException` when called on a `Project` that has no file path (e.g. an unsaved project appearing in the Recent Projects list). This surfaced as an unhandled crash.

Added a `project.hasFile()` guard in `ProjectControllerUIImpl.openProject`: if the project has no file, a warning dialog is shown and the method returns early.