### PR TITLE
Show error dialog when OpenGL is unsupported (GDI Generic / OpenGL < 2.0)

### DIFF
--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/component/VizEngineGraphCanvasManager.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/component/VizEngineGraphCanvasManager.java
@@ -7,8 +7,11 @@ import com.jogamp.newt.awt.NewtCanvasAWT;
 import com.jogamp.newt.event.MouseEvent;
 import com.jogamp.newt.event.NEWTEvent;
 import com.jogamp.newt.opengl.GLWindow;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GLAutoDrawable;
 import com.jogamp.opengl.GLCapabilities;
 import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.GLEventListener;
 import com.jogamp.opengl.GLProfile;
 import java.awt.BorderLayout;
 import java.awt.EventQueue;
@@ -18,9 +21,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.util.NbBundle;
 import org.gephi.graph.api.GraphModel;
 import org.gephi.project.api.Workspace;
 import org.gephi.ui.utils.UIUtils;
@@ -75,6 +83,9 @@ public class VizEngineGraphCanvasManager {
         final Screen screen = NewtFactory.createScreen(display, 0);
 
         this.glWindow = GLWindow.create(screen, caps);
+
+        // Check for unsupported OpenGL before the engine registers its listener
+        glWindow.addGLEventListener(new OpenGLVersionChecker());
 
         if (VizConfig.isEngineOpenGLDebug()) {
             glWindow.setContextCreationFlags(GLContext.CTX_OPTION_DEBUG);
@@ -245,6 +256,55 @@ public class VizEngineGraphCanvasManager {
             throw new RuntimeException("Interrupted while waiting for EDT task", ex);
         } catch (InvocationTargetException ex) {
             throw new RuntimeException("EDT task failed", ex.getCause());
+        }
+    }
+
+    private static class OpenGLVersionChecker implements GLEventListener {
+
+        private static final AtomicBoolean WARNED = new AtomicBoolean(false);
+
+        @Override
+        public void init(GLAutoDrawable drawable) {
+            final GL gl = drawable.getGL();
+            final String renderer = gl.glGetString(GL.GL_RENDERER);
+            final String version = gl.glGetString(GL.GL_VERSION);
+
+            // OpenGL version string starts with "major.minor"
+            boolean tooOld = false;
+            if (version != null && !version.isEmpty()) {
+                try {
+                    int major = Character.getNumericValue(version.charAt(0));
+                    tooOld = major < 2;
+                } catch (Exception ignored) {
+                }
+            }
+            final boolean isGdiGeneric = renderer != null && renderer.contains("GDI Generic");
+
+            if ((tooOld || isGdiGeneric) && WARNED.compareAndSet(false, true)) {
+                final String rendererStr = renderer != null ? renderer : "unknown";
+                final String versionStr = version != null ? version : "unknown";
+                Logger.getLogger(VizEngineGraphCanvasManager.class.getName()).log(
+                    Level.WARNING, "Unsupported OpenGL: renderer={0}, version={1}",
+                    new Object[] {rendererStr, versionStr});
+                SwingUtilities.invokeLater(() -> {
+                    String msg = NbBundle.getMessage(VizEngineGraphCanvasManager.class,
+                        "VizEngineGraphCanvasManager.opengl.unsupported.message", rendererStr, versionStr);
+                    NotifyDescriptor nd = new NotifyDescriptor.Message(msg, NotifyDescriptor.ERROR_MESSAGE);
+                    DialogDisplayer.getDefault().notify(nd);
+                });
+            }
+        }
+
+        @Override
+        public void dispose(GLAutoDrawable drawable) {
+        }
+
+        @Override
+        public void display(GLAutoDrawable drawable) {
+        }
+
+        @Override
+        public void reshape(GLAutoDrawable drawable, int x, int y, int width, int height) {
         }
     }
 }

--- a/modules/VisualizationImpl/src/main/resources/org/gephi/visualization/component/Bundle.properties
+++ b/modules/VisualizationImpl/src/main/resources/org/gephi/visualization/component/Bundle.properties
@@ -1,3 +1,4 @@
 CTL_GraphAction=Graph
 CTL_GraphTopComponent=Graph
 GraphTopComponent.waitingLabel.text=Initializing...
+VizEngineGraphCanvasManager.opengl.unsupported.message=Gephi requires OpenGL 2.0 or later, but your system only provides OpenGL {1} ({0}).\n\nThis usually means your graphics driver is not installed or you are running in a remote desktop session without GPU acceleration.\n\nPlease install or update your graphics driver and restart Gephi.


### PR DESCRIPTION
## Summary
- Registers a `GLEventListener` on the `GLWindow` before the viz engine registers its own listener, so it fires first during GL context initialization
- Checks for `GDI Generic` renderer or OpenGL version < 2.0, both of which indicate the Windows software fallback (no GPU driver / RDP session)
- Shows a clear error dialog via `NotifyDescriptor` on the EDT explaining the issue and pointing the user to install a graphics driver
- Uses a static `AtomicBoolean` to show the warning only once per JVM session

Fixes GEPHI-5JK, GEPHI-5JM, GEPHI-5HQ (all cascades from this root cause).

## Test plan
- [ ] On a normal system: no dialog appears, Gephi opens as usual
- [ ] On a system with GDI Generic / OpenGL 1.1: error dialog is shown instead of a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)