### PR TITLE
Fix ConcurrentModificationException in layout listener iteration

### DIFF
--- a/modules/LayoutAPI/src/main/java/org/gephi/layout/LayoutModelImpl.java
+++ b/modules/LayoutAPI/src/main/java/org/gephi/layout/LayoutModelImpl.java
@@ -192,7 +192,7 @@ public class LayoutModelImpl implements LayoutModel, Model {
             default:
                 return;
         }
-        for (PropertyChangeListener l : listeners) {
+        for (PropertyChangeListener l : new ArrayList<>(listeners)) {
             l.propertyChange(evt);
         }
     }


### PR DESCRIPTION
## Summary

- `firePropertyChangeEvent` in `LayoutModelImpl` iterated the `listeners` ArrayList directly
- A listener that adds or removes itself during the `propertyChange` callback (e.g. a one-shot listener that unregisters on receipt) causes `ConcurrentModificationException`
- Fix: snapshot the list with `new ArrayList<>(listeners)` before iterating — one character change, no new dependencies

Fixes GEPHI-5JW (5 users, 6 events)

## Test plan

- [ ] Run a layout, stop it — no CME thrown
- [ ] Register a listener that removes itself in `propertyChange` — no CME

🤖 Generated with [Claude Code](https://claude.com/claude-code)