### PR TITLE
Fix MissingResourceException on Turkish locale (dotless-i in bundle key lookup)

### DIFF
--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/propertyeditors/DependantOriginalColorPropertyEditor.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/propertyeditors/DependantOriginalColorPropertyEditor.java
@@ -44,6 +44,7 @@ package org.gephi.desktop.preview.propertyeditors;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.util.Locale;
 import org.gephi.preview.types.DependantColor;
 import org.gephi.preview.types.DependantOriginalColor;
 import org.gephi.preview.types.editors.BasicDependantOriginalColorPropertyEditor;
@@ -61,7 +62,7 @@ public class DependantOriginalColorPropertyEditor extends BasicDependantOriginal
             String localizedCustom = NbBundle.getMessage(DependantOriginalColorPropertyEditor.class, "DependantOriginalColorPropertyEditor.custom.text");
             return toText(localizedCustom, c.getCustomColor() == null ? Color.BLACK : c.getCustomColor());
         } else {
-            return NbBundle.getMessage(DependantOriginalColorPropertyEditor.class, "DependantOriginalColorPropertyEditor."+c.getMode().name().toLowerCase()+".text");
+            return NbBundle.getMessage(DependantOriginalColorPropertyEditor.class, "DependantOriginalColorPropertyEditor."+c.getMode().name().toLowerCase(Locale.ROOT)+".text");
         }
     }
 

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/propertyeditors/EdgeColorPropertyEditor.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/propertyeditors/EdgeColorPropertyEditor.java
@@ -44,6 +44,7 @@ package org.gephi.desktop.preview.propertyeditors;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.util.Locale;
 import org.gephi.preview.types.EdgeColor;
 import org.gephi.preview.types.editors.BasicEdgeColorPropertyEditor;
 import org.openide.util.NbBundle;
@@ -60,7 +61,7 @@ public class EdgeColorPropertyEditor extends BasicEdgeColorPropertyEditor {
             String localizedCustom = NbBundle.getMessage(EdgeColorPropertyEditor.class, "EdgeColorPropertyEditor.custom.text");
             return toText(localizedCustom, c.getCustomColor() == null ? Color.BLACK : c.getCustomColor());
         } else {
-            return NbBundle.getMessage(EdgeColorPropertyEditor.class, "EdgeColorPropertyEditor."+c.getMode().name().toLowerCase()+".text");
+            return NbBundle.getMessage(EdgeColorPropertyEditor.class, "EdgeColorPropertyEditor."+c.getMode().name().toLowerCase(Locale.ROOT)+".text");
         }
     }
 

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/types/editors/BasicDependantOriginalColorPropertyEditor.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/types/editors/BasicDependantOriginalColorPropertyEditor.java
@@ -43,6 +43,7 @@ Portions Copyrighted 2011 Gephi Consortium.
 package org.gephi.preview.types.editors;
 
 import java.awt.Color;
+import java.util.Locale;
 import org.gephi.preview.types.DependantOriginalColor;
 
 /**
@@ -62,7 +63,7 @@ public class BasicDependantOriginalColorPropertyEditor extends AbstractColorProp
         if (c.getMode().equals(DependantOriginalColor.Mode.CUSTOM)) {
             return toText(c.getMode().name(), c.getCustomColor() == null ? Color.BLACK : c.getCustomColor());
         } else {
-            return c.getMode().name().toLowerCase();
+            return c.getMode().name().toLowerCase(Locale.ROOT);
         }
     }
 
@@ -74,11 +75,11 @@ public class BasicDependantOriginalColorPropertyEditor extends AbstractColorProp
     @Override
     public void setAsText(String s) {
 
-        if (matchColorMode(s, DependantOriginalColor.Mode.CUSTOM.name().toLowerCase())) {
+        if (matchColorMode(s, DependantOriginalColor.Mode.CUSTOM.name().toLowerCase(Locale.ROOT))) {
             setValue(new DependantOriginalColor(toColor(s)));
-        } else if (matchColorMode(s, DependantOriginalColor.Mode.ORIGINAL.name().toLowerCase())) {
+        } else if (matchColorMode(s, DependantOriginalColor.Mode.ORIGINAL.name().toLowerCase(Locale.ROOT))) {
             setValue(new DependantOriginalColor(DependantOriginalColor.Mode.ORIGINAL));
-        } else if (matchColorMode(s, DependantOriginalColor.Mode.PARENT.name().toLowerCase())) {
+        } else if (matchColorMode(s, DependantOriginalColor.Mode.PARENT.name().toLowerCase(Locale.ROOT))) {
             setValue(new DependantOriginalColor(DependantOriginalColor.Mode.PARENT));
         }
     }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/types/editors/BasicEdgeColorPropertyEditor.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/types/editors/BasicEdgeColorPropertyEditor.java
@@ -43,6 +43,7 @@ Portions Copyrighted 2011 Gephi Consortium.
 package org.gephi.preview.types.editors;
 
 import java.awt.Color;
+import java.util.Locale;
 import org.gephi.preview.types.EdgeColor;
 
 /**
@@ -62,7 +63,7 @@ public class BasicEdgeColorPropertyEditor extends AbstractColorPropertyEditor {
         if (c.getMode().equals(EdgeColor.Mode.CUSTOM)) {
             return toText(c.getMode().name(), c.getCustomColor() == null ? Color.BLACK : c.getCustomColor());
         } else {
-            return c.getMode().name().toLowerCase();
+            return c.getMode().name().toLowerCase(Locale.ROOT);
         }
     }
 
@@ -73,15 +74,15 @@ public class BasicEdgeColorPropertyEditor extends AbstractColorPropertyEditor {
 
     @Override
     public void setAsText(String s) {
-        if (matchColorMode(s, EdgeColor.Mode.CUSTOM.name().toLowerCase())) {
+        if (matchColorMode(s, EdgeColor.Mode.CUSTOM.name().toLowerCase(Locale.ROOT))) {
             setValue(new EdgeColor(toColor(s)));
-        } else if (matchColorMode(s, EdgeColor.Mode.MIXED.name().toLowerCase())) {
+        } else if (matchColorMode(s, EdgeColor.Mode.MIXED.name().toLowerCase(Locale.ROOT))) {
             setValue(new EdgeColor(EdgeColor.Mode.MIXED));
-        } else if (matchColorMode(s, EdgeColor.Mode.ORIGINAL.name().toLowerCase())) {
+        } else if (matchColorMode(s, EdgeColor.Mode.ORIGINAL.name().toLowerCase(Locale.ROOT))) {
             setValue(new EdgeColor(EdgeColor.Mode.ORIGINAL));
-        } else if (matchColorMode(s, EdgeColor.Mode.SOURCE.name().toLowerCase())) {
+        } else if (matchColorMode(s, EdgeColor.Mode.SOURCE.name().toLowerCase(Locale.ROOT))) {
             setValue(new EdgeColor(EdgeColor.Mode.SOURCE));
-        } else if (matchColorMode(s, EdgeColor.Mode.TARGET.name().toLowerCase())) {
+        } else if (matchColorMode(s, EdgeColor.Mode.TARGET.name().toLowerCase(Locale.ROOT))) {
             setValue(new EdgeColor(EdgeColor.Mode.TARGET));
         }
     }

--- a/modules/VisualizationImpl/src/main/java/org/gephi/desktop/visualization/options/DefaultPanel.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/desktop/visualization/options/DefaultPanel.java
@@ -45,6 +45,7 @@ package org.gephi.desktop.visualization.options;
 import com.connectina.swing.fontchooser.JFontChooser;
 import java.awt.Component;
 import java.awt.Font;
+import java.util.Locale;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JLabel;
@@ -196,7 +197,7 @@ final class DefaultPanel extends javax.swing.JPanel {
                 if (value instanceof LabelColorMode mode) {
                     String prefix = forEdges ? "EdgeLabelColorMode." : "NodeLabelColorMode.";
                     label.setText(NbBundle.getMessage(EdgeSettingsPanel.class,
-                        prefix + mode.name().toLowerCase() + ".name"));
+                        prefix + mode.name().toLowerCase(Locale.ROOT) + ".name"));
                     label.setIcon(
                         ImageUtilities.loadIcon("VisualizationImpl/LabelColorMode_" + mode.name() + ".svg"));
                 }
@@ -214,7 +215,7 @@ final class DefaultPanel extends javax.swing.JPanel {
                     (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof LabelSizeMode mode) {
                     label.setText(NbBundle.getMessage(EdgeSettingsPanel.class,
-                        "LabelSizeMode." + mode.name().toLowerCase() + ".name"));
+                        "LabelSizeMode." + mode.name().toLowerCase(Locale.ROOT) + ".name"));
                     label.setIcon(
                         ImageUtilities.loadIcon("VisualizationImpl/LabelSizeMode_" + mode.name() + ".svg"));
                 }
@@ -232,7 +233,7 @@ final class DefaultPanel extends javax.swing.JPanel {
                     (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof EdgeColorMode mode) {
                     label.setText(NbBundle.getMessage(EdgeSettingsPanel.class,
-                        "EdgeColorMode." + mode.name().toLowerCase() + ".name"));
+                        "EdgeColorMode." + mode.name().toLowerCase(Locale.ROOT) + ".name"));
                     label.setIcon(
                         ImageUtilities.loadIcon("VisualizationImpl/EdgeColorMode_" + mode.name() + ".svg"));
                 }


### PR DESCRIPTION
Fixes GEPHI-5JB, GEPHI-5K8, GEPHI-5KA (4 users affected).

Enum names (`MIXED`, `ORIGINAL`, `PARENT`) were lowercased using the default system locale to construct bundle keys. Under Turkish locale, `"MIXED".toLowerCase()` produces `"mıxed"` (dotless-i), which doesn't match the bundle key `"mixed"`, causing a `MissingResourceException` when rendering the Preview and Visualization property editors.

Changed all `.toLowerCase()` calls used for bundle key construction or enum name matching to `.toLowerCase(Locale.ROOT)` in five files:

- `EdgeColorPropertyEditor` (GEPHI-5K8, GEPHI-5KA)
- `DependantOriginalColorPropertyEditor` (GEPHI-5JB)
- `BasicEdgeColorPropertyEditor` — same bug, also affects project deserialization
- `BasicDependantOriginalColorPropertyEditor` — same bug, also affects project deserialization
- `DefaultPanel` — `EdgeColorMode`, `LabelSizeMode`, `LabelColorMode` renderers