### PR TITLE
Add ImportException hierarchy for known import failures

### DIFF
--- a/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/DesktopImportControllerUI.java
+++ b/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/DesktopImportControllerUI.java
@@ -67,6 +67,7 @@ import org.gephi.desktop.mrufiles.api.MostRecentFiles;
 import org.gephi.io.importer.api.Container;
 import org.gephi.io.importer.api.Database;
 import org.gephi.io.importer.api.ImportController;
+import org.gephi.io.importer.api.ImportException;
 import org.gephi.io.importer.api.ImportUtils;
 import org.gephi.io.importer.api.Issue;
 import org.gephi.io.importer.api.Report;
@@ -563,11 +564,37 @@ public class DesktopImportControllerUI implements ImportControllerUI {
                 return;
             }
             count.incrementAndGet();
+
+            // Known import failure: surface the localized message via the issues report panel,
+            // without raising the developer-facing "Unexpected Exception" dialog.
+            ImportException known = findImportException(t);
+            if (known != null) {
+                String msg = NbBundle
+                    .getMessage(DesktopImportControllerUI.class, "DesktopImportControllerUI.errorHandler.critical",
+                        source, known.getMessage());
+                errorReport.logIssue(new Issue(msg, Issue.Level.SEVERE));
+                return;
+            }
+
             String msg =
                 NbBundle.getMessage(DesktopImportControllerUI.class, "DesktopImportControllerUI.errorHandler.critical",
                     source, t.getMessage());
             errorReport.logIssue(new Issue(msg, Issue.Level.SEVERE, t));
             Exceptions.printStackTrace(t);
+        }
+
+        private static ImportException findImportException(Throwable t) {
+            Throwable current = t;
+            while (current != null) {
+                if (current instanceof ImportException) {
+                    return (ImportException) current;
+                }
+                if (current.getCause() == current) {
+                    break;
+                }
+                current = current.getCause();
+            }
+            return null;
         }
 
         public int countErrors() {

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EmptyFileException.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EmptyFileException.java
@@ -57,12 +57,19 @@ public final class EmptyFileException extends ImportException {
     private final String fileName;
 
     public EmptyFileException(String fileName) {
-        super(NbBundle.getMessage(EmptyFileException.class, "EmptyFileException.message", fileName));
+        super(buildMessage(fileName));
         this.fileName = fileName;
     }
 
+    private static String buildMessage(String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            return NbBundle.getMessage(EmptyFileException.class, "EmptyFileException.messageNoName");
+        }
+        return NbBundle.getMessage(EmptyFileException.class, "EmptyFileException.message", fileName);
+    }
+
     /**
-     * @return the name of the empty file that triggered this exception
+     * @return the name of the empty file that triggered this exception, or {@code null} if it isn't known
      */
     public String getFileName() {
         return fileName;

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EmptyFileException.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/EmptyFileException.java
@@ -1,0 +1,70 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+*/
+
+package org.gephi.io.importer.api;
+
+import org.openide.util.NbBundle;
+
+/**
+ * Thrown when an import is attempted on a file that contains no data.
+ * <p>
+ * The {@link #getMessage() message} is localized via {@code NbBundle} and includes the name of the offending file so it
+ * can be shown directly to the user.
+ *
+ * @author Mathieu Bastian
+ */
+public final class EmptyFileException extends ImportException {
+
+    private final String fileName;
+
+    public EmptyFileException(String fileName) {
+        super(NbBundle.getMessage(EmptyFileException.class, "EmptyFileException.message", fileName));
+        this.fileName = fileName;
+    }
+
+    /**
+     * @return the name of the empty file that triggered this exception
+     */
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportException.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportException.java
@@ -1,0 +1,66 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+*/
+
+package org.gephi.io.importer.api;
+
+/**
+ * Base class for known, user-facing failures raised by the import pipeline.
+ * <p>
+ * Unlike a generic {@link RuntimeException}, an {@code ImportException} carries a message that has already been
+ * localized for end-user display. The desktop UI (and other front-ends) can catch instances of this class to present
+ * the failure as a friendly message instead of the default unexpected-exception treatment.
+ * <p>
+ * Subclasses should be created for specific known conditions (for example {@link EmptyFileException}) so that callers
+ * can react to them programmatically when needed.
+ *
+ * @author Mathieu Bastian
+ */
+public class ImportException extends RuntimeException {
+
+    public ImportException(String message) {
+        super(message);
+    }
+
+    public ImportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import org.gephi.io.importer.api.Container;
 import org.gephi.io.importer.api.ContainerUnloader;
 import org.gephi.io.importer.api.Database;
+import org.gephi.io.importer.api.EmptyFileException;
 import org.gephi.io.importer.api.FileType;
 import org.gephi.io.importer.api.ImportController;
 import org.gephi.io.importer.api.ImportUtils;
@@ -145,6 +146,7 @@ public class ImportControllerImpl implements ImportController {
         FileObject fileObject = FileUtil.toFileObject(file);
         if (fileObject != null) {
             fileObject = ImportUtils.getArchivedFile(fileObject);   //Unzip and return content file
+            checkFileNotEmpty(fileObject);
             file = FileUtil.toFile(fileObject);
             FileImporterBuilder builder = getMatchingImporter(fileObject);
             if (fileObject != null && builder != null) {
@@ -160,6 +162,7 @@ public class ImportControllerImpl implements ImportController {
         FileObject fileObject = FileUtil.toFileObject(file);
         if (fileObject != null) {
             fileObject = ImportUtils.getArchivedFile(fileObject);   //Unzip and return content file
+            checkFileNotEmpty(fileObject);
             file = FileUtil.toFile(fileObject);
             if (fileObject != null) {
                 Container c = importFile(fileObject.getInputStream(), importer, file);
@@ -167,6 +170,12 @@ public class ImportControllerImpl implements ImportController {
             }
         }
         return null;
+    }
+
+    private static void checkFileNotEmpty(FileObject fileObject) {
+        if (fileObject != null && fileObject.getSize() == 0) {
+            throw new EmptyFileException(fileObject.getNameExt());
+        }
     }
 
     @Override

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/impl/ImportControllerImpl.java
@@ -42,6 +42,7 @@
 
 package org.gephi.io.importer.impl;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -178,12 +179,32 @@ public class ImportControllerImpl implements ImportController {
         }
     }
 
+    private static Reader checkReaderNotEmpty(Reader reader, File file) {
+        // Wrap so we can peek the first character without consuming the stream.
+        BufferedReader bufferedReader =
+            reader instanceof BufferedReader ? (BufferedReader) reader : new BufferedReader(reader);
+        try {
+            bufferedReader.mark(1);
+            if (bufferedReader.read() == -1) {
+                throw new EmptyFileException(file != null ? file.getName() : null);
+            }
+            bufferedReader.reset();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        return bufferedReader;
+    }
+
     @Override
     public Container importFile(Reader reader, FileImporter importer) {
         return importFile(reader, importer, null);
     }
 
     public Container importFile(Reader reader, FileImporter importer, File file) {
+        // Detect empty input early so importers don't have to handle this case themselves
+        // and so the desktop UI can surface a friendly EmptyFileException.
+        reader = checkReaderNotEmpty(reader, file);
+
         //Create Container
         final Container container = Lookup.getDefault().lookup(Container.Factory.class).newContainer();
 

--- a/modules/ImportAPI/src/main/resources/org/gephi/io/importer/api/Bundle.properties
+++ b/modules/ImportAPI/src/main/resources/org/gephi/io/importer/api/Bundle.properties
@@ -11,3 +11,4 @@ ImportUtils.error_io = Impossible to read the given file
 ImportUtils.error_sax = Impossible to parse the given XML file
 
 EmptyFileException.message = The file ''{0}'' is empty.
+EmptyFileException.messageNoName = The file is empty.

--- a/modules/ImportAPI/src/main/resources/org/gephi/io/importer/api/Bundle.properties
+++ b/modules/ImportAPI/src/main/resources/org/gephi/io/importer/api/Bundle.properties
@@ -9,3 +9,5 @@ ImportUtils.error_file_not_found = Impossible to open the file.
 ImportUtils.error_missing_document_instance_factory = Impossible to obtain an instance of DocumentBuilder
 ImportUtils.error_io = Impossible to read the given file
 ImportUtils.error_sax = Impossible to parse the given XML file
+
+EmptyFileException.message = The file ''{0}'' is empty.

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGEXF.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/importer/plugin/file/ImporterGEXF.java
@@ -43,7 +43,6 @@
 package org.gephi.io.importer.plugin.file;
 
 import java.awt.Color;
-import java.io.IOException;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -146,10 +145,6 @@ public class ImporterGEXF implements FileImporter, LongTask {
         this.report = new Report();
         Progress.start(progress);
         try {
-
-            if (!reader.ready()) {
-                throw new IOException("The GEXF file is empty or has no content");
-            }
 
             XMLInputFactory inputFactory = XMLInputFactory.newInstance();
             if (inputFactory.isPropertySupported("javax.xml.stream.isValidating")) {

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -64,6 +64,7 @@
         <ul>
             <li>Processors function in <code>ImportController</code> now return a <code>Workspace</code> to clarify which worspaces graph data has been pushed to, given that providing a workspace to <code>process()</code> functions isn't required (and sometimes not even allowed, depending on the processor).</li>
             <li>Added <code>hasIssues()</code> to <code>Report</code> class to check if the report contains any issues.</li>
+            <li>Added a new <code>ImportException</code> base class for known, user-facing import failures, along with an <code>EmptyFileException</code> subclass. Empty files are now detected centrally in <code>ImportController</code> and raised as <code>EmptyFileException</code> with a localized message, so UIs can present a clean error instead of the default unexpected-exception treatment.</li>
         </ul>
         <h3>0.10.0</h3>
         <h4>Project API</h4>


### PR DESCRIPTION
## Summary

- Introduce `ImportException` (base) and `EmptyFileException` in the public `ImportAPI` so file importers can signal known, user-facing failures with a localized message, distinguished from genuinely unexpected errors.
- Move the empty-file detection out of individual importers and into `ImportControllerImpl` so every file importer (GEXF, GraphML, GML, GDF, DOT, Pajek, TGF, TLP, DL, VNA, spreadsheets) is protected by the same single check, raised as `EmptyFileException`.
- Teach `DesktopImportControllerUI.ImportErrorHandler` to recognize `ImportException` in the cause chain and surface only the friendly message via the existing issues report panel, instead of the developer-facing "Unexpected Exception" stacktrace popup. Unexpected errors keep their previous behaviour.
- Drop the now-redundant `reader.ready()` check in `ImporterGEXF` (introduced in #3192).
- Mention the new exceptions in the 0.11.0 Import API entry of `overview.html`.

The new types are extensible: future known errors (e.g. unsupported version, malformed root element) can be added as additional `ImportException` subclasses with their own bundle keys, with no further changes required in the controller or the desktop UI.

## Test plan

- [ ] Open an empty `.gexf` file - a friendly "The file '...' is empty." dialog appears in the issues panel, no stacktrace popup.
- [ ] Open an empty `.graphml`, `.gml`, `.gdf`, `.csv` etc. - same friendly dialog now triggered for all file formats.
- [ ] Open a malformed (but non-empty) file - existing developer popup with stacktrace still appears.
- [ ] Open a valid file - import works normally.

Made with [Cursor](https://cursor.com)