### PR TITLE
Fix IllegalArgumentException when saving project with null statistics chart image

### DIFF
--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsModelImpl.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsModelImpl.java
@@ -195,7 +195,9 @@ public class StatisticsModelImpl implements StatisticsModel {
                 File file = new File(filename);
                 try {
                     BufferedImage image = ImageIO.read(file);
-                    ImageIO.write(image, "PNG", out);
+                    if (image != null) {
+                        ImageIO.write(image, "PNG", out);
+                    }
                 } catch (Exception e) {
                     Exceptions.printStackTrace(e);
                 }


### PR DESCRIPTION
Fixes GEPHI-5PB (2 users, 159 events — crashes on every save attempt).

`StatisticsModelImpl.embedImages` calls `ImageIO.read(file)` which returns `null` when the image file is missing or unreadable (rather than throwing). The existing `catch` block does not prevent `ImageIO.write(null, ...)` from then throwing `IllegalArgumentException: image == null!`, which propagates up through `SaveTask` and aborts the save with `GephiFormatException`.

Added a null check on the result of `ImageIO.read`: if the image is null the entry is skipped and the save continues normally.