### PR TITLE
Fix cryptic WstxEOFException when importing an empty GEXF file

### DIFF
--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGEXF.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGEXF.java
@@ -43,6 +43,7 @@
 package org.gephi.io.importer.plugin.file;
 
 import java.awt.Color;
+import java.io.IOException;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -145,6 +146,10 @@ public class ImporterGEXF implements FileImporter, LongTask {
         this.report = new Report();
         Progress.start(progress);
         try {
+
+            if (!reader.ready()) {
+                throw new IOException("The GEXF file is empty or has no content");
+            }
 
             XMLInputFactory inputFactory = XMLInputFactory.newInstance();
             if (inputFactory.isPropertySupported("javax.xml.stream.isValidating")) {


### PR DESCRIPTION
Fixes GEPHI-5JN (2 users affected).

`ImporterGEXF` passed an empty reader directly to the XML stream parser, which threw `WstxEOFException: Unexpected EOF in prolog at [1,0]` — surfaced to the user as a double-wrapped `RuntimeException`.

Added a `reader.ready()` check before creating the XML stream reader. If the file is empty, an `IOException` with a clear message is thrown instead.