### PR TITLE
Move all GL2xxx reference to GL3ES3

### DIFF
--- a/modules/VisualizationEngine/src/main/java/jogamp/text/util/ShaderLoader.java
+++ b/modules/VisualizationEngine/src/main/java/jogamp/text/util/ShaderLoader.java
@@ -28,7 +28,7 @@
 
 package jogamp.text.util;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import com.jogamp.opengl.GLException;
 import com.jogamp.opengl.util.glsl.ShaderUtil;
 
@@ -66,8 +66,8 @@ public final class ShaderLoader {
      * @param shader OpenGL handle to a shader
      * @return True if shader was compiled without errors
      */
-    private static boolean isShaderCompiled(/*@Nonnull*/ final GL2ES2 gl, final int shader) {
-        return ShaderUtil.isShaderStatusValid(gl, shader, GL2ES2.GL_COMPILE_STATUS, null);
+    private static boolean isShaderCompiled(/*@Nonnull*/ final GL3ES3 gl, final int shader) {
+        return ShaderUtil.isShaderStatusValid(gl, shader, GL3ES3.GL_COMPILE_STATUS, null);
     }
 
     /**
@@ -77,8 +77,8 @@ public final class ShaderLoader {
      * @param program OpenGL handle to a shader program
      * @return True if program was linked successfully
      */
-    private static boolean isProgramLinked(/*@Nonnull*/ final GL2ES2 gl, final int program) {
-        return ShaderUtil.isProgramStatusValid(gl, program, GL2ES2.GL_LINK_STATUS);
+    private static boolean isProgramLinked(/*@Nonnull*/ final GL3ES3 gl, final int program) {
+        return ShaderUtil.isProgramStatusValid(gl, program, GL3ES3.GL_LINK_STATUS);
     }
 
     /**
@@ -93,7 +93,7 @@ public final class ShaderLoader {
      * @throws GLException              if program did not compile or link successfully
      */
     /*@Nonnegative*/
-    public static int loadProgram(/*@Nonnull*/ final GL2ES2 gl,
+    public static int loadProgram(/*@Nonnull*/ final GL3ES3 gl,
         /*@Nonnull*/ final String vss,
         /*@Nonnull*/ final String fss) {
 
@@ -104,8 +104,8 @@ public final class ShaderLoader {
         Check.argument(!fss.isEmpty(), "Fragment shader source cannot be empty");
 
         // Create the shaders
-        final int vs = loadShader(gl, vss, GL2ES2.GL_VERTEX_SHADER);
-        final int fs = loadShader(gl, fss, GL2ES2.GL_FRAGMENT_SHADER);
+        final int vs = loadShader(gl, vss, GL3ES3.GL_VERTEX_SHADER);
+        final int fs = loadShader(gl, fss, GL3ES3.GL_FRAGMENT_SHADER);
 
         // Create a program and attach the shaders
         final int program = gl.glCreateProgram();
@@ -140,7 +140,7 @@ public final class ShaderLoader {
      * @throws GLException if a GLSL-capable context is not active or could not compile shader
      */
     /*@Nonnegative*/
-    private static int loadShader(/*@Nonnull*/ final GL2ES2 gl,
+    private static int loadShader(/*@Nonnull*/ final GL3ES3 gl,
         /*@Nonnull*/ final String source,
                                                final int type) {
 

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/availability/ArrayDraw.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/availability/ArrayDraw.java
@@ -18,7 +18,7 @@ public class ArrayDraw {
             return false;
         }
 
-        return drawable.getGLProfile().isGL2ES2();
+        return drawable.getGLProfile().isGL3ES3();
     }
 
 }

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/availability/InstancedDraw.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/availability/InstancedDraw.java
@@ -20,7 +20,7 @@ public class InstancedDraw {
             return false;
         }
 
-        return drawable.getGLProfile().isGL2ES3()
+        return drawable.getGLProfile().isGL3ES3()
             && engine.getOpenGLOptions().isInstancingSupported();
     }
 }

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgecircle/EdgeCircleSelfLoopNoSelection.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgecircle/EdgeCircleSelfLoopNoSelection.java
@@ -17,7 +17,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PRO
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -31,7 +31,7 @@ public class EdgeCircleSelfLoopNoSelection {
     private static final String SHADERS_NODE_CIRCLE_SOURCE_VS = "selfloop";
     private static final String SHADERS_NODE_CIRCLE_SOURCE_FS = "selfloop";
 
-    public void initGLProgram(GL2ES2 gl) {
+    public void initGLProgram(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_NODE_CIRCLE_SOURCE_VS, SHADERS_NODE_CIRCLE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
             .addUniformName(UNIFORM_NAME_EDGE_SCALE_MIN)
@@ -47,7 +47,7 @@ public class EdgeCircleSelfLoopNoSelection {
             .init(gl);
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float edgeScale, float minWeight, float maxWeight,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float edgeScale, float minWeight, float maxWeight,
                            float edgeRescaleMin, float edgeRescaleMax, float nodeScale) {
         program.use(gl);
 
@@ -67,7 +67,7 @@ public class EdgeCircleSelfLoopNoSelection {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgecircle/EdgeCircleSelfLoopSelectionSelected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgecircle/EdgeCircleSelfLoopSelectionSelected.java
@@ -21,7 +21,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -34,7 +34,7 @@ public class EdgeCircleSelfLoopSelectionSelected {
     private static final String SHADERS_NODE_CIRCLE_SOURCE_VS = "selfloop_selected";
     private static final String SHADERS_NODE_CIRCLE_SOURCE_FS = "selfloop_selected";
 
-    public void initGLProgram(GL2ES2 gl) {
+    public void initGLProgram(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_NODE_CIRCLE_SOURCE_VS, SHADERS_NODE_CIRCLE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
             .addUniformName(UNIFORM_NAME_BACKGROUND_COLOR)
@@ -54,7 +54,7 @@ public class EdgeCircleSelfLoopSelectionSelected {
             .init(gl);
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float[] backgroundColorFloats, float colorLightenFactor,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float[] backgroundColorFloats, float colorLightenFactor,
                            float globalTime, float selectionTime, float edgeScale, float minWeight, float maxWeight,
                            float edgeRescaleMin, float edgeRescaleMax, float nodeScale) {
         program.use(gl);
@@ -79,7 +79,7 @@ public class EdgeCircleSelfLoopSelectionSelected {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgecircle/EdgeCircleSelfLoopSelectionUnselected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgecircle/EdgeCircleSelfLoopSelectionUnselected.java
@@ -21,7 +21,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -33,7 +33,7 @@ public class EdgeCircleSelfLoopSelectionUnselected {
     private static final String SHADERS_NODE_CIRCLE_SOURCE_VS = "selfloop_unselected";
     private static final String SHADERS_NODE_CIRCLE_SOURCE_FS = "selfloop_unselected";
 
-    public void initGLProgram(GL2ES2 gl) {
+    public void initGLProgram(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_NODE_CIRCLE_SOURCE_VS, SHADERS_NODE_CIRCLE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_BACKGROUND_COLOR)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
@@ -53,7 +53,7 @@ public class EdgeCircleSelfLoopSelectionUnselected {
             .init(gl);
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float[] backgroundColorFloats, float colorLightenFactor,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float[] backgroundColorFloats, float colorLightenFactor,
                            float globalTime, float selectionTime, float edgeScale, float minWeight, float maxWeight,
                            float edgeRescaleMin, float edgeRescaleMax, float nodeScale) {
         program.use(gl);
@@ -77,7 +77,7 @@ public class EdgeCircleSelfLoopSelectionUnselected {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/directed/EdgeLineDirectedModelNoSelection.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/directed/EdgeLineDirectedModelNoSelection.java
@@ -23,7 +23,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PRO
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -47,7 +47,7 @@ public class EdgeLineDirectedModelNoSelection {
     private static final String SHADERS_EDGE_LINE_SOURCE_FS = "edge-line-directed";
 
 
-    public void initProgram(GL2ES2 gl) {
+    public void initProgram(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_EDGE_LINE_SOURCE_VS, SHADERS_EDGE_LINE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
             .addUniformName(UNIFORM_NAME_EDGE_SCALE_MIN)
@@ -68,7 +68,7 @@ public class EdgeLineDirectedModelNoSelection {
     }
 
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float edgeScale, float minWeight, float maxWeight,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float edgeScale, float minWeight, float maxWeight,
                            float edgeRescaleMin, float edgeRescaleMax, float nodeScale, float edgeInset) {
         program.use(gl);
         prepareProgramData(gl, mvpFloats, edgeScale, minWeight, maxWeight, nodeScale, edgeRescaleMin, edgeRescaleMax,
@@ -76,7 +76,7 @@ public class EdgeLineDirectedModelNoSelection {
     }
 
 
-    private void prepareProgramData(GL2ES2 gl, float[] mvpFloats, float scale, float minWeight, float maxWeight,
+    private void prepareProgramData(GL3ES3 gl, float[] mvpFloats, float scale, float minWeight, float maxWeight,
                                     float nodeScale, float edgeRescaleMin, float edgeRescaleMax, float edgeInset) {
         gl.glUniformMatrix4fv(program.getUniformLocation(UNIFORM_NAME_MODEL_VIEW_PROJECTION), 1, false, mvpFloats, 0);
         gl.glUniform1f(program.getUniformLocation(UNIFORM_NAME_NODE_SCALE), nodeScale);
@@ -96,7 +96,7 @@ public class EdgeLineDirectedModelNoSelection {
     }
 
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/directed/EdgeLineDirectedModelSelectionSelected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/directed/EdgeLineDirectedModelSelectionSelected.java
@@ -25,7 +25,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -51,7 +51,7 @@ public class EdgeLineDirectedModelSelectionSelected {
     private static final String SHADERS_EDGE_LINE_SOURCE_FS = "edge-line-directed";
 
 
-    public void initProgram(GL2ES2 gl) {
+    public void initProgram(GL3ES3 gl) {
         program =
             new GLShaderProgram(SHADERS_ROOT, SHADERS_EDGE_LINE_SOURCE_VS,
                 SHADERS_EDGE_LINE_SOURCE_FS)
@@ -76,7 +76,7 @@ public class EdgeLineDirectedModelSelectionSelected {
     }
 
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float edgeScale, float minWeight,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float edgeScale, float minWeight,
                            float maxWeight, float edgeResclaleMin, float edgeRescaleMax,
                            float nodeScale, float edgeInset, float globalTime,
                            float selectionTime) {
@@ -87,7 +87,7 @@ public class EdgeLineDirectedModelSelectionSelected {
     }
 
 
-    private void prepareProgramData(GL2ES2 gl, float[] mvpFloats, float scale, float minWeight,
+    private void prepareProgramData(GL3ES3 gl, float[] mvpFloats, float scale, float minWeight,
                                     float maxWeight, float nodeScale, float edgeRescaleMin,
                                     float edgeRescaleMax, float edgeInset,
                                     float globalTime, float selectionTime) {
@@ -115,7 +115,7 @@ public class EdgeLineDirectedModelSelectionSelected {
     }
 
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/directed/EdgeLineDirectedModelSelectionUnselected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/directed/EdgeLineDirectedModelSelectionUnselected.java
@@ -27,7 +27,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -50,7 +50,7 @@ public class EdgeLineDirectedModelSelectionUnselected {
     private static final String SHADERS_EDGE_LINE_SOURCE_VS = "edge-line-directed_with_selection_unselected";
     private static final String SHADERS_EDGE_LINE_SOURCE_FS = "edge-line-directed";
 
-    public void initProgram(GL2ES2 gl) {
+    public void initProgram(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_EDGE_LINE_SOURCE_VS,
             SHADERS_EDGE_LINE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
@@ -75,7 +75,7 @@ public class EdgeLineDirectedModelSelectionUnselected {
     }
 
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float edgeScale, float minWeight,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float edgeScale, float minWeight,
                            float maxWeight, float edgeRescaleMin, float edgeRescaleMax,
                            float[] backgroundColorFloats,
                            float colorLightenFactor, float nodeScale, float edgeInset,
@@ -86,7 +86,7 @@ public class EdgeLineDirectedModelSelectionUnselected {
             colorLightenFactor, nodeScale, edgeInset, globalTime, selectionTime);
     }
 
-    private void prepareProgramData(GL2ES2 gl, float[] mvpFloats, float scale, float minWeight,
+    private void prepareProgramData(GL3ES3 gl, float[] mvpFloats, float scale, float minWeight,
                                     float maxWeight, float edgeRescaleMin, float edgeRescaleMax,
                                     float[] backgroundColorFloats,
                                     float colorLightenFactor, float nodeScale, float edgeInset,
@@ -119,7 +119,7 @@ public class EdgeLineDirectedModelSelectionUnselected {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/undirected/EdgeLineUndirectedModelNoSelection.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/undirected/EdgeLineUndirectedModelNoSelection.java
@@ -22,7 +22,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PRO
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -45,7 +45,7 @@ public class EdgeLineUndirectedModelNoSelection {
     private static final String SHADERS_EDGE_LINE_SOURCE_VS = "edge-line-undirected";
     private static final String SHADERS_EDGE_LINE_SOURCE_FS = "edge-line-undirected";
 
-    public void initProgram(GL2ES2 gl) {
+    public void initProgram(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_EDGE_LINE_SOURCE_VS, SHADERS_EDGE_LINE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
             .addUniformName(UNIFORM_NAME_EDGE_SCALE_MIN)
@@ -64,7 +64,7 @@ public class EdgeLineUndirectedModelNoSelection {
 
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float edgeScale, float minWeight, float maxWeight,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float edgeScale, float minWeight, float maxWeight,
                            float edgeRescaleMin, float edgeRescaleMax, float nodeScale) {
         //Line:
         program.use(gl);
@@ -72,7 +72,7 @@ public class EdgeLineUndirectedModelNoSelection {
     }
 
 
-    private void prepareProgramData(GL2ES2 gl, float[] mvpFloats, float scale, float minWeight, float maxWeight,
+    private void prepareProgramData(GL3ES3 gl, float[] mvpFloats, float scale, float minWeight, float maxWeight,
                                     float nodeScale, float edgeRescaleMin, float edgeRescaleMax) {
         gl.glUniformMatrix4fv(program.getUniformLocation(UNIFORM_NAME_MODEL_VIEW_PROJECTION), 1, false, mvpFloats, 0);
         gl.glUniform1f(program.getUniformLocation(UNIFORM_NAME_NODE_SCALE), nodeScale);
@@ -90,7 +90,7 @@ public class EdgeLineUndirectedModelNoSelection {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/undirected/EdgeLineUndirectedModelSelectionSelected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/undirected/EdgeLineUndirectedModelSelectionSelected.java
@@ -24,7 +24,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -48,7 +48,7 @@ public class EdgeLineUndirectedModelSelectionSelected {
     private static final String SHADERS_EDGE_LINE_SOURCE_FS = "edge-line-undirected";
 
 
-    public void initProgram(GL2ES2 gl) {
+    public void initProgram(GL3ES3 gl) {
         program =
             new GLShaderProgram(SHADERS_ROOT, SHADERS_EDGE_LINE_SOURCE_VS,
                 SHADERS_EDGE_LINE_SOURCE_FS)
@@ -70,7 +70,7 @@ public class EdgeLineUndirectedModelSelectionSelected {
                 .init(gl);
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float edgeScale, float minWeight,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float edgeScale, float minWeight,
                            float maxWeight, float edgeRescaleMin, float edgeRescaleMax,
                            float nodeScale, float globalTime,
                            float selectionTime) {
@@ -81,7 +81,7 @@ public class EdgeLineUndirectedModelSelectionSelected {
     }
 
 
-    private void prepareProgramData(GL2ES2 gl, float[] mvpFloats, float scale, float minWeight,
+    private void prepareProgramData(GL3ES3 gl, float[] mvpFloats, float scale, float minWeight,
                                     float maxWeight, float edgeRescaleMin, float edgeRescaleMax,
                                     float nodeScale,
                                     float globalTime, float selectionTime) {
@@ -107,7 +107,7 @@ public class EdgeLineUndirectedModelSelectionSelected {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/undirected/EdgeLineUndirectedModelSelectionUnselected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/edgeline/undirected/EdgeLineUndirectedModelSelectionUnselected.java
@@ -26,7 +26,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_NODE_SCALE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_WEIGHT_DIFFERENCE_DIVISOR;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.NumberUtils;
 import org.gephi.viz.engine.util.gl.Constants;
@@ -48,7 +48,7 @@ public class EdgeLineUndirectedModelSelectionUnselected {
     private static final String SHADERS_EDGE_LINE_SOURCE_VS = "edge-line-undirected_with_selection_unselected";
     private static final String SHADERS_EDGE_LINE_SOURCE_FS = "edge-line-undirected";
 
-    public void initProgram(GL2ES2 gl) {
+    public void initProgram(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_EDGE_LINE_SOURCE_VS,
             SHADERS_EDGE_LINE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
@@ -71,7 +71,7 @@ public class EdgeLineUndirectedModelSelectionUnselected {
             .init(gl);
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float edgeScale, float minWeight,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float edgeScale, float minWeight,
                            float maxWeight, float edgeRescaleMin, float edgeRescaleMax,
                            float[] backgroundColorFloats,
                            float colorLightenFactor, float nodeScale, float globalTime,
@@ -82,7 +82,7 @@ public class EdgeLineUndirectedModelSelectionUnselected {
             colorLightenFactor, nodeScale, globalTime, selectionTime);
     }
 
-    private void prepareProgramData(GL2ES2 gl, float[] mvpFloats, float scale, float minWeight,
+    private void prepareProgramData(GL3ES3 gl, float[] mvpFloats, float scale, float minWeight,
                                     float maxWeight, float edgeRescaleMin, float edgeRescaleMax,
                                     float[] backgroundColorFloats,
                                     float colorLightenFactor, float nodeScale, float globalTime,
@@ -114,7 +114,7 @@ public class EdgeLineUndirectedModelSelectionUnselected {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/nodedisk/NodeDiskModelNoSelection.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/nodedisk/NodeDiskModelNoSelection.java
@@ -12,7 +12,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_BORDER_SIZE;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_DARKEN_FACTOR;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PROJECTION;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.gl.Constants;
 
@@ -27,7 +27,7 @@ public class NodeDiskModelNoSelection {
     private static final String SHADERS_NODE_CIRCLE_SOURCE_VS = "node";
     private static final String SHADERS_NODE_CIRCLE_SOURCE_FS = "node";
 
-    public void initGLPrograms(GL2ES2 gl) {
+    public void initGLPrograms(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_NODE_CIRCLE_SOURCE_VS, SHADERS_NODE_CIRCLE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
             .addUniformName(UNIFORM_NAME_BORDER_SIZE)
@@ -39,7 +39,7 @@ public class NodeDiskModelNoSelection {
             .init(gl);
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats, float nodeBorderColorFactor) {
+    public void useProgram(GL3ES3 gl, float[] mvpFloats, float nodeBorderColorFactor) {
         //Circle:
         program.use(gl);
         gl.glUniformMatrix4fv(program.getUniformLocation(UNIFORM_NAME_MODEL_VIEW_PROJECTION), 1, false, mvpFloats, 0);
@@ -49,7 +49,7 @@ public class NodeDiskModelNoSelection {
             nodeBorderColorFactor);
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/nodedisk/NodeDiskModelSelectionSelected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/nodedisk/NodeDiskModelSelectionSelected.java
@@ -14,7 +14,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_GLOBAL_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PROJECTION;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.gl.Constants;
 
@@ -30,7 +30,7 @@ public class NodeDiskModelSelectionSelected {
     private static final String SHADERS_NODE_CIRCLE_SOURCE_VS = "node_with_selection_selected";
     private static final String SHADERS_NODE_CIRCLE_SOURCE_FS = "node";
 
-    public void initGLPrograms(GL2ES2 gl) {
+    public void initGLPrograms(GL3ES3 gl) {
         program =
             new GLShaderProgram(SHADERS_ROOT, SHADERS_NODE_CIRCLE_SOURCE_VS,
                 SHADERS_NODE_CIRCLE_SOURCE_FS)
@@ -48,7 +48,7 @@ public class NodeDiskModelSelectionSelected {
 
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats,
                            float globalTime, float selectedTime, float nodeBorderColorFactor) {
         //Circle:
         program.use(gl);
@@ -66,7 +66,7 @@ public class NodeDiskModelSelectionSelected {
     }
 
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/nodedisk/NodeDiskModelSelectionUnselected.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/models/nodedisk/NodeDiskModelSelectionUnselected.java
@@ -16,7 +16,7 @@ import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_GLOBAL_TIME;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PROJECTION;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_SELECTION_TIME;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import org.gephi.viz.engine.jogl.util.gl.GLShaderProgram;
 import org.gephi.viz.engine.util.gl.Constants;
 
@@ -32,7 +32,7 @@ public class NodeDiskModelSelectionUnselected {
     private static final String SHADERS_NODE_CIRCLE_SOURCE_VS = "node_with_selection_unselected";
     private static final String SHADERS_NODE_CIRCLE_SOURCE_FS = "node_with_selection_unselected";
 
-    public void initGLPrograms(GL2ES2 gl) {
+    public void initGLPrograms(GL3ES3 gl) {
         program = new GLShaderProgram(SHADERS_ROOT, SHADERS_NODE_CIRCLE_SOURCE_VS,
             SHADERS_NODE_CIRCLE_SOURCE_FS)
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
@@ -49,7 +49,7 @@ public class NodeDiskModelSelectionUnselected {
             .init(gl);
     }
 
-    public void useProgram(GL2ES2 gl, float[] mvpFloats,
+    public void useProgram(GL3ES3 gl, float[] mvpFloats,
                            float[] backgroundColorFloats, float colorLightenFactor,
                            float globalTime, float selectedTime, float nodeBorderColorFactor) {
         //Circle:
@@ -73,7 +73,7 @@ public class NodeDiskModelSelectionUnselected {
     }
 
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (program != null) {
             program.destroy(gl);
             program = null;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/ArrayDrawEdgeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/ArrayDrawEdgeData.java
@@ -4,7 +4,7 @@ import static com.jogamp.opengl.GL.GL_FLOAT;
 import static org.gephi.viz.engine.pipeline.RenderingLayer.BACK1;
 
 import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import com.jogamp.opengl.util.GLBuffers;
 import java.nio.FloatBuffer;
 import org.gephi.graph.api.Edge;
@@ -48,7 +48,7 @@ public class ArrayDrawEdgeData extends AbstractEdgeData {
         super(edgesCallback, nodesCallback, false, false);
     }
 
-    public void drawArrays(GL2ES2 gl, RenderingLayer layer, EdgeWorldData data, float[] mvpFloats) {
+    public void drawArrays(GL3ES3 gl, RenderingLayer layer, EdgeWorldData data, float[] mvpFloats) {
         refreshTime();
         if (edgesCallback.hasSelfLoop()) {
             drawSelfLoop(gl, data, layer, mvpFloats);
@@ -58,7 +58,7 @@ public class ArrayDrawEdgeData extends AbstractEdgeData {
 
     }
 
-    private void drawSelfLoop(GL2ES2 gl, EdgeWorldData data,
+    private void drawSelfLoop(GL3ES3 gl, EdgeWorldData data,
                               RenderingLayer layer, float[] mvpFloats) {
         final int instanceCount = setupShaderProgramForRenderingLayerSelfLoop(gl, layer, data, mvpFloats);
 
@@ -106,7 +106,7 @@ public class ArrayDrawEdgeData extends AbstractEdgeData {
         unsetupSelfLoopVertexArrayAttributes(gl);
     }
 
-    private void drawUndirected(GL2ES2 gl, EdgeWorldData data,
+    private void drawUndirected(GL3ES3 gl, EdgeWorldData data,
                                 RenderingLayer layer, float[] mvpFloats) {
         final int instanceCount = setupShaderProgramForRenderingLayerUndirected(gl, layer, data, mvpFloats);
 
@@ -153,7 +153,7 @@ public class ArrayDrawEdgeData extends AbstractEdgeData {
         unsetupUndirectedVertexArrayAttributes(gl);
     }
 
-    private void drawDirected(GL2ES2 gl, EdgeWorldData data,
+    private void drawDirected(GL3ES3 gl, EdgeWorldData data,
                               RenderingLayer layer, float[] mvpFloats) {
         final int instanceCount = setupShaderProgramForRenderingLayerDirected(gl, layer, data, mvpFloats);
 

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/ArrayDrawNodeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/ArrayDrawNodeData.java
@@ -5,7 +5,7 @@ import static org.gephi.viz.engine.util.gl.Constants.SHADER_POSITION_LOCATION;
 import static org.gephi.viz.engine.util.gl.Constants.SHADER_SIZE_LOCATION;
 
 import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import java.nio.FloatBuffer;
 import org.gephi.viz.engine.jogl.pipeline.common.AbstractNodeData;
 import org.gephi.viz.engine.jogl.pipeline.common.NodeWorldData;
@@ -27,14 +27,14 @@ public class ArrayDrawNodeData extends AbstractNodeData {
         super(nodesCallback, false, false);
     }
 
-    public void drawArrays(GL2ES2 gl, RenderingLayer layer, NodeWorldData data,
+    public void drawArrays(GL3ES3 gl, RenderingLayer layer, NodeWorldData data,
                            float[] mvpFloats) {
         refreshTime();
 
         drawArraysInternal(gl, layer, data, mvpFloats);
     }
 
-    public void drawArraysInternal(final GL2ES2 gl,
+    public void drawArraysInternal(final GL3ES3 gl,
                                    final RenderingLayer layer,
                                    final NodeWorldData data,
                                    final float[] mvpFloats) {

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/EdgeRendererArrayDraw.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/EdgeRendererArrayDraw.java
@@ -37,7 +37,7 @@ public class EdgeRendererArrayDraw extends AbstractEdgeRenderer {
 
     @Override
     public void render(EdgeWorldData data, JOGLRenderingTarget target, RenderingLayer layer, float[] mvpFloats) {
-        edgeData.drawArrays(target.getDrawable().getGL().getGL2ES2(), layer, data, mvpFloats);
+        edgeData.drawArrays(target.getDrawable().getGL().getGL3ES3(), layer, data, mvpFloats);
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/NodeRendererArrayDraw.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/NodeRendererArrayDraw.java
@@ -38,7 +38,7 @@ public class NodeRendererArrayDraw extends AbstractNodeRenderer {
     @Override
     public void render(NodeWorldData data, JOGLRenderingTarget target, RenderingLayer layer, float[] mvpFloats) {
 
-        nodeData.drawArrays(target.getDrawable().getGL().getGL2ES2(), layer, data, mvpFloats);
+        nodeData.drawArrays(target.getDrawable().getGL().getGL3ES3(), layer, data, mvpFloats);
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/RectangleSelectionArrayDraw.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/RectangleSelectionArrayDraw.java
@@ -12,7 +12,7 @@ import static org.gephi.viz.engine.util.gl.Constants.SHADER_VERT_LOCATION;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PROJECTION;
 
 import com.jogamp.newt.event.NEWTEvent;
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import java.nio.FloatBuffer;
 import java.util.EnumSet;
 import org.gephi.viz.engine.VizEngine;
@@ -65,7 +65,7 @@ public class RectangleSelectionArrayDraw implements Renderer<JOGLRenderingTarget
 
     @Override
     public void init(JOGLRenderingTarget target) {
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         shaderProgram = new GLShaderProgram(SHADERS_ROOT, "rectangleSelection", "rectangleSelection")
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
@@ -90,7 +90,7 @@ public class RectangleSelectionArrayDraw implements Renderer<JOGLRenderingTarget
 
     @Override
     public void dispose(JOGLRenderingTarget target) {
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         if (shaderProgram != null) {
             shaderProgram.destroy(gl);
@@ -122,7 +122,7 @@ public class RectangleSelectionArrayDraw implements Renderer<JOGLRenderingTarget
 
     @Override
     public VoidWorldData worldUpdated(VizEngineModel model, JOGLRenderingTarget target, float[] mvpFloats) {
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         final GraphSelection graphSelection = model.getGraphSelection();
         backgroundIsDark = model.getRenderingOptions().isBackgroundColorDark();
@@ -187,7 +187,7 @@ public class RectangleSelectionArrayDraw implements Renderer<JOGLRenderingTarget
 
     @Override
     public void render(VoidWorldData data, JOGLRenderingTarget target, RenderingLayer layer, float[] mvpFloats) {
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         if (render) {
             shaderProgram.use(gl);
@@ -239,7 +239,7 @@ public class RectangleSelectionArrayDraw implements Renderer<JOGLRenderingTarget
         }
 
         @Override
-        protected void configure(GL2ES2 gl) {
+        protected void configure(GL3ES3 gl) {
             vertexGLBuffer.bind(gl);
             {
                 gl.glVertexAttribPointer(SHADER_VERT_LOCATION, VERTEX_FLOATS, GL_FLOAT, false, 0, 0);

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/SimpleMouseSelectionArrayDraw.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/renderers/SimpleMouseSelectionArrayDraw.java
@@ -13,7 +13,7 @@ import static org.gephi.viz.engine.util.gl.Constants.SHADER_VERT_LOCATION;
 import static org.gephi.viz.engine.util.gl.Constants.UNIFORM_NAME_MODEL_VIEW_PROJECTION;
 
 import com.jogamp.newt.event.NEWTEvent;
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import java.nio.FloatBuffer;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -69,7 +69,7 @@ public class SimpleMouseSelectionArrayDraw implements Renderer<JOGLRenderingTarg
 
     @Override
     public VoidWorldData worldUpdated(VizEngineModel model, JOGLRenderingTarget target, float[] mvpFloats) {
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         final GraphSelection graphSelection = model.getGraphSelection();
         backgroundIsDark = model.getRenderingOptions().isBackgroundColorDark();
@@ -121,7 +121,7 @@ public class SimpleMouseSelectionArrayDraw implements Renderer<JOGLRenderingTarg
     @Override
     public void render(VoidWorldData data, JOGLRenderingTarget target, RenderingLayer layer, float[] mvpFloats) {
 
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         if (render) {
             shaderProgram.use(gl);
@@ -184,7 +184,7 @@ public class SimpleMouseSelectionArrayDraw implements Renderer<JOGLRenderingTarg
 
     @Override
     public void init(JOGLRenderingTarget target) {
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         shaderProgram = new GLShaderProgram(SHADERS_ROOT, "simpleMouseSelection", "simpleMouseSelection")
             .addUniformName(UNIFORM_NAME_MODEL_VIEW_PROJECTION)
@@ -208,7 +208,7 @@ public class SimpleMouseSelectionArrayDraw implements Renderer<JOGLRenderingTarg
 
     @Override
     public void dispose(JOGLRenderingTarget target) {
-        final GL2ES2 gl = target.getDrawable().getGL().getGL2ES2();
+        final GL3ES3 gl = target.getDrawable().getGL().getGL3ES3();
 
         if (shaderProgram != null) {
             shaderProgram.destroy(gl);
@@ -243,7 +243,7 @@ public class SimpleMouseSelectionArrayDraw implements Renderer<JOGLRenderingTarg
         }
 
         @Override
-        protected void configure(GL2ES2 gl) {
+        protected void configure(GL3ES3 gl) {
             vertexGLBuffer.bind(gl);
             {
                 gl.glVertexAttribPointer(SHADER_VERT_LOCATION, VERTEX_FLOATS, GL_FLOAT, false, 0, 0);

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/updaters/EdgesUpdaterArrayDrawRendering.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/updaters/EdgesUpdaterArrayDrawRendering.java
@@ -26,12 +26,12 @@ public class EdgesUpdaterArrayDrawRendering implements WorldUpdater<JOGLRenderin
 
     @Override
     public void init(JOGLRenderingTarget target) {
-        edgeData.init(target.getDrawable().getGL().getGL2ES2());
+        edgeData.init(target.getDrawable().getGL().getGL3ES3());
     }
 
     @Override
     public void dispose(JOGLRenderingTarget target) {
-        edgeData.dispose(target.getDrawable().getGL().getGL2ES2());
+        edgeData.dispose(target.getDrawable().getGL().getGL3ES3());
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/updaters/NodesUpdaterArrayDrawRendering.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/arrays/updaters/NodesUpdaterArrayDrawRendering.java
@@ -26,12 +26,12 @@ public class NodesUpdaterArrayDrawRendering implements WorldUpdater<JOGLRenderin
 
     @Override
     public void init(JOGLRenderingTarget target) {
-        nodeData.init(target.getDrawable().getGL().getGL2ES2());
+        nodeData.init(target.getDrawable().getGL().getGL3ES3());
     }
 
     @Override
     public void dispose(JOGLRenderingTarget target) {
-        nodeData.dispose(target.getDrawable().getGL().getGL2ES2());
+        nodeData.dispose(target.getDrawable().getGL().getGL3ES3());
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractEdgeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractEdgeData.java
@@ -13,7 +13,7 @@ import static org.gephi.viz.engine.util.gl.Constants.SHADER_VERT_LOCATION;
 
 import com.jogamp.newt.event.NEWTEvent;
 import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import java.nio.FloatBuffer;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Node;
@@ -138,7 +138,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         this.usesSecondaryBuffer = usesSecondaryBuffer;
     }
 
-    public void init(GL2ES2 gl) {
+    public void init(GL3ES3 gl) {
         edgeCircleSelfLoopNoSelection.initGLProgram(gl);
         edgeCircleSelfLoopSelectionUnselected.initGLProgram(gl);
         edgeCircleSelfLoopSelectionSelected.initGLProgram(gl);
@@ -164,7 +164,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
     }
 
     protected int setupShaderProgramForRenderingLayerSelfLoop(
-        final GL2ES2 gl,
+        final GL3ES3 gl,
         final RenderingLayer layer,
         final EdgeWorldData data,
         final float[] mvpFloats
@@ -256,7 +256,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         return instanceCount;
     }
 
-    protected int setupShaderProgramForRenderingLayerUndirected(final GL2ES2 gl,
+    protected int setupShaderProgramForRenderingLayerUndirected(final GL3ES3 gl,
                                                                 final RenderingLayer layer,
                                                                 final EdgeWorldData data,
                                                                 final float[] mvpFloats) {
@@ -357,7 +357,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         return instanceCount;
     }
 
-    protected int setupShaderProgramForRenderingLayerDirected(final GL2ES2 gl,
+    protected int setupShaderProgramForRenderingLayerDirected(final GL3ES3 gl,
                                                               final RenderingLayer layer,
                                                               final EdgeWorldData data,
                                                               final float[] mvpFloats) {
@@ -1236,7 +1236,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
     private SelfLoopEdgesVAO selfLoopEdgesVAO;
     private SelfLoopEdgesVAO selfLoopEdgesVAOSecondary;
 
-    public void setupSelfLoopVertexArrayAttributes(GL2ES2 gl, EdgeWorldData data) {
+    public void setupSelfLoopVertexArrayAttributes(GL3ES3 gl, EdgeWorldData data) {
         if (selfLoopEdgesVAO == null) {
             selfLoopEdgesVAO = new SelfLoopEdgesVAO(
                 data.getOpenGLOptions(),
@@ -1247,7 +1247,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         selfLoopEdgesVAO.use(gl);
     }
 
-    public void setupSelfLoopVertexArrayAttributesSecondary(GL2ES2 gl, EdgeWorldData data) {
+    public void setupSelfLoopVertexArrayAttributesSecondary(GL3ES3 gl, EdgeWorldData data) {
         if (selfLoopEdgesVAOSecondary == null) {
             selfLoopEdgesVAOSecondary = new SelfLoopEdgesVAO(
                 data.getOpenGLOptions(),
@@ -1258,7 +1258,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         selfLoopEdgesVAOSecondary.use(gl);
     }
 
-    public void setupUndirectedVertexArrayAttributes(GL2ES2 gl, EdgeWorldData data) {
+    public void setupUndirectedVertexArrayAttributes(GL3ES3 gl, EdgeWorldData data) {
         if (undirectedEdgesVAO == null) {
             undirectedEdgesVAO = new UndirectedEdgesVAO(
                 data.getOpenGLOptions(),
@@ -1269,7 +1269,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         undirectedEdgesVAO.use(gl);
     }
 
-    public void setupUndirectedVertexArrayAttributesSecondary(GL2ES2 gl,
+    public void setupUndirectedVertexArrayAttributesSecondary(GL3ES3 gl,
                                                               EdgeWorldData data) {
         if (undirectedEdgesVAOSecondary == null) {
             undirectedEdgesVAOSecondary = new UndirectedEdgesVAO(
@@ -1281,7 +1281,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         undirectedEdgesVAOSecondary.use(gl);
     }
 
-    public void unsetupSelfLoopVertexArrayAttributes(GL2ES2 gl) {
+    public void unsetupSelfLoopVertexArrayAttributes(GL3ES3 gl) {
         if (selfLoopEdgesVAO != null) {
             selfLoopEdgesVAO.stopUsing(gl);
         }
@@ -1291,7 +1291,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         }
     }
 
-    public void unsetupUndirectedVertexArrayAttributes(GL2ES2 gl) {
+    public void unsetupUndirectedVertexArrayAttributes(GL3ES3 gl) {
         if (undirectedEdgesVAO != null) {
             undirectedEdgesVAO.stopUsing(gl);
         }
@@ -1301,7 +1301,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         }
     }
 
-    public void setupDirectedVertexArrayAttributes(GL2ES2 gl, EdgeWorldData data) {
+    public void setupDirectedVertexArrayAttributes(GL3ES3 gl, EdgeWorldData data) {
         if (directedEdgesVAO == null) {
             directedEdgesVAO = new DirectedEdgesVAO(
                 data.getOpenGLOptions(),
@@ -1312,7 +1312,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         directedEdgesVAO.use(gl);
     }
 
-    public void setupDirectedVertexArrayAttributesSecondary(GL2ES2 gl,
+    public void setupDirectedVertexArrayAttributesSecondary(GL3ES3 gl,
                                                             EdgeWorldData data) {
         if (directedEdgesVAOSecondary == null) {
             directedEdgesVAOSecondary = new DirectedEdgesVAO(
@@ -1324,7 +1324,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         directedEdgesVAOSecondary.use(gl);
     }
 
-    public void unsetupDirectedVertexArrayAttributes(GL2ES2 gl) {
+    public void unsetupDirectedVertexArrayAttributes(GL3ES3 gl) {
         if (directedEdgesVAO != null) {
             directedEdgesVAO.stopUsing(gl);
         }
@@ -1392,48 +1392,48 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
 
         // Destroy and reset VAOs to prevent reuse after re-init
         if (undirectedEdgesVAO != null) {
-            undirectedEdgesVAO.destroy(gl.getGL2ES2());
+            undirectedEdgesVAO.destroy(gl.getGL3ES3());
             undirectedEdgesVAO = null;
         }
 
         if (undirectedEdgesVAOSecondary != null) {
-            undirectedEdgesVAOSecondary.destroy(gl.getGL2ES2());
+            undirectedEdgesVAOSecondary.destroy(gl.getGL3ES3());
             undirectedEdgesVAOSecondary = null;
         }
 
         if (directedEdgesVAO != null) {
-            directedEdgesVAO.destroy(gl.getGL2ES2());
+            directedEdgesVAO.destroy(gl.getGL3ES3());
             directedEdgesVAO = null;
         }
 
         if (directedEdgesVAOSecondary != null) {
-            directedEdgesVAOSecondary.destroy(gl.getGL2ES2());
+            directedEdgesVAOSecondary.destroy(gl.getGL3ES3());
             directedEdgesVAOSecondary = null;
         }
 
         if (selfLoopEdgesVAO != null) {
-            selfLoopEdgesVAO.destroy(gl.getGL2ES2());
+            selfLoopEdgesVAO.destroy(gl.getGL3ES3());
             selfLoopEdgesVAO = null;
         }
 
         if (selfLoopEdgesVAOSecondary != null) {
-            selfLoopEdgesVAOSecondary.destroy(gl.getGL2ES2());
+            selfLoopEdgesVAOSecondary.destroy(gl.getGL3ES3());
             selfLoopEdgesVAOSecondary = null;
         }
 
         // Destroy shader programs
-        lineUndirectedModelSelectionSelected.destroy(gl.getGL2ES2());
-        lineUndirectedModelSelectionUnselected.destroy(gl.getGL2ES2());
-        lineUndirectedModelNoSelection.destroy(gl.getGL2ES2());
+        lineUndirectedModelSelectionSelected.destroy(gl.getGL3ES3());
+        lineUndirectedModelSelectionUnselected.destroy(gl.getGL3ES3());
+        lineUndirectedModelNoSelection.destroy(gl.getGL3ES3());
 
-        lineDirectedModelNoSelection.destroy(gl.getGL2ES2());
-        lineDirectedModelSelectionSelected.destroy(gl.getGL2ES2());
-        lineDirectedModelSelectionUnselected.destroy(gl.getGL2ES2());
+        lineDirectedModelNoSelection.destroy(gl.getGL3ES3());
+        lineDirectedModelSelectionSelected.destroy(gl.getGL3ES3());
+        lineDirectedModelSelectionUnselected.destroy(gl.getGL3ES3());
 
 
-        edgeCircleSelfLoopNoSelection.destroy(gl.getGL2ES2());
-        edgeCircleSelfLoopSelectionSelected.destroy(gl.getGL2ES2());
-        edgeCircleSelfLoopSelectionUnselected.destroy(gl.getGL2ES2());
+        edgeCircleSelfLoopNoSelection.destroy(gl.getGL3ES3());
+        edgeCircleSelfLoopSelectionSelected.destroy(gl.getGL3ES3());
+        edgeCircleSelfLoopSelectionUnselected.destroy(gl.getGL3ES3());
 
         edgesCallback.reset();
     }
@@ -1449,7 +1449,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         }
 
         @Override
-        protected void configure(GL2ES2 gl) {
+        protected void configure(GL3ES3 gl) {
             vertexGLBufferSelfLoop.bind(gl);
             {
                 gl.glVertexAttribPointer(SHADER_VERT_LOCATION, CommonEdgeCircleSelfLoop.VERTEX_FLOATS, GL_FLOAT,
@@ -1525,7 +1525,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         }
 
         @Override
-        protected void configure(GL2ES2 gl) {
+        protected void configure(GL3ES3 gl) {
             vertexGLBufferUndirected.bind(gl);
             {
                 gl.glVertexAttribPointer(SHADER_VERT_LOCATION, CommonEdgeLineUndirected.VERTEX_FLOATS, GL_FLOAT, false,
@@ -1605,7 +1605,7 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
         }
 
         @Override
-        protected void configure(GL2ES2 gl) {
+        protected void configure(GL3ES3 gl) {
             vertexGLBufferDirected.bind(gl);
             {
 

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractNodeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractNodeData.java
@@ -13,7 +13,7 @@ import static org.gephi.viz.engine.util.gl.GLConstants.INDIRECT_DRAW_COMMAND_INT
 
 import com.jogamp.newt.event.NEWTEvent;
 import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import com.jogamp.opengl.util.GLBuffers;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -109,7 +109,7 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
         firstVertex8 = circleMesh64.vertexCount + circleMesh32.vertexCount + circleMesh16.vertexCount;
     }
 
-    public void init(GL2ES2 gl) {
+    public void init(GL3ES3 gl) {
         diskModelNoSelection.initGLPrograms(gl);
         diskModelSelectionSelected.initGLPrograms(gl);
         diskModelSelectionUnselected.initGLPrograms(gl);
@@ -153,7 +153,7 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
         vertexGLBuffer.unbind(gl);
     }
 
-    protected int setupShaderProgramForRenderingLayer(final GL2ES2 gl,
+    protected int setupShaderProgramForRenderingLayer(final GL3ES3 gl,
                                                       final RenderingLayer layer,
                                                       final NodeWorldData data,
                                                       final float[] mvpFloats) {
@@ -416,7 +416,7 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
     private NodesVAO nodesVAO;
     private NodesVAO nodesVAOSecondary;
 
-    public void setupVertexArrayAttributes(GL2ES2 gl, NodeWorldData data) {
+    public void setupVertexArrayAttributes(GL3ES3 gl, NodeWorldData data) {
         if (nodesVAO == null) {
             nodesVAO = new NodesVAO(data.getOpenGLOptions(),
                 vertexGLBuffer, attributesGLBuffer
@@ -426,7 +426,7 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
         nodesVAO.use(gl);
     }
 
-    public void setupSecondaryVertexArrayAttributes(GL2ES2 gl, NodeWorldData data) {
+    public void setupSecondaryVertexArrayAttributes(GL3ES3 gl, NodeWorldData data) {
         if (nodesVAOSecondary == null) {
             nodesVAOSecondary = new NodesVAO(data.getOpenGLOptions(),
                 vertexGLBuffer, attributesGLBufferSecondary
@@ -436,7 +436,7 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
         nodesVAOSecondary.use(gl);
     }
 
-    public void unsetupVertexArrayAttributes(GL2ES2 gl) {
+    public void unsetupVertexArrayAttributes(GL3ES3 gl) {
         if (nodesVAO != null) {
             nodesVAO.stopUsing(gl);
         }
@@ -480,19 +480,19 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
 
         // Destroy and reset VAOs to prevent reuse after re-init
         if (nodesVAO != null) {
-            nodesVAO.destroy(gl.getGL2ES2());
+            nodesVAO.destroy(gl.getGL3ES3());
             nodesVAO = null;
         }
 
         if (nodesVAOSecondary != null) {
-            nodesVAOSecondary.destroy(gl.getGL2ES2());
+            nodesVAOSecondary.destroy(gl.getGL3ES3());
             nodesVAOSecondary = null;
         }
 
         // Destroy shader programs
-        diskModelNoSelection.destroy(gl.getGL2ES2());
-        diskModelSelectionSelected.destroy(gl.getGL2ES2());
-        diskModelSelectionUnselected.destroy(gl.getGL2ES2());
+        diskModelNoSelection.destroy(gl.getGL3ES3());
+        diskModelSelectionSelected.destroy(gl.getGL3ES3());
+        diskModelSelectionUnselected.destroy(gl.getGL3ES3());
 
         nodesCallback.reset();
     }
@@ -510,7 +510,7 @@ public abstract class AbstractNodeData extends AbstractSelectionData {
         }
 
         @Override
-        protected void configure(GL2ES2 gl) {
+        protected void configure(GL3ES3 gl) {
             vertexBuffer.bind(gl);
             {
                 gl.glVertexAttribPointer(SHADER_VERT_LOCATION, CommonNodeDiskModel.VERTEX_FLOATS, GL_FLOAT, false,

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/InstancedNodeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/InstancedNodeData.java
@@ -1,7 +1,7 @@
 package org.gephi.viz.engine.jogl.pipeline.instanced;
 
 import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GL2ES3;
+import com.jogamp.opengl.GL3ES3;
 import java.nio.FloatBuffer;
 import org.gephi.viz.engine.jogl.pipeline.common.AbstractNodeData;
 import org.gephi.viz.engine.jogl.pipeline.common.NodeWorldData;
@@ -26,13 +26,13 @@ public class InstancedNodeData extends AbstractNodeData {
     private static final int ATTRIBS_BUFFER = 1;
     private static final int ATTRIBS_BUFFER_SECONDARY = 2;
 
-    public void drawInstanced(GL2ES3 gl, RenderingLayer layer, NodeWorldData data, float[] mvpFloats) {
+    public void drawInstanced(GL3ES3 gl, RenderingLayer layer, NodeWorldData data, float[] mvpFloats) {
         refreshTime();
 
         drawInstancedInternal(gl, layer, data, mvpFloats);
     }
 
-    private void drawInstancedInternal(final GL2ES3 gl,
+    private void drawInstancedInternal(final GL3ES3 gl,
                                        final RenderingLayer layer,
                                        final NodeWorldData data,
                                        final float[] mvpFloats) {

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/renderers/NodeRendererInstanced.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/renderers/NodeRendererInstanced.java
@@ -38,7 +38,7 @@ public class NodeRendererInstanced extends AbstractNodeRenderer {
     @Override
     public void render(NodeWorldData data, JOGLRenderingTarget target, RenderingLayer layer, float[] mvpFloats) {
 
-        nodeData.drawInstanced(target.getDrawable().getGL().getGL2ES3(), layer, data, mvpFloats);
+        nodeData.drawInstanced(target.getDrawable().getGL().getGL3ES3(), layer, data, mvpFloats);
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/updaters/EdgesUpdaterInstancedRendering.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/updaters/EdgesUpdaterInstancedRendering.java
@@ -26,7 +26,7 @@ public class EdgesUpdaterInstancedRendering implements WorldUpdater<JOGLRenderin
 
     @Override
     public void init(JOGLRenderingTarget target) {
-        edgeData.init(target.getDrawable().getGL().getGL2ES2());
+        edgeData.init(target.getDrawable().getGL().getGL3ES3());
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/updaters/NodesUpdaterInstancedRendering.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/instanced/updaters/NodesUpdaterInstancedRendering.java
@@ -26,7 +26,7 @@ public class NodesUpdaterInstancedRendering implements WorldUpdater<JOGLRenderin
 
     @Override
     public void init(JOGLRenderingTarget target) {
-        nodeData.init(target.getDrawable().getGL().getGL2ES2());
+        nodeData.init(target.getDrawable().getGL().getGL3ES3());
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLBufferMutable.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLBufferMutable.java
@@ -4,7 +4,6 @@ import static org.gephi.viz.engine.util.ArrayUtils.getNextPowerOf2;
 import static org.gephi.viz.engine.util.gl.Buffers.bufferElementBytes;
 
 import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GL2ES2;
 import com.jogamp.opengl.GL3ES3;
 import java.nio.Buffer;
 import java.util.logging.Level;
@@ -21,7 +20,7 @@ public class GLBufferMutable implements GLBuffer {
     public static final int GL_BUFFER_TYPE_ELEMENT_INDICES = GL.GL_ELEMENT_ARRAY_BUFFER;
     public static final int GL_BUFFER_TYPE_DRAW_INDIRECT = GL3ES3.GL_DRAW_INDIRECT_BUFFER;
     public static final int GL_BUFFER_USAGE_STATIC_DRAW = GL.GL_STATIC_DRAW;
-    public static final int GL_BUFFER_USAGE_STREAM_DRAW = GL2ES2.GL_STREAM_DRAW;
+    public static final int GL_BUFFER_USAGE_STREAM_DRAW = GL3ES3.GL_STREAM_DRAW;
     public static final int GL_BUFFER_USAGE_DYNAMIC_DRAW = GL.GL_DYNAMIC_DRAW;
 
     private final int id;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLFunctions.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLFunctions.java
@@ -3,14 +3,13 @@ package org.gephi.viz.engine.jogl.util.gl;
 import static com.jogamp.opengl.GL.GL_TRIANGLES;
 import static org.gephi.viz.engine.util.gl.GLConstants.INDIRECT_DRAW_COMMAND_BYTES;
 
-import com.jogamp.opengl.GL2ES2;
-import com.jogamp.opengl.GL2ES3;
+import com.jogamp.opengl.GL3ES3;
 import com.jogamp.opengl.GL4;
 import java.nio.IntBuffer;
 
 public class GLFunctions {
 
-    public static void glGenVertexArrays(GL2ES2 gl, int n, IntBuffer arrays) {
+    public static void glGenVertexArrays(GL3ES3 gl, int n, IntBuffer arrays) {
         if (gl.isGL2GL3()) {
             gl.getGL2GL3().glGenVertexArrays(n, arrays);
         } else {
@@ -18,7 +17,7 @@ public class GLFunctions {
         }
     }
 
-    public static void glDeleteVertexArrays(GL2ES2 gl, int n, IntBuffer arrays) {
+    public static void glDeleteVertexArrays(GL3ES3 gl, int n, IntBuffer arrays) {
         if (gl.isGL2GL3()) {
             gl.getGL2GL3().glDeleteVertexArrays(n, arrays);
         } else {
@@ -26,7 +25,7 @@ public class GLFunctions {
         }
     }
 
-    public static void glBindVertexArray(GL2ES2 gl, int array) {
+    public static void glBindVertexArray(GL3ES3 gl, int array) {
         if (gl.isGL2GL3()) {
             gl.getGL2GL3().glBindVertexArray(array);
         } else {
@@ -34,7 +33,7 @@ public class GLFunctions {
         }
     }
 
-    public static void glUnbindVertexArray(GL2ES2 gl, int defaultVAO) {
+    public static void glUnbindVertexArray(GL3ES3 gl, int defaultVAO) {
         if (gl.isGL2GL3()) {
             gl.getGL2GL3().glBindVertexArray(defaultVAO);
         } else {
@@ -42,15 +41,15 @@ public class GLFunctions {
         }
     }
 
-    public static void glVertexAttribDivisor(GL2ES2 gl, int index, int divisor) {
+    public static void glVertexAttribDivisor(GL3ES3 gl, int index, int divisor) {
         if (gl.isGL2GL3()) {
             gl.getGL2GL3().glVertexAttribDivisor(index, divisor);
-        } else if (gl.isGL2ES2()) {
+        } else if (gl.isGL3ES3()) {
             gl.getGLES2().glVertexAttribDivisor(index, divisor);
         }
     }
 
-    public static String glGetStringi(GL2ES3 gl, int name, int index) {
+    public static String glGetStringi(GL3ES3 gl, int name, int index) {
         if (gl.isGL2GL3()) {
             return gl.getGL2GL3().glGetStringi(name, index);
         } else {
@@ -58,15 +57,15 @@ public class GLFunctions {
         }
     }
 
-    public static void stopUsingProgram(GL2ES2 gl) {
+    public static void stopUsingProgram(GL3ES3 gl) {
         gl.glUseProgram(0);
     }
 
-    public static void drawArraysSingleInstance(GL2ES2 gl, int firstVertexIndex, int vertexCount) {
+    public static void drawArraysSingleInstance(GL3ES3 gl, int firstVertexIndex, int vertexCount) {
         gl.glDrawArrays(GL_TRIANGLES, firstVertexIndex, vertexCount);
     }
 
-    public static void drawInstanced(GL2ES3 gl, int vertexOffset, int vertexCount, int instanceCount) {
+    public static void drawInstanced(GL3ES3 gl, int vertexOffset, int vertexCount, int instanceCount) {
         if (instanceCount <= 0) {
             return;
         }

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLShaderProgram.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLShaderProgram.java
@@ -1,9 +1,9 @@
 package org.gephi.viz.engine.jogl.util.gl;
 
-import static com.jogamp.opengl.GL2ES2.GL_FRAGMENT_SHADER;
-import static com.jogamp.opengl.GL2ES2.GL_VERTEX_SHADER;
+import static com.jogamp.opengl.GL3ES3.GL_FRAGMENT_SHADER;
+import static com.jogamp.opengl.GL3ES3.GL_VERTEX_SHADER;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import com.jogamp.opengl.util.glsl.ShaderCode;
 import com.jogamp.opengl.util.glsl.ShaderProgram;
 import java.util.HashMap;
@@ -51,7 +51,7 @@ public class GLShaderProgram {
         return this;
     }
 
-    public GLShaderProgram init(GL2ES2 gl) {
+    public GLShaderProgram init(GL3ES3 gl) {
         if (initDone) {
             throw new IllegalStateException("Already initialized");
         }
@@ -136,7 +136,7 @@ public class GLShaderProgram {
         return loc;
     }
 
-    public void use(GL2ES2 gl) {
+    public void use(GL3ES3 gl) {
         if (!isInitialized()) {
             throw new IllegalStateException("Initialize the program first!");
         }
@@ -144,11 +144,11 @@ public class GLShaderProgram {
         gl.glUseProgram(id);
     }
 
-    public void stopUsing(GL2ES2 gl) {
+    public void stopUsing(GL3ES3 gl) {
         gl.glUseProgram(0);
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (id != -1) {
             gl.glDeleteProgram(id);
             id = -1;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLVertexArrayObject.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GLVertexArrayObject.java
@@ -1,8 +1,8 @@
 package org.gephi.viz.engine.jogl.util.gl;
 
-import static com.jogamp.opengl.GL2ES3.GL_VERTEX_ARRAY_BINDING;
+import static com.jogamp.opengl.GL3ES3.GL_VERTEX_ARRAY_BINDING;
 
-import com.jogamp.opengl.GL2ES2;
+import com.jogamp.opengl.GL3ES3;
 import com.jogamp.opengl.util.GLBuffers;
 import java.nio.IntBuffer;
 import org.gephi.viz.engine.util.gl.OpenGLOptions;
@@ -25,7 +25,7 @@ public abstract class GLVertexArrayObject {
         vaoSupported = openGLOptions.isVAOSupported();
     }
 
-    private void init(GL2ES2 gl) {
+    private void init(GL3ES3 gl) {
         attributeLocations = getUsedAttributeLocations();
         if (attributeLocations == null) {
             attributeLocations = new int[0];
@@ -58,7 +58,7 @@ public abstract class GLVertexArrayObject {
         }
     }
 
-    public void use(GL2ES2 gl) {
+    public void use(GL3ES3 gl) {
         if (attributeLocations == null) {
             init(gl);
         }
@@ -70,7 +70,7 @@ public abstract class GLVertexArrayObject {
         }
     }
 
-    public void stopUsing(GL2ES2 gl) {
+    public void stopUsing(GL3ES3 gl) {
         if (vaoSupported) {
             unbind(gl);
         } else {
@@ -78,20 +78,20 @@ public abstract class GLVertexArrayObject {
         }
     }
 
-    private void configureAll(GL2ES2 gl) {
+    private void configureAll(GL3ES3 gl) {
         configure(gl);
         configureEnabledAttributes(gl);
     }
 
-    private void bind(GL2ES2 gl) {
+    private void bind(GL3ES3 gl) {
         GLFunctions.glBindVertexArray(gl, arrayId);
     }
 
-    private void unbind(GL2ES2 gl) {
+    private void unbind(GL3ES3 gl) {
         GLFunctions.glUnbindVertexArray(gl, previousArrayId[0]);
     }
 
-    private void configureEnabledAttributes(GL2ES2 gl) {
+    private void configureEnabledAttributes(GL3ES3 gl) {
         for (int attributeLocation : attributeLocations) {
             gl.glEnableVertexAttribArray(attributeLocation);
         }
@@ -100,7 +100,7 @@ public abstract class GLVertexArrayObject {
         }
     }
 
-    private void unconfigureEnabledAttributes(GL2ES2 gl) {
+    private void unconfigureEnabledAttributes(GL3ES3 gl) {
         for (int attributeLocation : attributeLocations) {
             gl.glDisableVertexAttribArray(attributeLocation);
         }
@@ -109,7 +109,7 @@ public abstract class GLVertexArrayObject {
         }
     }
 
-    public void destroy(GL2ES2 gl) {
+    public void destroy(GL3ES3 gl) {
         if (vaoSupported && arrayId != -1) {
             IntBuffer vertexArrayName = GLBuffers.newDirectIntBuffer(1);
             vertexArrayName.put(0, arrayId);
@@ -120,7 +120,7 @@ public abstract class GLVertexArrayObject {
         instancedAttributeLocations = null;
     }
 
-    protected abstract void configure(GL2ES2 gl);
+    protected abstract void configure(GL3ES3 gl);
 
     protected abstract int[] getUsedAttributeLocations();
 

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GlDebugOutput.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/GlDebugOutput.java
@@ -1,7 +1,7 @@
 package org.gephi.viz.engine.jogl.util.gl;
 
-import static com.jogamp.opengl.GL2ES2.GL_DEBUG_SEVERITY_LOW;
-import static com.jogamp.opengl.GL2ES2.GL_DEBUG_SEVERITY_NOTIFICATION;
+import static com.jogamp.opengl.GL3ES3.GL_DEBUG_SEVERITY_LOW;
+import static com.jogamp.opengl.GL3ES3.GL_DEBUG_SEVERITY_NOTIFICATION;
 
 import com.jogamp.opengl.GLDebugListener;
 import com.jogamp.opengl.GLDebugMessage;

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/capabilities/GLCapabilitiesSummary.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/util/gl/capabilities/GLCapabilitiesSummary.java
@@ -4,11 +4,11 @@ import static com.jogamp.opengl.GL.GL_EXTENSIONS;
 import static com.jogamp.opengl.GL.GL_RENDERER;
 import static com.jogamp.opengl.GL.GL_VENDOR;
 import static com.jogamp.opengl.GL.GL_VERSION;
-import static com.jogamp.opengl.GL2ES2.GL_SHADING_LANGUAGE_VERSION;
-import static com.jogamp.opengl.GL2ES3.GL_CONTEXT_FLAGS;
-import static com.jogamp.opengl.GL2ES3.GL_MAJOR_VERSION;
-import static com.jogamp.opengl.GL2ES3.GL_MINOR_VERSION;
-import static com.jogamp.opengl.GL2ES3.GL_NUM_EXTENSIONS;
+import static com.jogamp.opengl.GL3ES3.GL_CONTEXT_FLAGS;
+import static com.jogamp.opengl.GL3ES3.GL_MAJOR_VERSION;
+import static com.jogamp.opengl.GL3ES3.GL_MINOR_VERSION;
+import static com.jogamp.opengl.GL3ES3.GL_NUM_EXTENSIONS;
+import static com.jogamp.opengl.GL3ES3.GL_SHADING_LANGUAGE_VERSION;
 
 import com.jogamp.opengl.GL;
 import com.jogamp.opengl.util.GLBuffers;
@@ -70,12 +70,12 @@ public final class GLCapabilitiesSummary {
 
         final List<String> extensionsList = new ArrayList<>();
 
-        if (gl.isGL2ES3()) {
+        if (gl.isGL3ES3()) {
             gl.glGetIntegerv(GL_NUM_EXTENSIONS, data);
             version.NUM_EXTENSIONS = data.get(0);
 
             for (int i = 0; i < version.NUM_EXTENSIONS; i++) {
-                String extension = GLFunctions.glGetStringi(gl.getGL2ES3(), GL_EXTENSIONS, i);
+                String extension = GLFunctions.glGetStringi(gl.getGL3ES3(), GL_EXTENSIONS, i);
                 extensionsList.add(extension.trim());
             }
         } else {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description
Purely JOGL matter to use mostly GL3ES3 as base interface for GL operation.
https://jogamp.org/jogl/doc/uml/html/index.html

Keep GL2ES2 on custom jogamp.text as it's just a copy paste 
Keep GL4 for indirect draw as it's only supported on GL4
<!--
Please include a summary of the code changes. Please also link the GitHub issue if it exists.
-->

## Checklist

- [ ] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed
