### PR TITLE
Fix NPE when tab action command is null in WorkspacePanel

### DIFF
--- a/modules/DesktopWindow/src/main/java/org/gephi/desktop/banner/workspace/WorkspacePanel.java
+++ b/modules/DesktopWindow/src/main/java/org/gephi/desktop/banner/workspace/WorkspacePanel.java
@@ -129,23 +129,23 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
             @Override
             public void actionPerformed(ActionEvent e) {
                 TabActionEvent tabActionEvent = (TabActionEvent) e;
-                if (tabActionEvent.getActionCommand().equals(TabbedContainer.COMMAND_CLOSE)) {
+                if (TabbedContainer.COMMAND_CLOSE.equals(tabActionEvent.getActionCommand())) {
                     TabData tabData = tabDataModel.getTab(tabActionEvent.getTabIndex());
                     Actions.forID("Workspace", "org.gephi.desktop.project.actions.DeleteWorkspace").actionPerformed(
                         new ActionEvent(tabData.getUserObject(), 0, null));
 
                     tabActionEvent.consume();
-                } else if (tabActionEvent.getActionCommand().equals(TabbedContainer.COMMAND_CLOSE_ALL)) {
+                } else if (TabbedContainer.COMMAND_CLOSE_ALL.equals(tabActionEvent.getActionCommand())) {
                     Actions.forID("File", "org.gephi.desktop.project.actions.CloseProject").actionPerformed(null);
                     tabActionEvent.consume();
-                } else if (tabActionEvent.getActionCommand().equals(TabbedContainer.COMMAND_CLOSE_ALL_BUT_THIS)) {
+                } else if (TabbedContainer.COMMAND_CLOSE_ALL_BUT_THIS.equals(tabActionEvent.getActionCommand())) {
                     TabData tabData = tabDataModel.getTab(tabActionEvent.getTabIndex());
 
                     Actions.forID("Workspace", "org.gephi.desktop.project.actions.DeleteOtherWorkspaces").actionPerformed(
                         new ActionEvent(tabData.getUserObject(), 0, null));
 
                     tabActionEvent.consume();
-                } else if (tabActionEvent.getActionCommand().equals(TabbedContainer.COMMAND_SELECT)) {
+                } else if (TabbedContainer.COMMAND_SELECT.equals(tabActionEvent.getActionCommand())) {
                     TabData tabData = tabDataModel.getTab(tabActionEvent.getTabIndex());
                     ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
                     pc.openWorkspace((Workspace) tabData.getUserObject());


### PR DESCRIPTION
## Summary

- NetBeans `TabControlButton.fireActionPerformed` can fire a `TabActionEvent` with a null action command in certain tab interactions (e.g. clicking the close button on a workspace tab)
- `WorkspacePanel$3.actionPerformed` called `.equals()` on the command string without a null check, causing NPE
- Fix: flip all four comparisons to constant-side (`TabbedContainer.COMMAND_CLOSE.equals(...)`) — null-safe with no behavioural change

The 10 events/user ratio indicates users repeatedly hit this in normal use (every close-tab click).

Fixes GEPHI-5A0 (7 users, 70 events)

## Test plan

- [ ] Click the × button on a workspace tab — workspace closes, no NPE
- [ ] Right-click tab → Close All — works correctly
- [ ] Right-click tab → Close All But This — works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)