### PR TITLE
Add ARCHITECTURE.md, CONTRIBUTING.md, and AI agent tooling setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,12 @@
+@AGENTS.md
+
+<!-- CODEGRAPH_START -->
+## CodeGraph
+
+In repositories indexed by CodeGraph (a `.codegraph/` directory exists at the repo root), reach for it BEFORE grep/find or reading files when you need to understand or locate code:
+
+- **MCP tool** (when available): `codegraph_explore` answers most code questions in one call — the relevant symbols' verbatim source plus the call paths between them, including dynamic-dispatch hops grep can't follow. Name a file or symbol in the query to read its current line-numbered source. If it's listed but deferred, load it by name via tool search.
+- **Shell** (always works): `codegraph explore "<symbol names or question>"` prints the same output.
+
+If there is no `.codegraph/` directory, skip CodeGraph entirely — indexing is the user's decision.
+<!-- CODEGRAPH_END -->

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: sentry-triage
+version: 1.0.0
+description: Triage unresolved Gephi exceptions from Sentry (org "gephi", project "gephi") into a prioritized, read-only report table. Filters out issues that cannot be fixed in Gephi's code (network/firewall/proxy blocks, OpenGL/GPU driver limits, corrupted/mounted installs, AV/cloud-sync file locking, disk full), scores the rest by user/event impact, and dispatches Sonnet sub-agents to investigate root cause and fix direction for the top-priority issues. Never edits code. Use when asked to triage, review, prioritize, or report on Sentry issues/exceptions for Gephi.
+---
+
+## Purpose
+
+Turn the raw Sentry backlog into a prioritized, actionable report so a human or a follow-up agent can decide what to fix next, without anyone having to manually reread 50+ issues first.
+
+## Hard rule — read first
+
+**This skill never modifies application code.** No `Edit`/`Write` on any file under `modules/`, `src/`, or similar. Its only job is to produce a report. Any sub-agent it spawns must be told explicitly that it is read-only and must not attempt a fix — only diagnose and suggest a direction. If the user wants a fix implemented, that is a separate, later task.
+
+The only writes this skill performs are: (a) a local report file, and (b) optionally, Sentry comments/status changes on excluded issues — and only after explicit user confirmation (see Step 3).
+
+## Inputs
+
+- Sentry org slug: `gephi`, project slug: `gephi` (confirmed via `find_organizations`/`find_projects` — don't re-discover each run).
+- Optional argument: top-N issues to send for deep investigation. Default **12**.
+- Issue window: `search_issues` with `period: "90d"` (the tool's max) and `query: "is:unresolved environment:production release:latest"`. Scope is deliberately **production + the current release only**. `release:latest` tracks whatever the current release is at run time, so it never needs hardcoding or updating as Gephi ships new versions. This excludes dev/SNAPSHOT-build noise and avoids re-triaging bugs already fixed in the current release but still open under an older version someone hasn't upgraded off of. The trade-off, worth restating in the report: a regression that only affects users still on an older release won't surface here. If that matters for a given run, rerun without the `release:latest` filter and say so explicitly in the report. State the resolved scope (e.g. "environment:production, release:latest = Gephi 0.11.2 at run time") in the report Summary so it's never ambiguous what was covered.
+
+## Step-by-step process
+
+### 1. Pull the backlog
+
+`search_issues(organizationSlug="gephi", projectSlugOrId="gephi", query="is:unresolved environment:production release:latest", period="90d", sort="freq", limit=100)`
+
+Also pull `is:ignored` and `is:resolved` (limit 25 each) just to know what's already been dispositioned — never re-analyze those.
+
+### 2. Categorize every unresolved issue
+
+Classify each issue using its title, exception type, and **culprit** (package/class/method). Classify by the **specific exception type/message**, not the culprit alone: a single generic handler method (e.g. a downloader's shared `notifyException` callback) can be the culprit for many different underlying failures with very different fixability. Two issues sharing a culprit can legitimately land in different categories/tiers if their exception types differ — a connection timeout through that handler is unfixable network noise, but an HTTP 429 rate-limit through the *same* handler is a `handling gap`, since Gephi's own retry/backoff behavior is directly implicated. If you place two same-culprit issues in different buckets, say so explicitly in the report so it doesn't look like an inconsistency; one line is enough.
+
+Two confirmed exclusion categories plus three more identified from this project's history:
+
+| Category | Signal patterns (examples, not exhaustive — use judgment) |
+|---|---|
+| **Network / firewall / proxy** | `ConnectException`, `SocketTimeoutException`, `IOException: Connection timed out`, `PacParsingException`, PKIX/certificate path errors, HTTP 4xx/429/timeout from GitHub raw/update URLs, `wpad.dat`. Culprit often in `org.netbeans.modules.autoupdate.*`, `sun.nio.ch.*`, `sun.net.www.protocol.http.*`. |
+| **OpenGL / GPU driver** | `GLException`, `glCreateProgram`/shader/context errors, `OpenGLVersionChecker`, native windowing crashes (`WindowsWindow.wndProc`, `jogamp.newt.*`). Culprit in `org.gephi.viz.engine.*` init/context code or `jogamp.*`. |
+| **Corrupted / mounted / partial install** | `FileNotFoundException` for a resource inside a `.jar` that ships with the app itself (e.g. `org-gephi-desktop-branding.jar!/...`, `org-netbeans-*.jar!/...`), especially when the path contains `/Volumes/` (running straight from a mounted macOS `.dmg` instead of installing) or an otherwise mangled install path. |
+| **AV / cloud-sync file locking** | `IOException`/`FSException` like "file already being used by another process", "could not delete temporary file", "Cannot rename file... New file exists: false", where the path is inside `OneDrive`, `Dropbox`, or similar sync roots, or generically racing against another process (antivirus scan). |
+| **Disk full** | `IOException: No space left on device` and equivalents. |
+
+Issues matching these categories are **excluded from the actionable report**: Gephi code cannot fix a user's network policy, GPU driver, broken install location, third-party file lock, or full disk.
+
+**Record a "signal" for every issue, excluded or not** — the exception type plus culprit class/method (e.g. `IOException: No space left on device — Installer$OutputHandler.publish`). Every row in every table gets this, even rows that don't get deep investigation. A bare title is not enough for anyone to act on or verify later without re-opening Sentry.
+
+**Do not silently drop anything.** Every excluded issue still gets listed in an "Excluded — not actionable" appendix with its signal, category, and one-line reason, so the exclusion logic stays auditable without needing Sentry access.
+
+**Decision rule for borderline cases** — the actual test, applied the same way every time: *could Gephi's own code plausibly add a defensive improvement (catch the exception, degrade gracefully, validate/sanitize input) around this, even though the trigger itself is external?*
+
+- If yes: keep it in the actionable report, tagged `handling gap` (not excluded), regardless of how "environmental" the trigger looks.
+- If no — there is truly nothing Gephi's code could do differently — exclude it.
+
+Apply this literally. A `PacParsingException` or an HTTP 429 from a rate limit are externally triggered, but Gephi's code could still catch them and fail quietly instead of surfacing a crash, so they belong in the actionable table as `handling gap`, not in the excluded table with a footnote. Reserve real exclusion for cases with no in-app mitigation at all: disk full, GPU below the minimum OpenGL version, a broken/mounted install, third-party file locks, no network route at all.
+
+If you encounter a new recurring pattern that clearly isn't fixable in Gephi's code and doesn't match the categories above, still include it in the actionable report but flag it clearly (e.g. `category: possibly unfixable — new pattern`) rather than silently inventing a new exclusion category. That's a judgment call for the human reviewing the report.
+
+### 3. Confirm exclusions before touching Sentry
+
+Present the exclusion list (issue ID, title, category, users/events) to the user and get explicit confirmation before writing anything to Sentry. This is shared state visible to the whole team — never skip this gate, even on repeat runs.
+
+Once confirmed, for each excluded issue:
+- Post a comment via `update_issue` (or the appropriate Sentry write tool) explaining the exclusion, e.g.: *"Triaged: not actionable in Gephi code — [category]. See `<report file>` for details. Marking as ignored."*
+- Set status to `ignored`.
+
+If the user doesn't confirm, still finish and write the report — just skip the Sentry writes and note in the report that exclusions were not applied to Sentry.
+
+### 4. Score the remaining (actionable) issues
+
+**Recency buckets** — use these three labels, not raw relative timestamps, so tier claims about recency are directly checkable in the table:
+- `Active`: last occurrence <7d ago
+- `Recent`: 7–30d
+- `Stale`: >30d
+
+**The primary axis is users affected (breadth of impact), not event count.** Event count is a secondary signal, not a tier driver: a handful of users retrying the same failing action hundreds of times ("event storm") is noted separately (`Notes: possible retry loop`), never used to bump a 1-2-user issue above a 50-user issue or vice versa. If you find yourself tiering two similar-shaped issues (e.g. both "many events, few users") several tiers apart, that's a signal event count is leaking into the decision — stop and re-apply the users-first rule.
+
+Assign a priority tier:
+
+- **P0 – Critical**: ≥50 affected users, OR a crash/data-loss on a core workflow (open/save project, import, export) regardless of user count — provided it's `Active` or `Recent`.
+- **P1 – High**: 15–49 affected users, `Active` or `Recent`.
+- **P2 – Medium**: <15 affected users but still `Active` or `Recent`; or any `handling gap` borderline issue (see Step 2) regardless of user count.
+- **P3 – Low**: `Stale` (no occurrence in 30+ days), regardless of how high the historical user/event count was — nobody is currently hitting it.
+
+**Within a tier, sort by users affected descending, then events descending as the tiebreak.** State this sort explicitly in the report so the ranking is reproducible, not just "however they came out."
+
+**Duplicate/related issues**: if two or more issues share a culprit class/method and clearly describe the same underlying bug (e.g. `setX` and `setY` both throwing "cannot be NaN" from the same layout algorithm, or the same watchdog exception and its `InterruptedException` sibling), group them explicitly. Investigate one representative, then apply its root cause, fix direction, and confidence **identically** to every other issue in the group in the table. Never leave some group members filled in and others blank with no explanation.
+
+**Issues already assigned to someone in Sentry**: keep them in the report under a separate "Assigned / in progress" section (still show their tier), but do not spend a sub-agent investigating them — someone's already on it, and re-investigating wastes effort. If an issue would otherwise be *excluded* (Step 2/3) but is already assigned, don't fold it quietly into the excluded table — call it out explicitly (e.g. in a summary note), since marking it `ignored` could clash with in-progress human work on a mitigation.
+
+### 5. Deep investigation for the top-N unassigned issues
+
+Take the top N (default 12, or the user-supplied count) **unassigned** actionable issues by tier. For each:
+
+1. Fetch full detail with `get_sentry_resource` (full stack trace, breadcrumbs, tags, a sample event) — do this yourself, don't make the sub-agent call Sentry.
+2. Spawn one sub-agent per issue, **model: sonnet**, read-only tools only (no `Edit`/`Write`/`NotebookEdit`), using this prompt shape:
+
+   > Investigate the root cause of this Gephi exception. Do NOT modify any files — this is investigation only, another task will implement any fix later.
+   >
+   > **Issue**: `<title/exception>`
+   > **Culprit**: `<package.Class#method>`
+   > **Stack trace**: `<relevant frames>`
+   > **Context**: `<users affected, events, first/last seen, any relevant tags/breadcrumbs>`
+   >
+   > Use CodeGraph (`codegraph_explore`) if available, otherwise grep/read, to find the relevant code. Report: (1) most likely root cause, (2) the specific file(s)/line(s) involved, (3) one or two concrete directions for a fix (not a diff, not implemented code — just the approach), (4) your confidence (high/medium/low) and why. Keep it under ~200 words.
+
+   Run independent issues' sub-agents in parallel (single Agent tool call with multiple invokes, or background if the count is large).
+3. If investigation genuinely can't pin a root cause (e.g. sparse stack trace, third-party library internals with no Gephi frame), report that honestly instead of guessing — "insufficient signal, needs a repro" is a valid finding.
+4. **Confidence is a single value: High / Medium / Low.** This is a table cell, not prose, and every row in the column uses this scale. If root-cause confidence and fix-mechanics confidence differ (e.g. you're sure what's broken but less sure of the best fix), report the *lower* of the two in the table and explain the split in the Investigation Details prose — never a compound string like "High / Medium-high" in the cell. Sub-agents will sometimes hand back hedge words like "medium-high" or "high-ish": first round that down to the nearest of the three real buckets (medium-high → Medium), *then* take the lower of root-cause vs. fix-mechanics. Don't let a hedge word sneak a higher value into the table than the rule allows. Check every table cell against this rule before writing the report — it's easy to get wrong while writing up many rows at once.
+
+Actionable issues beyond the top N: still list them in the report table with their Sentry metadata and tier, just without the investigation columns. Their Status cell must say `Not investigated (beyond cap of N)` with the actual N used for that run — not a bare "Not investigated" — so a reader can tell "deliberately out of scope for this run" apart from "this fell through a gap." If a run builds incrementally on a previous one (e.g. investigating 3 more issues on top of an earlier batch), state the cumulative count and the previous report it builds on in the Summary, rather than leaving the reader to infer why the cap looks larger than a single batch.
+
+### 6. Write the report
+
+Write to `reports/sentry-triage/sentry-triage-<YYYY-MM-DD>.md`, creating the directory if needed. This repo is public/open-source, so the path is gitignored — do not remove that `.gitignore` entry, and don't commit report files. If re-running the skill on the same day (e.g. investigating more issues on top of an earlier same-day run rather than starting over), append `-v2`, `-v3`, etc. to the filename and say in the new report's summary which earlier report it builds on — don't silently overwrite same-day history.
+
+Formatting rules:
+
+- Keep the summary table narrow and skimmable — it is a triage index, not the findings themselves. Root cause / fix-direction prose belongs only in the Investigation Details appendix, even when there's very little of it.
+- The `Signal` column (exception type + culprit, one line) is mandatory for every row, investigated or not, so nothing is ever a bare title with nothing to verify or act on.
+- The `Notes` column is for short tags only, a few words: `duplicate of GEPHI-XXXX`, `possible retry loop`, `handling gap`, `needs investigation to confirm X` — never a full sentence. If a categorization-time observation needs a full sentence (e.g. "this uncaught IOException surfacing as a RuntimeException suggests a missing catch regardless of the underlying cause"), it goes in the Investigation Details appendix as a short "Categorization note" entry for that issue, not stretched across the summary table.
+- Include, once, a one-line legend for the recency buckets right in the report (not just in this skill file) — e.g. `Active = last seen <7d, Recent = 7-30d, Stale = >30d` — so the report is self-contained and a reader can check the tiering without opening the skill definition.
+
+Structure:
+
+```markdown
+# Sentry Triage Report — <date>
+
+Org/project: gephi/gephi · Window: last 90 days · Generated by: sentry-triage skill
+
+## Summary
+- N unresolved issues pulled, X excluded (not actionable), Y actionable
+- Top N sent for deep investigation, Z remaining listed without investigation
+- Sort within each tier: users affected desc, then events desc
+- [Excluded issues marked as `ignored` in Sentry with explanatory comment | Exclusions NOT applied to Sentry — awaiting confirmation]
+- Any excluded-but-assigned issues, called out explicitly (see Step 4)
+
+## Actionable issues (prioritized)
+
+Sorted by tier, then users desc, then events desc within tier.
+
+| Tier | Issue | Signal (exception + culprit) | Users | Events | Last seen | Confidence | Status | Notes |
+|---|---|---|---|---|---|---|---|---|
+| P0 | [GEPHI-XXXX](link) Title | `IllegalArgumentException: x cannot be NaN` — `NodeImpl.setX` | 120 | 1021 | Active | High | Investigated | duplicate: see GEPHI-YYYY |
+| P0 | [GEPHI-YYYY](link) Title | `NullPointerException` — `NodeImpl.setY` | 20 | 117 | Active | High | Investigated (duplicate) | duplicate of GEPHI-XXXX |
+| P1 | [GEPHI-ZZZZ](link) Title | `IOException: ...` — `Some.Class#method` | 40 | 200 | Recent | — | Not investigated (beyond cap of N) | — |
+
+Every row must have a populated Signal column, even "Not investigated"
+ones — that's the minimum a follow-up agent needs to start from without
+re-querying Sentry.
+
+## Assigned / in progress (not re-investigated)
+
+| Tier | Issue | Signal | Assignee | Users | Events | Last seen |
+|---|---|---|---|---|---|---|
+
+## Excluded — not actionable
+
+| Issue | Signal (exception + culprit) | Category | Users | Events | Reason | Sentry action taken |
+|---|---|---|---|---|---|---|
+
+Call out any excluded issue that is also currently assigned to someone,
+right in this table's Reason cell as a plain sentence (e.g. "...
+Assigned to X — do not auto-ignore.") — don't bury it in a separate
+footnote, and don't reach for bold to make it stand out; a table cell is
+already the emphasis.
+
+## Investigation details
+
+### GEPHI-XXXX — Title
+- **Root cause**: ...
+- **Affected code**: `path/to/File.java:123`
+- **Suggested direction**: ...
+- **Confidence**: High — reasoning (include any root-cause-vs-fix confidence split here, not in the table)
+- **Duplicates**: GEPHI-YYYY, GEPHI-ZZZZ (same root cause) — omit if not applicable. Always say "duplicate"/"duplicates" here and in the table, never "cluster" in one place and "duplicate" in another for the same relationship.
+- **Sentry**: link
+
+### GEPHI-XXXX — categorization note
+Use this shorter form (no Root cause/Affected code/Confidence fields)
+for an issue that was *not* deep-investigated but whose categorization
+still needed more than the Notes column's few words to explain — e.g.
+why it doesn't fit an existing exclusion category, or why it shouldn't
+be lumped in with a category it superficially resembles. One short
+paragraph, plain prose.
+```
+
+### 7. Final message to the user
+
+Short summary only: counts per tier, how many investigated, link to the report file and to the Sentry dashboard. Do not paste the whole report into chat if it's long — point to the file.
+
+## Writing style
+
+The report is read by humans deciding what to fix and by other agents deciding how to fix it. Write it like you're briefing a colleague, not like you're demonstrating thoroughness. Concretely:
+
+- **Don't lean on em dashes as a default connector.** If every second clause is joined with "—", vary it: a period and a new sentence, "because", "which", "so", a comma. An em dash for a genuine aside is fine; an em dash because you didn't pick a real connective word is not.
+- **Don't bold for emphasis.** Bold is for the field labels (`**Root cause**:`) the template already defines — not for making a phrase inside a sentence stand out. If something's important, say it plainly; word choice and sentence position do the emphasis.
+- **Say it once.** Avoid restating the same qualifier in two forms in one sentence (e.g. "a genuine handling gap, not a fundamental limitation, and something Gephi could actually fix"). Pick the clearest version and cut the rest.
+- **Use one term per concept, everywhere.** Decide once whether grouped duplicate issues are called "duplicates" or "a cluster" and use that word in the table, the Notes column, and the Investigation Details section alike. Same for any other recurring concept — don't let synonyms drift in across sections written at different points in the run.
+- **Cut hedge-stacking.** "Medium-high confidence, though not fully certain, and somewhat speculative" is three hedges for one idea. Pick the single High/Medium/Low value the confidence rule requires and move the nuance, if any, into one clause of the details prose — not a chain of qualifiers.
+- **Vary sentence shape.** If three rows in a row start with "This is a genuine X, not Y" or "Root cause: X happens because Y", a reader notices the template before the content. Rewrite so consecutive entries don't read as filled-in mail merge.
+- Before finishing, skim your own draft once for these patterns specifically — they're the easiest tells that a report was written under time pressure rather than edited.
+
+## Guardrails recap
+
+- No code edits, ever — this skill and its sub-agents only read and report.
+- No silent drops — every pulled issue ends up in exactly one section of the report (actionable, assigned, or excluded).
+- No Sentry writes without explicit confirmation of the exclusion list.
+- Investigation sub-agents must say "insufficient signal" rather than fabricate a root cause when the stack trace doesn't support one.

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,8 @@ projects.xml
 modules/application/.flattened-pom.xml
 translations/**
 .cursor
-.claude
+.mcp.json
+.claude/*
+!.claude/CLAUDE.md
+!.claude/skills
+/reports/sentry-triage/

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ translations/**
 !.claude/CLAUDE.md
 !.claude/skills
 /reports/sentry-triage/
+.codegraph

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,15 @@ Gephi is an open-source graph visualization platform built on the Apache NetBean
 codebase is a multi-module Maven project (`modules/*`) written in Java, with a Swing/OpenGL desktop
 UI. See `README.md` for the product-level description and `pom.xml` for the module list.
 
+For anything beyond a small fix, read these first:
+
+- `ARCHITECTURE.md` — module layout, API/SPI/Lookup conventions, controllers vs. models.
+- `CONTRIBUTING.md` — local dev setup, branch/PR workflow, release process.
+
+Both were compiled from a 2022 presentation, so cross-check version-specific claims (JDK version,
+module counts) against `pom.xml`/`README.md` if something looks off — treat them as directionally
+right but not necessarily current on numbers.
+
 ## Build and test
 
 Requires JDK 17.
@@ -50,7 +59,11 @@ in CI); rules live in `checkstyle.xml`, suppressions in `checkstyle-suppressions
 
 - Keep commits scoped to one logical change; this repo takes many small dependency-bump and
   fix PRs, so noisy unrelated diffs stand out.
-- Reference the GitHub issue number when a change fixes a reported bug.
+- PR title: `ISSUE_NUMBER DESCRIPTIVE_SUMMARY` (e.g. `#1299 Fix issue with edge weight`) — omit the
+  issue number only if none exists.
+- Fill in `.github/pull_request_template.md` (auto-populated when opening a PR on GitHub) — don't
+  strip its checklist. It covers tests, README/API-changelog/code-doc updates, and merging with
+  master first.
 - Don't add tests-skipping flags or checkstyle suppressions to get a build green — fix the
   underlying issue.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,30 +11,14 @@ UI. See `README.md` for the product-level description and `pom.xml` for the modu
 For anything beyond a small fix, read these first:
 
 - `ARCHITECTURE.md` — module layout, API/SPI/Lookup conventions, controllers vs. models.
-- `CONTRIBUTING.md` — local dev setup, branch/PR workflow, release process.
-
-Both were compiled from a 2022 presentation, so cross-check version-specific claims (JDK version,
-module counts) against `pom.xml`/`README.md` if something looks off — treat them as directionally
-right but not necessarily current on numbers.
+- `CONTRIBUTING.md` — dev environment setup, the exact `mvn` build/test commands, the API-changelog
+  convention, branch/PR workflow, release process.
 
 ## Build and test
 
-Requires JDK 17.
-
-```bash
-# Full build + tests
-mvn -T 4 clean install
-
-# Faster iteration: skip tests
-mvn -T 4 clean install -P skipTests
-
-# Run the app after building
-cd modules/application
-mvn nbm:cluster-app nbm:run-platform
-
-# Match CI exactly (build + tests + checkstyle)
-mvn -T 4 --batch-mode -Djava.awt.headless=true verify -P enableCheckStyle
-```
+Requires JDK 17. See `CONTRIBUTING.md`'s "Building and running" section for the `mvn` commands
+(full build, skip-tests, running the app, matching CI) rather than this file — don't let the two
+drift out of sync.
 
 Checkstyle is disabled by default locally and only enforced via the `enableCheckStyle` profile (as
 in CI); rules live in `checkstyle.xml`, suppressions in `checkstyle-suppressions.xml`.
@@ -47,23 +31,20 @@ in CI); rules live in `checkstyle.xml`, suppressions in `checkstyle-suppressions
 - Gephi is dual-licensed CDDL 1.0 / GPLv3. New source files should carry the standard license
   header used elsewhere in the module (copy from a neighboring file in the same module).
 
-## Repo layout notes
+## Repo layout
 
-- `modules/` — the actual product code, one Maven module per feature area (e.g. `VisualizationImpl`,
-  `GraphModel`, `Layout`, `Filters`, `Export`, `Import*`, `Desktop*`).
-- `modules/application` — the assembled desktop app (NetBeans platform cluster).
-- Plugin development is a separate concern from core module changes — see the "Create Plug-ins"
-  section of `README.md` before assuming a change belongs in `modules/`.
+See `ARCHITECTURE.md` for module structure, naming, and package conventions rather than this file.
+One practical note not covered there: plugin development is a separate concern from core module
+changes — see the "Create Plug-ins" section of `README.md` before assuming a change belongs in
+`modules/`.
 
 ## PR / commit guidelines
 
+Follow `CONTRIBUTING.md`'s "PR format" section (title convention, `.github/pull_request_template.md`
+checklist) rather than duplicating it here. Two things worth restating for an agent specifically:
+
 - Keep commits scoped to one logical change; this repo takes many small dependency-bump and
   fix PRs, so noisy unrelated diffs stand out.
-- PR title: `ISSUE_NUMBER DESCRIPTIVE_SUMMARY` (e.g. `#1299 Fix issue with edge weight`) — omit the
-  issue number only if none exists.
-- Fill in `.github/pull_request_template.md` (auto-populated when opening a PR on GitHub) — don't
-  strip its checklist. It covers tests, README/API-changelog/code-doc updates, and merging with
-  master first.
 - Don't add tests-skipping flags or checkstyle suppressions to get a build green — fix the
   underlying issue.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+Instructions for AI coding agents (Claude Code, Cursor, Codex, etc.) working in this repository.
+
+## Project overview
+
+Gephi is an open-source graph visualization platform built on the Apache NetBeans Platform. The
+codebase is a multi-module Maven project (`modules/*`) written in Java, with a Swing/OpenGL desktop
+UI. See `README.md` for the product-level description and `pom.xml` for the module list.
+
+## Build and test
+
+Requires JDK 17.
+
+```bash
+# Full build + tests
+mvn -T 4 clean install
+
+# Faster iteration: skip tests
+mvn -T 4 clean install -P skipTests
+
+# Run the app after building
+cd modules/application
+mvn nbm:cluster-app nbm:run-platform
+
+# Match CI exactly (build + tests + checkstyle)
+mvn -T 4 --batch-mode -Djava.awt.headless=true verify -P enableCheckStyle
+```
+
+Checkstyle is disabled by default locally and only enforced via the `enableCheckStyle` profile (as
+in CI); rules live in `checkstyle.xml`, suppressions in `checkstyle-suppressions.xml`.
+
+## Code style
+
+- Follow the existing style of the file you're editing over any external convention.
+- Respect `checkstyle.xml` — run the `enableCheckStyle` profile before proposing changes to
+  widely-shared/core modules if you're unsure.
+- Gephi is dual-licensed CDDL 1.0 / GPLv3. New source files should carry the standard license
+  header used elsewhere in the module (copy from a neighboring file in the same module).
+
+## Repo layout notes
+
+- `modules/` — the actual product code, one Maven module per feature area (e.g. `VisualizationImpl`,
+  `GraphModel`, `Layout`, `Filters`, `Export`, `Import*`, `Desktop*`).
+- `modules/application` — the assembled desktop app (NetBeans platform cluster).
+- Plugin development is a separate concern from core module changes — see the "Create Plug-ins"
+  section of `README.md` before assuming a change belongs in `modules/`.
+
+## PR / commit guidelines
+
+- Keep commits scoped to one logical change; this repo takes many small dependency-bump and
+  fix PRs, so noisy unrelated diffs stand out.
+- Reference the GitHub issue number when a change fixes a reported bug.
+- Don't add tests-skipping flags or checkstyle suppressions to get a build green — fix the
+  underlying issue.
+
+## Security
+
+- Never commit secrets, API keys, or tokens.
+- This is a public repository — do not add personal or employer-internal tooling references
+  (private plugin marketplaces, internal service URLs, machine-specific paths) to any file
+  intended to be shared (this file, `.claude/CLAUDE.md`, committed skills). Keep that kind of
+  config local (gitignored).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,20 +154,20 @@ An importer SPI defines the operations an importer must provide, such as executi
 
 ### Available SPIs
 
-| SPI | Extension point |
-|---|---|
-| Import SPI | File, database, and wizard importers |
-| Layout SPI | Layout algorithms |
-| Statistics SPI | Other algorithms |
-| Tools SPI | Tools in the menu bar |
-| Project SPI | Persistence providers |
-| Export SPI | File exporters for graphs and graphics |
-| Filters SPI | Filters |
-| Preview SPI | Preview builders and renderers |
-| Generator SPI | Generators, similar to importers |
-| Data Laboratory SPI | Manipulators |
-| Appearance SPI | Transformers for ranking and partitioning |
-| Visualization SPI | Renderers for the new `VisualizationEngine` module (mid-migration from the legacy `VisualizationImpl` engine) |
+| SPI | Extension point                                                       |
+|---|-----------------------------------------------------------------------|
+| Import SPI | File, database, and wizard importers                                  |
+| Layout SPI | Layout algorithms                                                     |
+| Statistics SPI | Other algorithms                                                      |
+| Tools SPI | Tools in the menu bar                                                 |
+| Project SPI | Persistence providers                                                 |
+| Export SPI | File exporters for graphs and graphics                                |
+| Filters SPI | Filters                                                               |
+| Preview SPI | Preview builders and renderers                                        |
+| Generator SPI | Generators, similar to importers                                      |
+| Data Laboratory SPI | Manipulators                                                          |
+| Appearance SPI | Transformers for ranking and partitioning                             |
+| Visualization SPI | Renderers for the new `VisualizationEngine` module (work in progress) |
 
 The Project SPI’s persistence providers make `.gephi` project files extensible. Any module can add its own data to a `.gephi` file by implementing a persistence provider.
 
@@ -177,7 +177,7 @@ The available SPIs define the kinds of plugins that can be created: a plugin can
 
 Resources supplied with the architecture material:
 
-- API versus SPI: <https://netbeans.apache.org/wiki/DevFaqApiSpi.asciidoc>
+- API versus SPI: <https://netbeans.apache.org/wiki/main/netbeansdevelopperfaq/DevFaqApiSpi/>
 
 ## Lookup
 
@@ -225,7 +225,7 @@ A new layout, filter, renderer, or other extension is therefore added by:
 
 Resources supplied with the architecture material:
 
-- Lookup: <https://netbeans.apache.org/wiki/DevFaqLookup.asciidoc>
+- Lookup: <https://netbeans.apache.org/wiki/main/netbeansdevelopperfaq/DevFaqLookup/>
 
 ## API direction and compatibility
 
@@ -379,8 +379,6 @@ src/                  # Extra files, including the macOS launcher
 pom.xml               # Parent POM containing shared configuration
 ```
 
-Repository: <https://github.com/gephi/gephi>
-
 ### Application module
 
 The application module is different from the other modules. In NetBeans Platform terminology, the repository contains modules and an application. Gephi has one application module, the Gephi application, which depends on all the other modules and is built last.
@@ -392,22 +390,3 @@ The application module contains mostly configuration rather than code, including
 The root `src` folder contains extra files such as the macOS launcher and is not generally relevant to day-to-day development.
 
 The root `pom.xml` is the parent POM for the multi-module Maven repository. Shared configuration is kept there whenever possible, including dependency versions and build configuration. Every module declares this POM as its parent and inherits its configuration. Module-specific configuration may live in a module’s own POM, but this is uncommon.
-
-## Architecture resources included with the source material
-
-### NetBeans Platform
-
-- NetBeans APIs Documentation
-- Source code
-- FAQ
-- Documentation
-- Tutorials
-
-### Conventions and examples
-
-- Code Style
-- Localization
-- Documentation
-- Coding via examples
-- Plugins Bootcamp
-- Toolkit Demos

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,413 @@
+# Gephi Architecture
+
+## High-level architecture
+
+Gephi is based on the Java programming language and currently uses JDK 17.
+
+The software is layered as follows:
+
+```text
+Plugins                Plugins
+   │                       │
+   └──────────► Gephi UI ◄─┘
+                    │
+Plugin ───────► Core Gephi
+                    │
+            NetBeans Platform
+                    │
+                   Java
+```
+
+The NetBeans Platform provides the foundation for many Gephi features. It is also the foundation on which the NetBeans IDE is built. NetBeans APIs therefore appear throughout the Gephi codebase, and familiarity with the platform is useful when modifying Gephi.
+
+Core Gephi modules are separated from user-interface modules. This separation makes it possible to build a command-line tool or library using only non-UI modules, without importing unnecessary user-interface dependencies. Gephi’s toolkit uses this approach.
+
+Plugins can build on either core modules or UI modules. Gephi’s extensible architecture does not treat plugins as a separate kind of component: a plugin is another module.
+
+## Design principles
+
+### Modularity
+
+Gephi is designed to be extensible.
+
+- The codebase is broken down into 66 modules, per the root `pom.xml`'s `<modules>` list (not counting the `application` module itself).
+- Modules define dependencies between one another.
+- APIs and contracts separate modules.
+- A developer can locate the module responsible for a feature, work within it, and avoid needing to understand the entire codebase.
+- Plugins are nothing other than modules. Adding a plugin effectively adds another module to the software—for example, a 67th module alongside the 66 existing modules.
+
+### Multithreading
+
+Gephi is designed around a non-blocking user interface.
+
+- Long-running tasks can execute in the background.
+- Users can continue exploring a graph while algorithms run.
+- The graph structure is protected through locking so it remains consistent.
+- The UI reacts to data changes.
+
+For example, deleting a node also requires deleting its associated edges. It would be inconsistent for one thread to delete a node while another thread could still read edges belonging to that deleted node. Locking prevents this. The in-memory graph structure behaves like a database with consistency controls: callers can rely on the graph being consistent at any point in time.
+
+The multithreaded design extends to the user interface. The software assumes that a module or plugin may modify the graph at any time and that other modules will react to those changes. Code that changes the graph does not need to explicitly refresh each affected UI component; those components update automatically. This keeps modules separate and avoids a slow interface when many changes occur concurrently.
+
+## Technologies
+
+### Runtime and platform
+
+- Java, currently JDK 17
+- NetBeans Platform
+  - Module system
+  - Docking framework, including movable windows
+  - Auto-update functionality
+  - User-interface components
+
+The NetBeans Platform is open source, has a community around it, and is used as the basis for other desktop software.
+
+### User interface and rendering
+
+- Swing for the user interface
+- OpenGL for visualization
+- Java2D for rendering in the Preview tab
+
+### Build, testing, and automation
+
+- Maven
+- JUnit
+- GitHub Actions
+
+## Main APIs
+
+Functionality is exposed through APIs that correspond to modules:
+
+| API | Responsibility |
+|---|---|
+| Project API | Project management and workspaces |
+| Graph API | Graph structure and access to graph data — the actual data structure implementation lives in the separate [graphstore](https://github.com/gephi/graphstore) repository; `modules/GraphAPI` here is a thin NetBeans-module wrapper around it (see note below) |
+| Import API | Importing files and databases, including File Open workflows |
+| Layout API | Layout algorithms |
+| Filters API | Filters |
+| Statistics API | Algorithms such as community detection and PageRank |
+| Export API | Exporting files |
+| Preview API | Rendering preview images |
+| Appearance API | Partitioning, ranking, and transforming nodes and edges with colors and sizes |
+| Tools API | Tools associated with the visualization, such as shortest path |
+| Data Laboratory API | Manipulation of attributes and Data Laboratory operations |
+| Visualization API | Functionality offered by the OpenGL engine |
+
+APIs can depend on one another. For example, the Graph API depends on the Project API because graphs are associated with workspaces. Dependencies are declared as standard Maven dependencies in each module’s `pom.xml`. A new module dependency is added to that module’s POM.
+
+**Core graph structure lives in a separate repository.** `modules/GraphAPI` in this repo only wraps
+the `graphstore` library (pulled in as a Maven dependency, see the `graphstore.version` property in
+the root `pom.xml`) as a NetBeans module and exposes `org.gephi.graph.api`/`org.gephi.graph.impl`.
+The actual graph/node/edge data structure — the core of what Gephi manipulates — is implemented in
+[github.com/gephi/graphstore](https://github.com/gephi/graphstore), a separate repository. Any
+change to the core graph data structure itself (storage, indexing, node/edge/column implementation)
+belongs there, not here; changes here should be limited to the NetBeans-integration layer
+(`GraphControllerImpl`, `GraphPersistenceProvider`) and consumers of the API.
+
+### API properties
+
+Gephi APIs are plain Java interfaces.
+
+They use the NetBeans module system’s public-package mechanism. A module marks selected packages as public in its `pom.xml`; only those packages are accessible to other modules. The public-package list may also be empty.
+
+For example, the Import API module contains:
+
+- A public API package, such as `org.gephi.io.importer.api`.
+- An implementation package, such as `org.gephi.io.importer.impl`.
+- Other module-internal code.
+
+The API and its implementation can live in the same module, but only the API package is public. A module that depends on the Import API cannot access its implementation. This hides implementation details, preserves the API as a contract, and allows an implementation to be replaced later without consumers depending on its internals.
+
+This public-package approach predates the module system introduced in Java 9 but provides a similar form of encapsulation through the NetBeans Platform.
+
+Most APIs have reached a level of stability where backward compatibility is a goal. APIs may also be marked as under development while their entry points and contracts are being refined. The aim is for them eventually to become stable enough that plugins can rely on them over time.
+
+The main APIs are documented through Javadoc. Complete documentation for all main APIs is the goal. Documentation quality varies in some places, but in most cases it provides a usable entry point. API and SPI changes are tracked in `src/main/javadoc/overview.html` (the main Javadoc overview page), providing a change log for developers migrating modules or plugins, including new methods and other changes. This file is also the source used to compile release notes, so entries need to follow its existing formatting convention — see [CONTRIBUTING.md](CONTRIBUTING.md#api-changelog) for the exact structure.
+
+The architecture was heavily inspired by [*Practical API Design: Confessions of a Java Framework Architect*](https://wiki.apidesign.org/wiki/TheAPIBook), written by the architect of the NetBeans Platform. It is recommended as an introduction to API design.
+
+## APIs and SPIs
+
+SPI means **Service Provider Interface**.
+
+APIs and SPIs share implementation properties: both are Java interfaces, both use public packages, both are intended to be backward compatible, and both should be clearly documented. Their roles differ, and APIs and SPIs are never mixed.
+
+- APIs offer functionality to other modules.
+- SPIs are meant to be extended.
+- Plugins always extend an SPI.
+
+For example, the Import API module can contain:
+
+```text
+Import API module
+├── API: org.gephi.io.importer.api
+├── implementation: org.gephi.io.importer.impl
+└── SPI: org.gephi.io.importer.spi
+    └── Importer
+        ├── ImporterGEXF
+        ├── ImporterGML
+        ├── ImporterXXX
+        └── implementation supplied by a plugin
+```
+
+An importer SPI defines the operations an importer must provide, such as execution. Core modules and plugins can implement it for GEXF, GML, or other formats.
+
+### Available SPIs
+
+| SPI | Extension point |
+|---|---|
+| Import SPI | File, database, and wizard importers |
+| Layout SPI | Layout algorithms |
+| Statistics SPI | Other algorithms |
+| Tools SPI | Tools in the menu bar |
+| Project SPI | Persistence providers |
+| Export SPI | File exporters for graphs and graphics |
+| Filters SPI | Filters |
+| Preview SPI | Preview builders and renderers |
+| Generator SPI | Generators, similar to importers |
+| Data Laboratory SPI | Manipulators |
+| Appearance SPI | Transformers for ranking and partitioning |
+| Visualization SPI | Renderers for the new `VisualizationEngine` module (mid-migration from the legacy `VisualizationImpl` engine) |
+
+The Project SPI’s persistence providers make `.gephi` project files extensible. Any module can add its own data to a `.gephi` file by implementing a persistence provider.
+
+The visualization engine revamp is underway: a new `VisualizationEngine` module now exists alongside the legacy `VisualizationImpl` module (the application currently depends on both), with its own `org.gephi.viz.engine.spi.Renderer` SPI. The Visualization SPI's functionality is still being expanded as that migration progresses.
+
+The available SPIs define the kinds of plugins that can be created: a plugin can exist when it implements an SPI.
+
+Resources supplied with the architecture material:
+
+- API versus SPI: <https://netbeans.apache.org/wiki/DevFaqApiSpi.asciidoc>
+
+## Lookup
+
+Lookup is the most important NetBeans Platform utility in the Gephi architecture. It appears throughout the codebase and supports the API/implementation and SPI/implementation separations.
+
+### Finding a singleton service
+
+Controllers are obtained without accessing their implementations directly:
+
+```java
+ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
+```
+
+For example, code that needs to create, save, or otherwise manipulate projects obtains the `ProjectController` service through Lookup. This resembles dependency injection. The service is a singleton, and obtaining it through Lookup preserves the separation between the public API and its implementation.
+
+### Finding every implementation of an SPI
+
+Lookup can return every available implementation of an SPI:
+
+```java
+for (Renderer renderer : Lookup.getDefault().lookupAll(Renderer.class)) {
+}
+```
+
+The returned collection can contain implementations from core modules and plugins. Implementations added to the runtime classpath are included without callers needing to know their packages.
+
+This mechanism powers lists and trees of available extensions in the interface. A layout selector, for example, discovers every layout algorithm through `lookupAll`. The same pattern is used for exporters, renderers, filters, and other extension lists.
+
+### Registering an implementation
+
+SPI implementations must be registered with the service-provider annotation:
+
+```java
+@ServiceProvider(service = Renderer.class)
+public class NodeRenderer implements Renderer {
+}
+```
+
+The annotation states that the class supplies an implementation of the `Renderer` SPI. Lookup searches the classpath for these registrations. Implementing the interface without the annotation means that `lookupAll` will not discover the implementation.
+
+A new layout, filter, renderer, or other extension is therefore added by:
+
+1. Implementing the relevant SPI.
+2. Adding the service-provider annotation.
+
+Resources supplied with the architecture material:
+
+- Lookup: <https://netbeans.apache.org/wiki/DevFaqLookup.asciidoc>
+
+## API direction and compatibility
+
+The architecture aims to preserve the following properties:
+
+- Each feature has a clean, stable, documented API.
+- Developers can discover an extension point through Javadoc without first reading deeply into the implementation.
+- Implementations can be replaced without changing, or without substantially changing, the API.
+- New features can be added through plugins.
+- Core functionality can be used by command-line tools without UI modules.
+- Modules can be reused in other projects.
+- Gephi modules are published on Maven Central and can be selected individually, such as using only the graph structure or using the graph and layout modules in another library, cloud application, or third-party application.
+- Core and UI modules remain separated, even when features require user input and UI components.
+
+Gephi has rewritten modules internally multiple times while keeping their APIs unchanged or changing them only minimally. This remains an architectural goal.
+
+The NetBeans Platform also makes it possible to replace a default implementation. A plugin could provide a new implementation—for example, a replacement `ProjectController`—and give it a higher priority so that Lookup selects it instead of the default. This is uncommon in practice, but it demonstrates that the platform supports replacing as well as extending functionality.
+
+### Semantic versioning
+
+Gephi uses semantic versioning to communicate API changes:
+
+- **Patch (`0.11.x`)**: minimal API changes. A new method may be added to an API, but changes are otherwise limited.
+- **Minor (`0.x.x`)**: API additions and occasional compatibility breaks when necessary, particularly for APIs marked under development.
+- **Major (`x.x.x`)**: APIs may be rewritten from scratch with major changes, such as between `1.0` and `2.0`.
+
+## Anatomy of a module
+
+All modules follow the Maven-style structure:
+
+```text
+ModuleName/
+├── src/
+│   ├── main/
+│   │   ├── java/          # Sources
+│   │   ├── nbm/
+│   │   └── resources/     # Bundles, localization files, other files, icons, and images
+│   └── test/
+│       └── java/          # Test sources
+└── pom.xml                # Dependencies, public packages, and extra configuration
+```
+
+The module’s `pom.xml` is particularly important. It contains configuration such as dependencies and public packages. Creating a new Gephi module produces this Maven-convention structure.
+
+## Module and package conventions
+
+Most modules follow four naming roles. Using import as the example:
+
+| Module pattern | Role | Count among the 66 modules |
+|---|---|---:|
+| `ImportAPI` | Defines APIs and SPIs and implements APIs | 17 |
+| `ImportPlugin` | SPI implementations | 11 |
+| `ImportPluginUI` | UI-only SPI implementations | 6 |
+| `DesktopImport` | Remaining UI code | 17 |
+
+Together, 51 of the 66 modules follow this convention.
+
+### API modules
+
+An API module contains the API, its SPIs, and the API implementation. There are one or two exceptions. For example, the Filters implementation can still be found in a separate filters implementation module, though the intention is to place both APIs and implementations in the API module.
+
+### Plugin modules
+
+A plugin module contains SPI implementations. For import, this is where implementations such as the GEXF importer are found.
+
+API and plugin modules are core Gephi modules and contain no user-interface code. They are the modules needed by a command-line application that imports the file formats supported by Gephi.
+
+### Plugin UI modules
+
+Some SPIs include UI components. An import or export implementation may need a panel that lets users configure it. UI implementations of those SPIs live in a plugin UI module so that core and UI modules remain separate.
+
+For example, most graph formats do not need a configuration panel when imported. Spreadsheet import is an exception: it uses a full CSV import wizard, detects the content, and requires Swing UI code implementing the Importer UI SPI. That code belongs in the import plugin UI module.
+
+### Desktop modules
+
+Desktop modules contain remaining UI code. For import, the report panel shown after an import belongs in the desktop import module. That report displays the number of nodes, errors, and warnings.
+
+The same convention applies across domains. Examples include:
+
+- Layout API and Layout Plugin
+- Preview API and Preview Plugin
+- Statistics API, Statistics Plugin, Statistics Plugin UI, and Desktop Statistics
+
+Modules that do not follow the four-role convention cover other functionality, such as the welcome screen (`WelcomeScreen`) and settings migration between versions (`SettingsUpgrader`).
+
+### Package names
+
+| Role | Package convention |
+|---|---|
+| API | `org.gephi.NAME.api` |
+| API implementation | `org.gephi.NAME` |
+| SPI | `org.gephi.NAME.spi` |
+| SPI implementation | `org.gephi.NAME.plugin` |
+| SPI implementation, UI only | `org.gephi.ui.NAME.plugin` |
+| UI | `org.gephi.desktop.NAME` |
+
+These conventions should be followed when creating modules or changing implementations so the codebase remains organized.
+
+## Controllers and models
+
+Gephi uses a simplified Model–Controller pattern rather than a full Model–View–Controller pattern; there is no architectural View component.
+
+### Controllers
+
+Controllers include `ProjectController`, `ImportController`, and `GraphController`.
+
+- A controller is a singleton service found through Lookup.
+- It is the entry point for interacting with and executing a module’s functionality.
+- It is the entry point for any model alteration and contains setters.
+- It retrieves the model.
+
+### Models
+
+- Models contain all state and data and expose getters.
+- There is one model of each relevant kind per workspace.
+- Models are the source for persistence providers.
+
+A project can contain multiple independent workspaces. Each workspace has its own layout model, filter model, and other models. Configuration set in Workspace 1 changes when switching to Workspace 2, and the Workspace 1 configuration is restored when switching back.
+
+```text
+Project
+├── Workspace 1
+│   ├── Layout Model
+│   ├── Filter Model
+│   └── ...
+└── Workspace 2
+    ├── Layout Model
+    ├── Filter Model
+    └── ...
+```
+
+Models also provide the state serialized into `.gephi` project files. When saving, Gephi discovers all persistence-provider implementations. A layout persistence provider, for example, writes layout state into the file and restores it when the file is read.
+
+In summary:
+
+- Models provide the getters and contain the data.
+- Controllers provide the setters and alter state and data.
+- There is no View in the current architectural pattern.
+
+## Repository structure
+
+The repository is organized as follows:
+
+```text
+.github/
+└── workflows/       # GitHub Actions workflows
+modules/
+├── application/     # Gephi application module (built last, depends on all others)
+└── ...              # Source code for the other 66 modules
+src/                  # Extra files, including the macOS launcher
+pom.xml               # Parent POM containing shared configuration
+```
+
+Repository: <https://github.com/gephi/gephi>
+
+### Application module
+
+The application module is different from the other modules. In NetBeans Platform terminology, the repository contains modules and an application. Gephi has one application module, the Gephi application, which depends on all the other modules and is built last.
+
+The application module contains mostly configuration rather than code, including branding-screen configuration, versions, and installer-related configuration. Another application using only a subset of Gephi modules would use a separate application module with only those dependencies.
+
+### Root files
+
+The root `src` folder contains extra files such as the macOS launcher and is not generally relevant to day-to-day development.
+
+The root `pom.xml` is the parent POM for the multi-module Maven repository. Shared configuration is kept there whenever possible, including dependency versions and build configuration. Every module declares this POM as its parent and inherits its configuration. Module-specific configuration may live in a module’s own POM, but this is uncommon.
+
+## Architecture resources included with the source material
+
+### NetBeans Platform
+
+- NetBeans APIs Documentation
+- Source code
+- FAQ
+- Documentation
+- Tutorials
+
+### Conventions and examples
+
+- Code Style
+- Localization
+- Documentation
+- Coding via examples
+- Plugins Bootcamp
+- Toolkit Demos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,345 @@
+# Contributing to Gephi
+
+This guide covers setting up a development environment, building and running Gephi locally, finding your way around the codebase, and the pull-request and release workflows.
+
+## Development environment
+
+Gephi is a multi-module Maven project and currently uses JDK 17.
+
+Two IDEs are officially supported:
+
+- NetBeans IDE
+- IntelliJ IDEA
+
+Both recognize Gephi as a multi-module Maven project and use Maven behind the scenes for building. No IDE is required, however — everything below can also be done with the `mvn` CLI directly from the repository root.
+
+Whichever setup you choose, the goal is the same: build, run, and debug Gephi locally, with breakpoints and fast unit-test execution. Unit tests (JUnit) should run quickly, making it possible to work in a test-driven loop without starting the full Gephi application for every iteration.
+
+## Building and running
+
+### First build
+
+When starting out, or when importing Gephi into an IDE for the first time, run a complete build from the top-level Gephi parent project. This builds every module:
+
+```bash
+mvn -T 4 clean install
+```
+
+Parallel builds are supported — the `-T 4` above builds on four threads. Because module dependencies form a tree and circular dependencies are not allowed, modules at the top of the tree are built first and dependent modules are then built in parallel. The Gephi application module is always built last because it depends on every other module.
+
+After a successful complete build, run the locally built application:
+
+```bash
+cd modules/application
+mvn nbm:cluster-app nbm:run-platform
+```
+
+Two other commands are useful day to day:
+
+```bash
+# Faster iteration: skip tests
+mvn -T 4 clean install -P skipTests
+
+# Match what CI runs (build + tests + checkstyle)
+mvn -T 4 --batch-mode -Djava.awt.headless=true verify -P enableCheckStyle
+```
+
+### After changing a module
+
+Unit tests can use source changes immediately. To run the full Gephi application with a change:
+
+1. Rebuild the module that was changed, e.g. `mvn -pl modules/<ModuleName> -am install` (the `-am` flag also rebuilds its dependencies).
+2. Rebuild the application module: `cd modules/application && mvn install`.
+3. Run Gephi locally: `mvn nbm:cluster-app nbm:run-platform` (from `modules/application`).
+
+Rebuilding the changed module writes or overwrites its local JAR in the Maven local repository under `.m2`. If the module is not rebuilt, running Gephi can still use the previous local JAR rather than the new source changes. Rebuilding the application module afterwards ensures the application uses the latest local artifacts.
+
+When uncertain, rebuild the entire repository with `mvn -T 4 clean install`. This is slower but ensures everything is current.
+
+## Understanding the codebase
+
+Gephi is split into 66 modules, per the root `pom.xml`'s `<modules>` list (not counting the `application` module itself). Module dependencies form a tree, and circular dependencies are not allowed — this is what allows Maven to build independent parts in parallel.
+
+Core modules are separated from user-interface modules so that core functionality can be used by command-line tools and libraries without UI dependencies. A plugin is also a module: APIs expose functionality to other modules, SPIs are extension points, and plugins extend SPIs.
+
+**Core graph structure is developed in a separate repository.** `modules/GraphAPI` here is only a thin NetBeans-module wrapper around the `graphstore` library (a Maven dependency, see `graphstore.version` in the root `pom.xml`). The actual graph/node/edge data structure lives in [github.com/gephi/graphstore](https://github.com/gephi/graphstore) — changes to the core graph structure itself (storage, indexing, node/edge/column implementation) should be made there, not in this repo.
+
+### Repository layout
+
+The repository ([github.com/gephi/gephi](https://github.com/gephi/gephi)) is organized as follows:
+
+```text
+.github/
+└── workflows/       # GitHub Actions workflows
+modules/
+├── application/     # Gephi application module (built last, depends on all others)
+└── ...              # Source code for the other 66 modules
+src/                  # Extra files, including the macOS launcher
+pom.xml               # Parent POM containing shared configuration
+```
+
+The root `pom.xml` is the parent POM for the multi-module Maven project. Shared dependency versions and build configuration are kept there whenever possible; each module inherits this configuration by declaring the root POM as its parent. Configuration may be placed in a module's own POM when it is highly specific, but this is uncommon.
+
+The application module contains mostly application configuration, including branding, version, and installer configuration. It depends on all other modules.
+
+### Module structure
+
+A module follows Maven conventions:
+
+```text
+ModuleName/
+├── src/
+│   ├── main/
+│   │   ├── java/          # Sources
+│   │   ├── nbm/
+│   │   └── resources/     # Bundles, localization files, other files, icons, and images
+│   └── test/
+│       └── java/          # Test sources
+└── pom.xml                # Dependencies, public packages, and extra configuration
+```
+
+Each module's `pom.xml` declares its dependencies and public packages. Dependencies are standard Maven dependencies. Public packages define what other modules can access; implementation packages remain hidden.
+
+### Module names
+
+Most modules follow these roles:
+
+| Module pattern | Role | Count among the 66 modules |
+|---|---|---:|
+| `ImportAPI` | Defines APIs and SPIs and implements APIs | 17 |
+| `ImportPlugin` | SPI implementations | 11 |
+| `ImportPluginUI` | UI-only SPI implementations | 6 |
+| `DesktopImport` | Remaining UI code | 17 |
+
+Together, 51 of the 66 modules follow this convention. The same pattern is used in other areas, including Layout, Preview, and Statistics. The remaining modules cover other functionality, such as the welcome screen (`WelcomeScreen`) and settings migration between versions (`SettingsUpgrader`).
+
+### Package names
+
+Use the existing package conventions:
+
+| Role | Package convention |
+|---|---|
+| API | `org.gephi.NAME.api` |
+| API implementation | `org.gephi.NAME` |
+| SPI | `org.gephi.NAME.spi` |
+| SPI implementation | `org.gephi.NAME.plugin` |
+| SPI implementation, UI only | `org.gephi.ui.NAME.plugin` |
+| UI | `org.gephi.desktop.NAME` |
+
+### APIs, SPIs, and public packages
+
+APIs and SPIs are plain Java interfaces.
+
+- APIs offer functionality to other modules.
+- SPIs are meant to be extended.
+- Plugins always extend an SPI.
+- APIs and SPIs should be clearly documented.
+- API and SPI changes are recorded in the Javadoc overview page (see [API changelog](#api-changelog) below).
+- Most APIs aim to remain backward compatible; some may be marked under development while their contracts are refined.
+
+Only packages declared public in a module's `pom.xml` are accessible to other modules. API and implementation code may be in the same module, but implementation packages must remain hidden so consumers do not depend on details that may later be replaced.
+
+### API changelog
+
+Every public API/SPI change is recorded in `src/main/javadoc/overview.html`, under the `<h2>API Changes</h2>` section. This file is the source used to compile release notes, so new entries must follow its existing formatting convention exactly:
+
+- Entries are grouped by release under an `<h3>0.11.0</h3>`-style heading (the current in-progress version). Add a new `<h3>` only when starting the next version's entries; otherwise append to the existing one for the version you're targeting.
+- Within a version, entries are grouped by API under an `<h4>` heading using the API's name (e.g. `<h4>Graph API</h4>`, `<h4>Import API</h4>` — match the name used in ARCHITECTURE.md's [Main APIs](ARCHITECTURE.md#main-apis) table). Add a new `<h4>` (with its own `<ul>`) if that API has no entries yet in this version.
+- Each change is one `<li>` in that API's `<ul>`, written as a short, self-contained sentence describing what changed and why it matters to a consumer, with identifiers wrapped in `<code>` tags (e.g. `Addition of <code>newWorkspace()</code> in <code>ProjectController</code>...`).
+- Don't use the older `(Month DD YYYY)`-prefixed, undifferentiated-by-API list style — that's the legacy format used only in the `<h3>Archive</h3>` section at the bottom, kept for history and not a pattern to extend.
+- If an API's stability changes (e.g. goes from under development to stable, or gets deprecated), update its `<span class="unstable">`/`<span class="deprecated">` marking in the `<h2>API List</h2>` section at the bottom of the same file.
+
+### Adding an extension
+
+Implement the appropriate SPI and register the implementation with the NetBeans service-provider annotation:
+
+```java
+@ServiceProvider(service = Renderer.class)
+public class NodeRenderer implements Renderer {
+}
+```
+
+Lookup discovers registered implementations at runtime:
+
+```java
+for (Renderer renderer : Lookup.getDefault().lookupAll(Renderer.class)) {
+}
+```
+
+Without the service-provider annotation, `lookupAll` will not discover the implementation.
+
+The available extension categories are:
+
+| SPI | Extension point |
+|---|---|
+| Import SPI | File, database, and wizard importers |
+| Layout SPI | Layout algorithms |
+| Statistics SPI | Other algorithms |
+| Tools SPI | Tools in the menu bar |
+| Project SPI | Persistence providers |
+| Export SPI | File exporters for graphs and graphics |
+| Filters SPI | Filters |
+| Preview SPI | Preview builders and renderers |
+| Generator SPI | Generators, similar to importers |
+| Data Laboratory SPI | Manipulators |
+| Appearance SPI | Transformers for ranking and partitioning |
+| Visualization SPI | Renderers for the future visualization engine |
+
+Some SPIs have UI components. Keep those implementations in a plugin UI module rather than a core plugin module. For example, the CSV spreadsheet-import wizard implements a UI SPI and belongs in the import plugin UI module. Remaining UI such as the post-import report panel belongs in a desktop module.
+
+### Controllers and models
+
+Controllers are singleton services obtained through Lookup:
+
+```java
+ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
+```
+
+Use controllers as the entry point for executing module functionality and altering models. Controllers contain setters and retrieve models.
+
+Models contain state and data and expose getters. There is one model of each relevant kind per workspace. Models also supply state to persistence providers for serialization into and restoration from `.gephi` project files.
+
+## Branch and pull-request workflow
+
+### Day-to-day development
+
+The normal flow uses the master branch and feature branches:
+
+```text
+feature branch ──► pull request ──► build and test ──► merge
+master commit ────────────────────► build and test
+```
+
+A commit to master triggers the GitHub Actions **build and test** workflow. It builds Gephi and runs all tests. A successful run indicates that a regression has most likely not been introduced.
+
+A feature is developed on a feature branch and submitted through a pull request. Pull requests follow the same build-and-test path; when the tests pass, the pull request can be merged.
+
+### PR format
+
+Opening a PR on GitHub auto-populates it from [`.github/pull_request_template.md`](.github/pull_request_template.md) — use that template, don't replace it with free-form text.
+
+- **Title**: `ISSUE_NUMBER DESCRIPTIVE_SUMMARY`, e.g. `#1299 Fix issue with edge weight`. Omit the issue number if none exists.
+- Keep PRs small; split large changes rather than bundling unrelated work.
+- Fill in the **Description** section and link the GitHub issue if one exists.
+- Check the **Checklist**: confirm you've merged with master beforehand.
+- Check **Added tests?** honestly — if no, state why they aren't needed.
+- Check **Added to documentation?** for each box that applies: `README.md`, the [API changelog](CONTRIBUTING.md#api-changelog) (`src/main/javadoc/overview.html`), the separate [gephi-documentation](https://github.com/gephi/gephi-documentation) repo, and inline code documentation.
+
+## Releases
+
+Releasing Gephi is almost entirely automated through GitHub Actions. The only manual steps are:
+
+1. Change the version in the `pom.xml` files, including moving from a snapshot version to a non-snapshot version when creating a final release.
+2. Create the release on GitHub.
+
+Everything else in the release process is automated.
+
+### Release branches
+
+A release branch, such as `0.9.7`, uses the **release** GitHub Actions workflow, which:
+
+- Builds Gephi.
+- Runs all tests.
+- Produces release artifacts.
+- Deploys the artifacts to Maven Central.
+- Updates the NetBeans AutoUpdate site.
+
+The build-and-test portion overlaps with the normal master and pull-request workflow; artifact production and AutoUpdate-site updates are release-specific.
+
+### Development and final releases
+
+Development and final releases use the same release process. The Maven version determines which type is produced:
+
+- A version ending in `-SNAPSHOT` is a development release. Development releases can be produced repeatedly; their incremented build identifiers provide the latest binaries.
+- A version without `-SNAPSHOT` is a final release. A final release cannot be overwritten — after publishing `0.9.7`, another final release must use a new version such as `0.9.8`.
+
+A commit to a release branch whose POM files do not contain `-SNAPSHOT` triggers publication of the final version.
+
+### Artifacts and AutoUpdate
+
+The release workflow publishes all Gephi artifacts to Maven Central. These include:
+
+- Each module's JAR.
+- Each module's NBM, the NetBeans module file format.
+- Application binaries for Linux, Windows, macOS, and the other supported OS and architecture combinations.
+
+**Publishing is a single merged bundle, not five independent uploads.** Each matrix job stages its artifacts locally instead of publishing them directly; a separate `publish-central` job then downloads every job's staged output, merges it into one bundle, and uploads that as a single unit. This isn't an arbitrary design choice — Maven Central's Publisher Portal requires one atomic upload per component version, so the matrix jobs can't each publish on their own.
+
+The AutoUpdate site is also updated. Gephi queries an XML file hosted on the project's GitHub Pages site, which lists all required modules and their current versions. The release workflow updates the XML and module paths so an older Gephi installation can detect a newer version and prompt the user to update without reinstalling the application. Commits that update the AutoUpdate site are produced by GitHub Actions.
+
+The AutoUpdate URLs themselves are injected into `DesktopBranding`'s `layer.xml` via Maven resource filtering at build time — see the exclusion comment in `modules/DesktopBranding/pom.xml`, added after a `maven-resources-plugin` regression once silently overwrote the filtered file with unfiltered placeholder URLs, with no build failure. If you touch that module's resource or build configuration, double-check the built `layer.xml` still contains real URLs.
+
+### Matrix build
+
+The release uses a matrix build with one job for each supported operating-system and architecture combination — currently five: Linux x64, Linux aarch64, Windows x64, macOS x64, and macOS aarch64. Additional combinations can be added as operating systems and architectures develop.
+
+Release builds run without Maven's `-T 4` parallel-build flag used elsewhere in this guide — parallel builds proved unreliable for release deploys, so the release workflow builds single-threaded.
+
+### Embedded JRE
+
+Each OS and architecture artifact embeds a JRE. The release workflow downloads the corresponding current JRE from trusted sources and packages it into the binary. For example, a 64-bit Windows artifact receives the appropriate Windows JRE. Users therefore do not need to install Java before running Gephi.
+
+### macOS
+
+The macOS workflow performs additional security steps:
+
+- Code signing
+- App notarization
+
+App notarization sends the final binary to Apple for verification. The workflow waits up to 15 minutes for the result (configurable via the `gephi.apple.notarization.timeout` property). When verification succeeds, macOS Gatekeeper allows Gephi to run without warning that it may be spyware. These steps are automated in the release process.
+
+### Windows
+
+The Windows workflow creates an installer using Inno Setup, a popular open-source installer platform. The repository contains an installer-configuration file that can be modified. The release workflow runs Inno Setup and produces the final installer.
+
+The Windows binary is code-signed via eSigner, a cloud HSM service authenticated with a username, password, and TOTP secret, rather than a locally-held PFX certificate — a change made when the certificate-based approach became impractical to maintain in CI.
+
+### Lessons from past releases
+
+A few things learned from recent releases (0.11.0 through 0.11.2) are worth keeping in mind:
+
+- **Sanity-check the flattened POM before tagging.** 0.11.0 needed an emergency same-day patch (0.11.1) because the flattened POM produced for release was missing required descriptors — `groupId`, license, SCM, and developer metadata — that only get validated at actual release/publish time, not during a normal `mvn install`. If you change anything around POM structure or the `application` module's packaging, test it against a release-shaped build first.
+- **Budget for a stabilization patch about a week out.** 0.11.2 shipped a week after 0.11.0/0.11.1 with over a dozen crash fixes, each referencing a Sentry issue that only surfaced once the release reached a wide user base. Watch Sentry closely in the days following a release rather than treating post-release crash reports as exceptional.
+- **Release scripts run on Linux, macOS, and Windows runners — keep shell code portable.** A GNU-only `grep -oP` in a release-summary step worked on Linux but silently broke on macOS's BSD `grep`; it was replaced with `sed`. Avoid GNU-only flags in anything under `.github/workflows/release/`.
+- **The workflow branch triggers are hardcoded, not pattern-based.** `release.yml` only runs on an explicit `branches:` allow-list (currently just `0.11.3`), while `build.yml` excludes those same release branches via `branches-ignore:` so they aren't built twice. Both lists need updating by hand — add the new branch to `release.yml` and to `build.yml`'s ignore list when starting a release, and prune old entries once a branch is no longer active.
+
+## Compatibility expectations
+
+Gephi uses semantic versioning for API changes:
+
+- **Patch (`0.11.x`)**: minimal API changes; a method may be added.
+- **Minor (`0.x.x`)**: API additions and occasional compatibility breaks when necessary, especially for APIs under development.
+- **Major (`x.x.x`)**: APIs may be rewritten from scratch with major changes.
+
+The intended direction is to:
+
+- keep each feature's API clean, stable, and documented;
+- allow implementations to be replaced;
+- add new features through plugins;
+- keep core functionality usable without the UI;
+- keep modules reusable by other projects through Maven Central.
+
+## Further reading
+
+### NetBeans Platform
+
+- NetBeans APIs Documentation
+- Source code
+- FAQ
+- Documentation
+- Tutorials
+- API versus SPI: <https://netbeans.apache.org/wiki/DevFaqApiSpi.asciidoc>
+- Lookup: <https://netbeans.apache.org/wiki/DevFaqLookup.asciidoc>
+
+### Conventions and examples
+
+- Code Style
+- Localization
+- Documentation
+- Coding via examples
+- Plugins Bootcamp
+- Toolkit Demos
+
+### API design
+
+- [*Practical API Design: Confessions of a Java Framework Architect*](https://wiki.apidesign.org/wiki/TheAPIBook)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Gephi
 
-This guide covers setting up a development environment, building and running Gephi locally, finding your way around the codebase, and the pull-request and release workflows.
+This guide covers setting up a development environment, building and running Gephi locally, and the pull-request and release workflows. For how the codebase itself is organized — modules, APIs and SPIs, the Lookup pattern, controllers and models — see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Development environment
 
@@ -56,90 +56,7 @@ Rebuilding the changed module writes or overwrites its local JAR in the Maven lo
 
 When uncertain, rebuild the entire repository with `mvn -T 4 clean install`. This is slower but ensures everything is current.
 
-## Understanding the codebase
-
-Gephi is split into 66 modules, per the root `pom.xml`'s `<modules>` list (not counting the `application` module itself). Module dependencies form a tree, and circular dependencies are not allowed — this is what allows Maven to build independent parts in parallel.
-
-Core modules are separated from user-interface modules so that core functionality can be used by command-line tools and libraries without UI dependencies. A plugin is also a module: APIs expose functionality to other modules, SPIs are extension points, and plugins extend SPIs.
-
-**Core graph structure is developed in a separate repository.** `modules/GraphAPI` here is only a thin NetBeans-module wrapper around the `graphstore` library (a Maven dependency, see `graphstore.version` in the root `pom.xml`). The actual graph/node/edge data structure lives in [github.com/gephi/graphstore](https://github.com/gephi/graphstore) — changes to the core graph structure itself (storage, indexing, node/edge/column implementation) should be made there, not in this repo.
-
-### Repository layout
-
-The repository ([github.com/gephi/gephi](https://github.com/gephi/gephi)) is organized as follows:
-
-```text
-.github/
-└── workflows/       # GitHub Actions workflows
-modules/
-├── application/     # Gephi application module (built last, depends on all others)
-└── ...              # Source code for the other 66 modules
-src/                  # Extra files, including the macOS launcher
-pom.xml               # Parent POM containing shared configuration
-```
-
-The root `pom.xml` is the parent POM for the multi-module Maven project. Shared dependency versions and build configuration are kept there whenever possible; each module inherits this configuration by declaring the root POM as its parent. Configuration may be placed in a module's own POM when it is highly specific, but this is uncommon.
-
-The application module contains mostly application configuration, including branding, version, and installer configuration. It depends on all other modules.
-
-### Module structure
-
-A module follows Maven conventions:
-
-```text
-ModuleName/
-├── src/
-│   ├── main/
-│   │   ├── java/          # Sources
-│   │   ├── nbm/
-│   │   └── resources/     # Bundles, localization files, other files, icons, and images
-│   └── test/
-│       └── java/          # Test sources
-└── pom.xml                # Dependencies, public packages, and extra configuration
-```
-
-Each module's `pom.xml` declares its dependencies and public packages. Dependencies are standard Maven dependencies. Public packages define what other modules can access; implementation packages remain hidden.
-
-### Module names
-
-Most modules follow these roles:
-
-| Module pattern | Role | Count among the 66 modules |
-|---|---|---:|
-| `ImportAPI` | Defines APIs and SPIs and implements APIs | 17 |
-| `ImportPlugin` | SPI implementations | 11 |
-| `ImportPluginUI` | UI-only SPI implementations | 6 |
-| `DesktopImport` | Remaining UI code | 17 |
-
-Together, 51 of the 66 modules follow this convention. The same pattern is used in other areas, including Layout, Preview, and Statistics. The remaining modules cover other functionality, such as the welcome screen (`WelcomeScreen`) and settings migration between versions (`SettingsUpgrader`).
-
-### Package names
-
-Use the existing package conventions:
-
-| Role | Package convention |
-|---|---|
-| API | `org.gephi.NAME.api` |
-| API implementation | `org.gephi.NAME` |
-| SPI | `org.gephi.NAME.spi` |
-| SPI implementation | `org.gephi.NAME.plugin` |
-| SPI implementation, UI only | `org.gephi.ui.NAME.plugin` |
-| UI | `org.gephi.desktop.NAME` |
-
-### APIs, SPIs, and public packages
-
-APIs and SPIs are plain Java interfaces.
-
-- APIs offer functionality to other modules.
-- SPIs are meant to be extended.
-- Plugins always extend an SPI.
-- APIs and SPIs should be clearly documented.
-- API and SPI changes are recorded in the Javadoc overview page (see [API changelog](#api-changelog) below).
-- Most APIs aim to remain backward compatible; some may be marked under development while their contracts are refined.
-
-Only packages declared public in a module's `pom.xml` are accessible to other modules. API and implementation code may be in the same module, but implementation packages must remain hidden so consumers do not depend on details that may later be replaced.
-
-### API changelog
+## API changelog
 
 Every public API/SPI change is recorded in `src/main/javadoc/overview.html`, under the `<h2>API Changes</h2>` section. This file is the source used to compile release notes, so new entries must follow its existing formatting convention exactly:
 
@@ -148,56 +65,6 @@ Every public API/SPI change is recorded in `src/main/javadoc/overview.html`, und
 - Each change is one `<li>` in that API's `<ul>`, written as a short, self-contained sentence describing what changed and why it matters to a consumer, with identifiers wrapped in `<code>` tags (e.g. `Addition of <code>newWorkspace()</code> in <code>ProjectController</code>...`).
 - Don't use the older `(Month DD YYYY)`-prefixed, undifferentiated-by-API list style — that's the legacy format used only in the `<h3>Archive</h3>` section at the bottom, kept for history and not a pattern to extend.
 - If an API's stability changes (e.g. goes from under development to stable, or gets deprecated), update its `<span class="unstable">`/`<span class="deprecated">` marking in the `<h2>API List</h2>` section at the bottom of the same file.
-
-### Adding an extension
-
-Implement the appropriate SPI and register the implementation with the NetBeans service-provider annotation:
-
-```java
-@ServiceProvider(service = Renderer.class)
-public class NodeRenderer implements Renderer {
-}
-```
-
-Lookup discovers registered implementations at runtime:
-
-```java
-for (Renderer renderer : Lookup.getDefault().lookupAll(Renderer.class)) {
-}
-```
-
-Without the service-provider annotation, `lookupAll` will not discover the implementation.
-
-The available extension categories are:
-
-| SPI | Extension point |
-|---|---|
-| Import SPI | File, database, and wizard importers |
-| Layout SPI | Layout algorithms |
-| Statistics SPI | Other algorithms |
-| Tools SPI | Tools in the menu bar |
-| Project SPI | Persistence providers |
-| Export SPI | File exporters for graphs and graphics |
-| Filters SPI | Filters |
-| Preview SPI | Preview builders and renderers |
-| Generator SPI | Generators, similar to importers |
-| Data Laboratory SPI | Manipulators |
-| Appearance SPI | Transformers for ranking and partitioning |
-| Visualization SPI | Renderers for the future visualization engine |
-
-Some SPIs have UI components. Keep those implementations in a plugin UI module rather than a core plugin module. For example, the CSV spreadsheet-import wizard implements a UI SPI and belongs in the import plugin UI module. Remaining UI such as the post-import report panel belongs in a desktop module.
-
-### Controllers and models
-
-Controllers are singleton services obtained through Lookup:
-
-```java
-ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-```
-
-Use controllers as the entry point for executing module functionality and altering models. Controllers contain setters and retrieve models.
-
-Models contain state and data and expose getters. There is one model of each relevant kind per workspace. Models also supply state to persistence providers for serialization into and restoration from `.gephi` project files.
 
 ## Branch and pull-request workflow
 
@@ -236,7 +103,7 @@ Everything else in the release process is automated.
 
 ### Release branches
 
-A release branch, such as `0.9.7`, uses the **release** GitHub Actions workflow, which:
+A release branch, such as `0.11.2`, uses the **release** GitHub Actions workflow, which:
 
 - Builds Gephi.
 - Runs all tests.
@@ -293,52 +160,6 @@ App notarization sends the final binary to Apple for verification. The workflow 
 The Windows workflow creates an installer using Inno Setup, a popular open-source installer platform. The repository contains an installer-configuration file that can be modified. The release workflow runs Inno Setup and produces the final installer.
 
 The Windows binary is code-signed via eSigner, a cloud HSM service authenticated with a username, password, and TOTP secret, rather than a locally-held PFX certificate — a change made when the certificate-based approach became impractical to maintain in CI.
-
-### Lessons from past releases
-
-A few things learned from recent releases (0.11.0 through 0.11.2) are worth keeping in mind:
-
-- **Sanity-check the flattened POM before tagging.** 0.11.0 needed an emergency same-day patch (0.11.1) because the flattened POM produced for release was missing required descriptors — `groupId`, license, SCM, and developer metadata — that only get validated at actual release/publish time, not during a normal `mvn install`. If you change anything around POM structure or the `application` module's packaging, test it against a release-shaped build first.
-- **Budget for a stabilization patch about a week out.** 0.11.2 shipped a week after 0.11.0/0.11.1 with over a dozen crash fixes, each referencing a Sentry issue that only surfaced once the release reached a wide user base. Watch Sentry closely in the days following a release rather than treating post-release crash reports as exceptional.
-- **Release scripts run on Linux, macOS, and Windows runners — keep shell code portable.** A GNU-only `grep -oP` in a release-summary step worked on Linux but silently broke on macOS's BSD `grep`; it was replaced with `sed`. Avoid GNU-only flags in anything under `.github/workflows/release/`.
-- **The workflow branch triggers are hardcoded, not pattern-based.** `release.yml` only runs on an explicit `branches:` allow-list (currently just `0.11.3`), while `build.yml` excludes those same release branches via `branches-ignore:` so they aren't built twice. Both lists need updating by hand — add the new branch to `release.yml` and to `build.yml`'s ignore list when starting a release, and prune old entries once a branch is no longer active.
-
-## Compatibility expectations
-
-Gephi uses semantic versioning for API changes:
-
-- **Patch (`0.11.x`)**: minimal API changes; a method may be added.
-- **Minor (`0.x.x`)**: API additions and occasional compatibility breaks when necessary, especially for APIs under development.
-- **Major (`x.x.x`)**: APIs may be rewritten from scratch with major changes.
-
-The intended direction is to:
-
-- keep each feature's API clean, stable, and documented;
-- allow implementations to be replaced;
-- add new features through plugins;
-- keep core functionality usable without the UI;
-- keep modules reusable by other projects through Maven Central.
-
-## Further reading
-
-### NetBeans Platform
-
-- NetBeans APIs Documentation
-- Source code
-- FAQ
-- Documentation
-- Tutorials
-- API versus SPI: <https://netbeans.apache.org/wiki/DevFaqApiSpi.asciidoc>
-- Lookup: <https://netbeans.apache.org/wiki/DevFaqLookup.asciidoc>
-
-### Conventions and examples
-
-- Code Style
-- Localization
-- Documentation
-- Coding via examples
-- Plugins Bootcamp
-- Toolkit Demos
 
 ### API design
 


### PR DESCRIPTION
## Description

Adds contributor-facing documentation and vendor-neutral AI-agent tooling, none of which touches product code:

- **ARCHITECTURE.md** and **CONTRIBUTING.md**: compiled from a 2022 maintainer deep-dive presentation, fact-checked and corrected against the current `pom.xml`/CI config (JDK version, module counts, the `graphstore` split, release pipeline behavior). CONTRIBUTING.md also documents the `mvn` CLI build/test commands (verified locally — `mvn -T 4 --batch-mode -Djava.awt.headless=true verify -P enableCheckStyle` passes, 76/76 modules), the API-changelog convention for `src/main/javadoc/overview.html`, the PR-template convention, and lessons mined from the 0.11.0–0.11.2 release cycle. Duplicated content between the two files was removed in favor of cross-references.
- **AGENTS.md**: root-level, vendor-neutral instructions read natively by Codex, Cursor, and other AI coding tools; points to ARCHITECTURE.md/CONTRIBUTING.md rather than restating them.
- **.claude/CLAUDE.md**: Claude Code entry point that imports AGENTS.md.
- **.claude/skills/sentry-triage/**: a read-only Agent Skill for triaging Gephi's Sentry backlog into a prioritized report (never edits code).
- **.gitignore**: scoped so personal/local AI-tool config (`.claude/settings.json`, `.claude/settings.local.json`, `.mcp.json`) stays untracked, while `.claude/CLAUDE.md` and `.claude/skills/` are shared.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren't needed

This PR *is* the documentation update (ARCHITECTURE.md/CONTRIBUTING.md/AGENTS.md); README.md and the API changelog didn't need changes for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)