### PR TITLE
Fix NPE in setEditMode when Attributes model is null

### DIFF
--- a/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesUIControllerImpl.java
+++ b/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesUIControllerImpl.java
@@ -126,6 +126,9 @@ public class AttributesUIControllerImpl implements AttributesUIController, Contr
 
     private void setEditMode(boolean editMode) {
         AttributesUIModelImpl model = getModel();
+        if (model == null) {
+            return;
+        }
         if (model.isEditMode() != editMode) {
             model.setEditMode(editMode);
             if (editMode) {


### PR DESCRIPTION
## Summary

- When the Edit tool is deselected without a project loaded, it calls `disableEdit` → `setEditMode` on `AttributesUIControllerImpl`
- `setEditMode` was missing the null guard on `getModel()` that every other method in the class has, causing NPE
- One-line fix: add `if (model == null) { return; }` consistent with `setSelectedNodes`, `setSelectedEdges`, and `resetSelection`

Fixes GEPHI-5HP (7 users, 15 events)

## Test plan

- [ ] Start Gephi with no project, activate the Edit tool, then deselect it — no NPE
- [ ] Normal edit-mode toggle with a project open — behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)