### PR TITLE
Fix NPE in StatisticsControllerUIImpl.getUI when statistics is null

### DIFF
--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
@@ -163,7 +163,9 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
     }
 
     public StatisticsUI[] getUI(Statistics statistics) {
-        boolean dynamic = false;
+        if (statistics == null) {
+            return new StatisticsUI[0];
+        }
         ArrayList<StatisticsUI> list = new ArrayList<>();
         for (StatisticsUI sui : Lookup.getDefault().lookupAll(StatisticsUI.class)) {
             if (statistics.getClass().equals(sui.getStatisticsClass())) {


### PR DESCRIPTION
Fixes GEPHI-5CK (3 users, 8 events).

`getUI(Statistics statistics)` called `statistics.getClass()` without a null check. If a plugin's `Statistics` object failed to instantiate, `statistics` is null and the method throws `NullPointerException`, which surfaces as an unhandled crash when the user clicks Run on that statistic.

Return an empty `StatisticsUI[]` immediately when `statistics` is null.