### PR TITLE
Add Windows and macOS to CI build matrix and fix cross-platform issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,12 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    env:
+      MAVEN_OPTS: "-Djava.awt.headless=true"
     steps:
       - uses: actions/checkout@v7
       - name: Set up JDK 17
@@ -30,4 +35,4 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build project with Maven
-        run: mvn -T 4 --batch-mode -Djava.awt.headless=true verify -P enableCheckStyle
+        run: mvn -T 4 --batch-mode verify -P enableCheckStyle


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - ISSUE (if exists) DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: #1299 Fix issue with egde weight

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation on https://github.com/gephi/gephi-documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards and style

-->

## Description
Expand the GitHub Actions CI matrix to run on Windows, macOS, and Ubuntu instead of Ubuntu alone. The project documentation states that Gephi supports Windows, macOS, and Linux. However, the current CI workflow only executes on Ubuntu, which means platform-specific issues on Windows and macOS can go undetected until users encounter them.

### Expected results
The project builds successfully on Ubuntu, Windows, and macOS using JDK 8 while preserving the original build behavior.

### Actual results
In windows, the build fails with the error : `Unknown lifecycle phase ".awt.headless=true"`. This error can be fixed by setting the  MAVEN_OPTS environment variable.

### Description of fix
- Added an OS build matrix (ubuntu-latest, windows-latest, macos-latest).
- Moved Maven build properties (-Djava.awt.headless=true) into MAVEN_OPTS to avoid platform-specific command-line parsing issues.

<!--
Please include a summary of the code changes. Please also link the GitHub issue if it exists.
-->

## Checklist

- [ ] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren’t needed
