### PR TITLE
Fix NPE when FileUtil.toFileObject returns null in openFile

### DIFF
--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -590,7 +590,11 @@ public class ProjectControllerUIImpl implements ProjectListener {
                 FileObject fileObject = FileUtil.toFileObject(file);
 
                 if (fileObject == null) {
-                    continue;
+                    NotifyDescriptor.Message msg = new NotifyDescriptor.Message(NbBundle
+                        .getMessage(ProjectControllerUIImpl.class, "ProjectControllerUI.error.fileNotAccessible",
+                            file.getName()), NotifyDescriptor.ERROR_MESSAGE);
+                    DialogDisplayer.getDefault().notify(msg);
+                    return;
                 }
 
                 fileObjects.add(fileObject);

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -582,14 +582,18 @@ public class ProjectControllerUIImpl implements ProjectListener {
 
         if (returnFile == JFileChooser.APPROVE_OPTION) {
             File[] files = chooser.getSelectedFiles();
-            FileObject[] fileObjects = new FileObject[files.length];
+            List<FileObject> fileObjects = new ArrayList<>();
 
-            int i = 0;
             File gephiFile = null;
             for (File file : files) {
                 file = FileUtil.normalizeFile(file);
                 FileObject fileObject = FileUtil.toFileObject(file);
-                fileObjects[i++] = fileObject;
+
+                if (fileObject == null) {
+                    continue;
+                }
+
+                fileObjects.add(fileObject);
 
                 if (fileObject.getExt().equalsIgnoreCase("gephi")) {
                     if (gephiFile != null) {
@@ -621,7 +625,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
                 });
             } else {
                 //Import
-                importControllerUI.importFiles(fileObjects);
+                importControllerUI.importFiles(fileObjects.toArray(new FileObject[0]));
             }
         }
     }

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/actions/OpenFile.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/actions/OpenFile.java
@@ -87,6 +87,9 @@ public final class OpenFile extends AbstractAction {
         if (isEnabled()) {
             if (ev != null && ev.getSource() != null && ev.getSource() instanceof File) {
                 FileObject fileObject = FileUtil.toFileObject((File) ev.getSource());
+                if (fileObject == null) {
+                    return;
+                }
                 if (fileObject.hasExt(GEPHI_EXTENSION)) {
                     Lookup.getDefault().lookup(ProjectControllerUIImpl.class).openProject(FileUtil.toFile(fileObject));
                 } else {

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/actions/OpenFile.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/actions/OpenFile.java
@@ -86,8 +86,13 @@ public final class OpenFile extends AbstractAction {
     public void actionPerformed(ActionEvent ev) {
         if (isEnabled()) {
             if (ev != null && ev.getSource() != null && ev.getSource() instanceof File) {
-                FileObject fileObject = FileUtil.toFileObject((File) ev.getSource());
+                File sourceFile = (File) ev.getSource();
+                FileObject fileObject = FileUtil.toFileObject(sourceFile);
                 if (fileObject == null) {
+                    NotifyDescriptor.Message msg = new NotifyDescriptor.Message(NbBundle
+                        .getMessage(OpenFile.class, "OpenFile.fileNotAccessible", sourceFile.getName()),
+                        NotifyDescriptor.ERROR_MESSAGE);
+                    DialogDisplayer.getDefault().notify(msg);
                     return;
                 }
                 if (fileObject.hasExt(GEPHI_EXTENSION)) {

--- a/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/Bundle.properties
+++ b/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/Bundle.properties
@@ -23,6 +23,7 @@ OpenFile_filechooser_zipfilter=Archived Files
 ProjectControllerUI.error.open=The project file couldn't be opened. Please check the file has .gephi extension.
 ProjectControllerUI.error.multipleGephi=Please select a unique .gephi project file
 ProjectControllerUI.error.noFileAssociated=The project file for "{0}" cannot be found. The project may not have been saved to disk.
+ProjectControllerUI.error.fileNotAccessible=The file "{0}" cannot be accessed. It may have been moved, deleted, or is on an unavailable drive.
 
 DeleteWorkspace_confirm_message=Are you sure do you want to delete this workspace ?
 DeleteWorkspace_confirm_title=Close workspace

--- a/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/actions/Bundle.properties
+++ b/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/actions/Bundle.properties
@@ -17,3 +17,4 @@ CTL_OpenOnlineDoc=Online docs and support
 RenameWorkspace.dialog.title = Rename Workspace
 CTL_OpenRecentFiles=Open Recent...
 OpenFile.fileNotSupported=The file format is not supported
+OpenFile.fileNotAccessible=The file "{0}" cannot be accessed. It may have been moved, deleted, or is on an unavailable drive.


### PR DESCRIPTION
## Summary

- `FileUtil.toFileObject()` can return null when the selected file is not accessible through the NetBeans VFS (file deleted, unmounted drive, or network share dropped between dialog confirm and processing)
- `ProjectControllerUIImpl.openFile`: replaced fixed-size `FileObject[]` with a `List<FileObject>`, shows an error dialog naming the inaccessible file and returns instead of crashing with NPE on `.getExt()`
- `OpenFile.actionPerformed`: same null guard with error dialog before `.hasExt()` call

Rather than silently skipping the file (which leaves the user wondering what happened), both paths now show: _"The file '...' cannot be accessed. It may have been moved, deleted, or is on an unavailable drive."_

Fixes GEPHI-4EZ (16 users), GEPHI-5JT (9 users)

## Test plan

- [ ] Open a file via File > Open — verify normal flow unaffected
- [ ] Open a file that becomes inaccessible before dialog confirm — error dialog shown with filename, no crash
- [ ] Multi-select files — null entries produce error dialog and abort the batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)