### PR TITLE
Fix IllegalArgumentException in Search/Replace when columns have been deleted

### DIFF
--- a/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/SearchReplaceControllerImpl.java
+++ b/modules/DataLaboratoryAPI/src/main/java/org/gephi/datalab/impl/SearchReplaceControllerImpl.java
@@ -212,24 +212,29 @@ public class SearchReplaceControllerImpl implements SearchReplaceController {
         Table table = Lookup.getDefault().lookup(GraphController.class).getGraphModel().getNodeTable();
         Node[] nodes = searchOptions.getNodesToSearch();
         Node row;
-        Column column;
         Object value;
 
         TimeFormat timeFormat = table.getGraph().getModel().getTimeFormat();
         ZoneId timeZone = table.getGraph().getModel().getTimeZone();
+
+        // Use toArray() to get a compact, gap-free snapshot of active columns.
+        // Column indices in the store may not be contiguous after deletions, so
+        // countColumns() cannot safely be used as an upper bound for index-based access.
+        Column[] columns = table.toArray();
 
         for (; rowIndex < nodes.length; rowIndex++) {
             if (!gec.isNodeInGraph(nodes[rowIndex])) {
                 continue;//Make sure node is still in graph when continuing a search
             }
             row = nodes[rowIndex];
-            for (; columnIndex < table.countColumns(); columnIndex++) {
-                if (searchAllColumns || columnsToSearch.contains(columnIndex)) {
-                    column = table.getColumn(columnIndex);
+            for (; columnIndex < columns.length; columnIndex++) {
+                Column column = columns[columnIndex];
+                if (searchAllColumns || columnsToSearch.contains(column.getIndex())) {
                     value = row.getAttribute(column);
                     result = matchRegex(value, searchOptions, rowIndex, columnIndex, timeFormat, timeZone);
                     if (result != null) {
                         result.setFoundNode(nodes[rowIndex]);
+                        result.setFoundColumnIndex(column.getIndex());
                         return result;
                     }
                 }
@@ -249,24 +254,29 @@ public class SearchReplaceControllerImpl implements SearchReplaceController {
         Table table = Lookup.getDefault().lookup(GraphController.class).getGraphModel().getEdgeTable();
         Edge[] edges = searchOptions.getEdgesToSearch();
         Edge row;
-        Column column;
         Object value;
 
         TimeFormat timeFormat = table.getGraph().getModel().getTimeFormat();
         ZoneId timeZone = table.getGraph().getModel().getTimeZone();
+
+        // Use toArray() to get a compact, gap-free snapshot of active columns.
+        // Column indices in the store may not be contiguous after deletions, so
+        // countColumns() cannot safely be used as an upper bound for index-based access.
+        Column[] columns = table.toArray();
 
         for (; rowIndex < edges.length; rowIndex++) {
             if (!gec.isEdgeInGraph(edges[rowIndex])) {
                 continue;//Make sure edge is still in graph when continuing a search
             }
             row = edges[rowIndex];
-            for (; columnIndex < table.countColumns(); columnIndex++) {
-                if (searchAllColumns || columnsToSearch.contains(columnIndex)) {
-                    column = table.getColumn(columnIndex);
+            for (; columnIndex < columns.length; columnIndex++) {
+                Column column = columns[columnIndex];
+                if (searchAllColumns || columnsToSearch.contains(column.getIndex())) {
                     value = row.getAttribute(column);
                     result = matchRegex(value, searchOptions, rowIndex, columnIndex, timeFormat, timeZone);
                     if (result != null) {
                         result.setFoundEdge(edges[rowIndex]);
+                        result.setFoundColumnIndex(column.getIndex());
                         return result;
                     }
                 }


### PR DESCRIPTION
## Summary

- `ColumnStore` stores columns in a sparse array where deleted column slots become `null` and are recycled via a `garbageQueue`. This means column indices are **not contiguous** after any deletion.
- `findOnNodes` and `findOnEdges` used `table.countColumns()` as the loop upper bound and called `table.getColumn(columnIndex)` with a sequential counter. When a gap existed within `0..countColumns()-1`, `getColumnByIndex` threw `IllegalArgumentException: The column doesnt exist`.
- A secondary bug: `columnsToSearch` holds actual column store indices (from `column.getIndex()`), but the filter check compared them against the sequential loop counter — silently wrong after any deletion.

## Fix

- Replaced index-based iteration with `table.toArray()`, which returns a compact, gap-free snapshot of active columns.
- Use `column.getIndex()` for the `columnsToSearch` filter check and for `foundColumnIndex` stored in `SearchResult` (used by callers such as `canReplace`, `replace`, and `SearchReplaceUI` to call `table.getColumn()`).
- The `startingColumn` state (loop position for resuming iteration) continues to use the position within the `toArray()` snapshot, which is the correct semantic.

## Reproducer

1. Open a graph with columns
2. Delete a column (leaving a gap in the store index space)
3. Open Data Laboratory → Search/Replace and run a search
4. → `IllegalArgumentException: The column doesnt exist`

Made with [Cursor](https://cursor.com)