### PR TITLE
Fix project save failing on Windows when filename contains illegal characters

### DIFF
--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
@@ -48,6 +48,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Collection;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -64,7 +66,6 @@ import org.gephi.project.spi.WorkspaceXMLPersistenceProvider;
 import org.gephi.utils.longtask.spi.LongTask;
 import org.gephi.utils.progress.Progress;
 import org.gephi.utils.progress.ProgressTicket;
-import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle;
@@ -199,15 +200,7 @@ public class SaveTask implements LongTask {
 
             //Rename file
             if (!cancel && writeFile.exists() && file != writeFile) {
-                //Delete original file
-                if (file.exists()) {
-                    file.delete();
-                }
-
-                FileObject tempFileObject = FileUtil.toFileObject(writeFile);
-                FileLock lock = tempFileObject.lock();
-                tempFileObject.rename(lock, getFileNameWithoutExt(file), getFileExtension(file));
-                lock.releaseLock();
+                Files.move(writeFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
         } catch (Exception ex) {
             if (ex instanceof GephiFormatException) {


### PR DESCRIPTION
Fixes GEPHI-5PV (2 users, 10 events).

The save workflow writes to a temp file (`<name>_temp<timestamp>`) and then renames it to the final `.gephi` file. The rename was done via NetBeans `FileObject.rename()`, which validates the target filename and rejects characters that are illegal on Windows (`:`, `*`, `?`, `"`, `<`, `>`, `|`). A project named `"grafico 16:59"` failed with `FSException: Cannot rename file ... to grafico 16:59.gephi`.

Replace the `FileObject.rename()` + separate `file.delete()` with a single `Files.move(..., REPLACE_EXISTING)`, which delegates directly to the OS and performs an atomic overwrite without filename validation. Also removes the now-unused `FileLock` import.