### PR TITLE
Fix EDT deadlock during PreviewUIController init

### DIFF
--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIControllerImpl.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIControllerImpl.java
@@ -59,8 +59,6 @@ import org.gephi.desktop.preview.propertyeditors.DependantColorPropertyEditor;
 import org.gephi.desktop.preview.propertyeditors.DependantOriginalColorPropertyEditor;
 import org.gephi.desktop.preview.propertyeditors.DisabledAwareFontEditor;
 import org.gephi.desktop.preview.propertyeditors.EdgeColorPropertyEditor;
-import org.gephi.graph.api.GraphController;
-import org.gephi.graph.api.GraphModel;
 import org.gephi.preview.api.PreviewController;
 import org.gephi.preview.api.PreviewModel;
 import org.gephi.preview.api.PreviewPreset;
@@ -78,61 +76,60 @@ import org.gephi.preview.types.EdgeColor;
 import org.gephi.project.api.ProjectController;
 import org.gephi.project.api.Workspace;
 import org.gephi.project.api.WorkspaceListener;
+import org.gephi.project.spi.Controller;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
 import org.openide.windows.WindowManager;
 
 /**
  * Controller implementation of the preview UI.
  *
+ * <p>Implements the {@link Controller} SPI so that a {@link PreviewUIModelImpl} is created in
+ * every workspace's lookup automatically by {@code WorkspaceImpl.initModels()}. This keeps the
+ * controller stateless and side-effect free at construction time, which avoids EDT stalls during
+ * lazy lookup of the singleton (see GEPHI-5KZ).
+ *
  * @author Jérémy Subtil, Mathieu Bastian
  */
-@ServiceProvider(service = PreviewUIController.class)
-public class PreviewUIControllerImpl implements PreviewUIController {
+@ServiceProviders({
+    @ServiceProvider(service = PreviewUIController.class),
+    @ServiceProvider(service = Controller.class, position = 2000)})
+public class PreviewUIControllerImpl implements PreviewUIController, Controller<PreviewUIModelImpl> {
 
-    private final List<PropertyChangeListener> listeners;
-    private final PreviewController previewController;
-    private final GraphController graphController;
+    private final List<PropertyChangeListener> listeners = new ArrayList<>();
     private final PresetUtils presetUtils = new PresetUtils();
-    private PreviewUIModelImpl model = null;
-    private GraphModel graphModel = null;
+    private final PreviewController previewController;
 
     public PreviewUIControllerImpl() {
         previewController = Lookup.getDefault().lookup(PreviewController.class);
-        listeners = new ArrayList<>();
+
         ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-        graphController = Lookup.getDefault().lookup(GraphController.class);
         pc.addWorkspaceListener(new WorkspaceListener() {
             @Override
             public void initialize(Workspace workspace) {
-                PreviewModel previewModel = previewController.getModel(workspace);
-                if (workspace.getLookup().lookup(PreviewUIModelImpl.class) == null) {
-                    workspace.add(new PreviewUIModelImpl(previewModel, PreviewUIControllerImpl.this));
-                }
                 enableRefresh();
             }
 
             @Override
             public void select(Workspace workspace) {
-                graphModel = graphController.getGraphModel(workspace);
-
-                PreviewModel previewModel = previewController.getModel(workspace);
-                model = workspace.getLookup().lookup(PreviewUIModelImpl.class);
-                if (model == null) {
-                    model = new PreviewUIModelImpl(previewModel, PreviewUIControllerImpl.this);
-                    workspace.add(model);
+                PreviewUIModelImpl model = getModel(workspace);
+                if (model != null) {
+                    PreviewModel previewModel = model.getPreviewModel();
+                    if (previewModel != null) {
+                        Float visibilityRatio =
+                            previewModel.getProperties().getFloatValue(PreviewProperty.VISIBILITY_RATIO);
+                        if (visibilityRatio != null) {
+                            model.setVisibilityRatio(visibilityRatio);
+                        }
+                    }
                 }
-                Float visibilityRatio = previewModel.getProperties().getFloatValue(PreviewProperty.VISIBILITY_RATIO);
-                model.setVisibilityRatio(visibilityRatio);
                 fireEvent(SELECT, model);
             }
 
             @Override
             public void unselect(Workspace workspace) {
-                if (graphModel != null) {
-                    graphModel = null;
-                }
-                fireEvent(UNSELECT, model);
+                fireEvent(UNSELECT, getModel(workspace));
             }
 
             @Override
@@ -141,27 +138,9 @@ public class PreviewUIControllerImpl implements PreviewUIController {
 
             @Override
             public void disable() {
-                if (graphModel != null) {
-                    graphModel = null;
-                }
                 fireEvent(SELECT, null);
-                model = null;
             }
         });
-        if (pc.getCurrentWorkspace() != null) {
-            model = pc.getCurrentWorkspace().getLookup().lookup(PreviewUIModelImpl.class);
-            if (model == null) {
-                PreviewModel previewModel = previewController.getModel(pc.getCurrentWorkspace());
-                model = new PreviewUIModelImpl(previewModel, this);
-                pc.getCurrentWorkspace().add(model);
-            }
-            Float visibilityRatio =
-                previewController.getModel().getProperties().getFloatValue(PreviewProperty.VISIBILITY_RATIO);
-            if (visibilityRatio != null) {
-                model.setVisibilityRatio(visibilityRatio);
-            }
-            graphModel = graphController.getGraphModel(pc.getCurrentWorkspace());
-        }
 
         //Register editors
         //Overriding default Preview API basic editors that don't support CustomEditor
@@ -173,27 +152,40 @@ public class PreviewUIControllerImpl implements PreviewUIController {
         PropertyEditorManager.registerEditor(Font.class, DisabledAwareFontEditor.class);
     }
 
+    @Override
+    public PreviewUIModelImpl newModel(Workspace workspace) {
+        return new PreviewUIModelImpl(workspace, this);
+    }
+
+    @Override
+    public Class<PreviewUIModelImpl> getModelClass() {
+        return PreviewUIModelImpl.class;
+    }
+
+    @Override
+    public PreviewUIModelImpl getModel() {
+        return Controller.super.getModel();
+    }
+
     /**
      * Refreshes the preview applet.
      */
     @Override
     public void refreshPreview() {
+        final PreviewUIModelImpl model = getModel();
         if (model != null) {
-            Thread refreshThread = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    model.setRefreshing(true);
-                    fireEvent(REFRESHING, true);
+            Thread refreshThread = new Thread(() -> {
+                model.setRefreshing(true);
+                fireEvent(REFRESHING, true);
 
-                    previewController.getModel().getProperties()
-                        .putValue(PreviewProperty.VISIBILITY_RATIO, model.getVisibilityRatio());
-                    previewController.refreshPreview();
+                previewController.getModel().getProperties()
+                    .putValue(PreviewProperty.VISIBILITY_RATIO, model.getVisibilityRatio());
+                previewController.refreshPreview();
 
-                    fireEvent(REFRESHED, model);
+                fireEvent(REFRESHED, model);
 
-                    model.setRefreshing(false);
-                    fireEvent(REFRESHING, false);
-                }
+                model.setRefreshing(false);
+                fireEvent(REFRESHING, false);
             }, "Refresh Preview");
             refreshThread.start();
         }
@@ -203,28 +195,21 @@ public class PreviewUIControllerImpl implements PreviewUIController {
      * Enables the preview refresh action.
      */
     private void enableRefresh() {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                PreviewSettingsTopComponent pstc = (PreviewSettingsTopComponent) WindowManager.getDefault()
-                    .findTopComponent("PreviewSettingsTopComponent");
-                if (pstc != null) {
-                    pstc.enableRefreshButton();
-                }
+        SwingUtilities.invokeLater(() -> {
+            PreviewSettingsTopComponent pstc = (PreviewSettingsTopComponent) WindowManager.getDefault()
+                .findTopComponent("PreviewSettingsTopComponent");
+            if (pstc != null) {
+                pstc.enableRefreshButton();
             }
         });
     }
 
     @Override
     public void setVisibilityRatio(float visibilityRatio) {
+        PreviewUIModelImpl model = getModel();
         if (model != null) {
             model.setVisibilityRatio(visibilityRatio);
         }
-    }
-
-    @Override
-    public PreviewUIModel getModel() {
-        return model;
     }
 
     @Override
@@ -242,10 +227,13 @@ public class PreviewUIControllerImpl implements PreviewUIController {
 
     @Override
     public void setCurrentPreset(PreviewPreset preset) {
+        PreviewUIModelImpl model = getModel();
         if (model != null) {
             model.setCurrentPreset(preset);
             PreviewModel previewModel = previewController.getModel();
-            previewModel.getProperties().applyPreset(preset);
+            if (previewModel != null) {
+                previewModel.getProperties().applyPreset(preset);
+            }
         }
     }
 
@@ -266,6 +254,7 @@ public class PreviewUIControllerImpl implements PreviewUIController {
 
     @Override
     public void savePreset(String name) {
+        PreviewUIModelImpl model = getModel();
         if (model != null) {
             PreviewModel previewModel = previewController.getModel();
             Map<String, Object> map = new HashMap<>();

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIModelImpl.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIModelImpl.java
@@ -54,29 +54,37 @@ import org.gephi.preview.api.PreviewPreset;
 import org.gephi.preview.presets.BlackBackground;
 import org.gephi.preview.presets.DefaultPreset;
 import org.gephi.project.api.Workspace;
+import org.gephi.project.spi.Model;
 import org.gephi.ui.utils.UIUtils;
 import org.openide.util.NbPreferences;
 
 /**
  * @author Mathieu Bastian
  */
-public class PreviewUIModelImpl implements PreviewUIModel {
+public class PreviewUIModelImpl implements PreviewUIModel, Model {
 
     public static final String DEFAULT_PRESET_CLASS = "PreviewOptions.defaultPresetClass";
     public static final String DEFAULT_PRESET_NAME = "PreviewOptions.defaultPresetName";
 
-    private final PreviewModel previewModel;
+    private final Workspace workspace;
     private final PreviewUIController controller;
     //Data
     private float visibilityRatio = 1f;
     private PreviewPreset currentPreset;
     private boolean refreshing;
 
-    public PreviewUIModelImpl(PreviewModel model, PreviewUIController controller) {
-        previewModel = model;
+    public PreviewUIModelImpl(Workspace workspace, PreviewUIController controller) {
+        this.workspace = workspace;
         this.controller = controller;
         currentPreset = resolveDefaultPreset();
-        model.getProperties().applyPreset(currentPreset);
+        // PreviewModel is owned by PreviewController and may not yet be present in the workspace
+        // lookup (depends on Controller iteration order in WorkspaceImpl.initModels). Apply the
+        // default preset only if it is already there; otherwise the preset will be applied lazily
+        // via setCurrentPreset or when the user/persistence triggers a refresh.
+        PreviewModel previewModel = getPreviewModel();
+        if (previewModel != null) {
+            previewModel.getProperties().applyPreset(currentPreset);
+        }
     }
 
     private PreviewPreset resolveDefaultPreset() {
@@ -105,12 +113,12 @@ public class PreviewUIModelImpl implements PreviewUIModel {
 
     @Override
     public PreviewModel getPreviewModel() {
-        return previewModel;
+        return workspace.getLookup().lookup(PreviewModel.class);
     }
 
     @Override
     public Workspace getWorkspace() {
-        return previewModel.getWorkspace();
+        return workspace;
     }
 
     @Override

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIPersistenceProvider.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIPersistenceProvider.java
@@ -4,8 +4,6 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 import org.gephi.desktop.preview.api.PreviewUIController;
-import org.gephi.preview.api.PreviewController;
-import org.gephi.preview.api.PreviewModel;
 import org.gephi.project.api.Workspace;
 import org.gephi.project.spi.WorkspacePersistenceProvider;
 import org.gephi.project.spi.WorkspaceXMLPersistenceProvider;
@@ -30,14 +28,12 @@ public class PreviewUIPersistenceProvider implements WorkspaceXMLPersistenceProv
     @Override
     public void readXML(XMLStreamReader reader, Workspace workspace) {
         PreviewUIModelImpl model = workspace.getLookup().lookup(PreviewUIModelImpl.class);
-        PreviewModel previewModel = workspace.getLookup().lookup(PreviewModel.class);
-        if (previewModel == null) {
-            PreviewController previewController = Lookup.getDefault().lookup(PreviewController.class);
-            previewModel = previewController.getModel(workspace);
-        }
         if (model == null) {
+            // The model is normally created by WorkspaceImpl.initModels() via the Controller SPI.
+            // This branch only triggers if the workspace was constructed without initializing
+            // models; create one defensively so legacy/edge-case load paths still work.
             PreviewUIController previewUIController = Lookup.getDefault().lookup(PreviewUIController.class);
-            model = new PreviewUIModelImpl(previewModel, previewUIController);
+            model = new PreviewUIModelImpl(workspace, previewUIController);
             workspace.add(model);
         }
         try {

--- a/modules/DesktopPreview/src/test/java/org/gephi/desktop/preview/utils/Utils.java
+++ b/modules/DesktopPreview/src/test/java/org/gephi/desktop/preview/utils/Utils.java
@@ -1,21 +1,14 @@
 package org.gephi.desktop.preview.utils;
 
 import org.gephi.desktop.preview.PreviewUIModelImpl;
-import org.gephi.desktop.preview.api.PreviewUIController;
-import org.gephi.preview.api.PreviewController;
-import org.gephi.preview.api.PreviewModel;
 import org.gephi.project.impl.WorkspaceImpl;
-import org.openide.util.Lookup;
 
 public class Utils {
 
     public static PreviewUIModelImpl newPreviewUIModel() {
+        // WorkspaceImpl.initModels() auto-creates both PreviewModelImpl and PreviewUIModelImpl
+        // via the registered Controller SPI implementations.
         WorkspaceImpl workspace = new WorkspaceImpl(null, 0);
-        PreviewController previewController = Lookup.getDefault().lookup(PreviewController.class);
-        PreviewModel previewModel = previewController.getModel(workspace);
-        PreviewUIController previewUIController = Lookup.getDefault().lookup(PreviewUIController.class);
-        PreviewUIModelImpl model = new PreviewUIModelImpl(previewModel, previewUIController);
-        workspace.add(model);
-        return model;
+        return workspace.getLookup().lookup(PreviewUIModelImpl.class);
     }
 }

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/PreviewControllerImpl.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/PreviewControllerImpl.java
@@ -77,7 +77,7 @@ import org.openide.util.lookup.ServiceProviders;
  */
 @ServiceProviders({
     @ServiceProvider(service = PreviewController.class),
-    @ServiceProvider(service = Controller.class)})
+    @ServiceProvider(service = Controller.class, position = 1000)})
 public class PreviewControllerImpl implements PreviewController, Controller<PreviewModelImpl> {
 
     //Registered renderers

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
@@ -242,9 +242,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public ProjectsImpl getProjects() {
-        synchronized (this) {
-            return projects;
-        }
+        return projects;
     }
 
     @Override
@@ -254,9 +252,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public boolean hasCurrentProject() {
-        synchronized (this) {
-            return projects.hasCurrentProject();
-        }
+        return projects.hasCurrentProject();
     }
 
     @Override
@@ -334,19 +330,15 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public ProjectImpl getCurrentProject() {
-        synchronized (this) {
-            return projects.getCurrentProject();
-        }
+        return projects.getCurrentProject();
     }
 
     @Override
     public WorkspaceImpl getCurrentWorkspace() {
-        synchronized (this) {
-            if (projects.hasCurrentProject()) {
-                return getCurrentProject().getCurrentWorkspace();
-            }
-            return null;
-        }
+        // Read-only access; do not acquire the controller-wide monitor here, as long-running
+        // write operations (open/save/load) hold it and the EDT frequently calls this method.
+        ProjectImpl current = projects.getCurrentProject();
+        return current != null ? current.getCurrentWorkspace() : null;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes the GUI freeze reported as **GEPHI-5KZ** (`CLIOptions2$EQStuck` on `PreviewUIControllerImpl.<init>:151`). Two complementary changes:

- **`ProjectControllerImpl`**: drop `synchronized(this)` from the read-only methods (`getCurrentWorkspace`, `getCurrentProject`, `hasCurrentProject`, `getProjects`). Long-running write paths (open/save/load) hold this monitor, and the EDT was blocking on it. Underlying state in `ProjectsImpl`/`WorkspaceProviderImpl` is already thread-safe via its own internal locks.

- **PreviewUI**: migrate `PreviewUIControllerImpl` / `PreviewUIModelImpl` to the `Controller<Model>` SPI so the model is created automatically by `WorkspaceImpl.initModels()`. The controller constructor no longer reads project state, removing the EDT-init contention path entirely. Also drops the dead `graphModel` field.

## Test plan

- [x] `ProjectControllerImplTest` (22/22 passing)
- [x] `PreviewAPI` tests (13/13 passing)
- [x] `DesktopPreview.PersistenceProviderTest` (4/4 passing)
- [ ] Manual smoke test: open/close projects, switch workspaces, save/load `.gephi` files, change preview presets and visibility ratio

Made with [Cursor](https://cursor.com)