### PR TITLE
Guard against a Swing NPE race when NEWT canvas focus closes an open popup menu

### DIFF
--- a/modules/VisualizationEngine/src/main/java/com/jogamp/newt/awt/NewtCanvasAWT.java
+++ b/modules/VisualizationEngine/src/main/java/com/jogamp/newt/awt/NewtCanvasAWT.java
@@ -287,9 +287,12 @@ public class NewtCanvasAWT extends java.awt.Canvas
     private final Runnable awtClearSelectedMenuPath = new Runnable() {
         @Override
         public void run() {
-            final MenuSelectionManager msm = MenuSelectionManager.defaultManager();
-            if (msm.getSelectedPath().length > 0) {
-                msm.clearSelectedPath();
+            try {
+                MenuSelectionManager.defaultManager().clearSelectedPath();
+            } catch (final NullPointerException npe) {
+                // Benign JDK race: clearSelectedPath() can re-enter a JPopupMenu that is
+                // already mid-close (setVisible -> Popup.hide()) and find its internal
+                // Popup reference already null. The menu is closing either way.
             }
         }
     };

--- a/modules/VisualizationEngine/src/main/java/com/jogamp/newt/awt/NewtCanvasAWT.java
+++ b/modules/VisualizationEngine/src/main/java/com/jogamp/newt/awt/NewtCanvasAWT.java
@@ -287,7 +287,10 @@ public class NewtCanvasAWT extends java.awt.Canvas
     private final Runnable awtClearSelectedMenuPath = new Runnable() {
         @Override
         public void run() {
-            MenuSelectionManager.defaultManager().clearSelectedPath();
+            final MenuSelectionManager msm = MenuSelectionManager.defaultManager();
+            if (msm.getSelectedPath().length > 0) {
+                msm.clearSelectedPath();
+            }
         }
     };
     private final WindowListener clearAWTMenusOnNewtFocus = new WindowAdapter() {


### PR DESCRIPTION
## Description

Gephi vendors a patched copy of JogAmp's `NewtCanvasAWT` (`modules/VisualizationEngine/src/main/java/com/jogamp/newt/awt/NewtCanvasAWT.java`) to work around a macOS focus deadlock. As part of that patch, `windowGainedFocus()` (line ~304) schedules `awtClearSelectedMenuPath`, which calls `MenuSelectionManager.defaultManager().clearSelectedPath()` every time the OpenGL graph-view canvas regains AWT focus, to force any open AWT menu closed when native/NEWT focus takes over.

The graph view frequently regains focus right after a user dismisses a `JPopupMenu` (e.g. a right-click context menu on the graph canvas). If that popup is still mid-close at the exact moment focus returns, `clearSelectedPath()` re-enters `JPopupMenu`'s `menuSelectionChanged`/`setSelectedPath` machinery while it's already tearing itself down. That hits a known JDK Swing race where the popup's internal `Popup` reference has already been nulled out, and the re-entrant call throws an NPE inside JDK Swing code (`Popup.hide()`).

**Note on this PR's history:** an earlier revision guarded the call with `if (getSelectedPath().length > 0)`. That guard turned out to be a no-op: `MenuSelectionManager.clearSelectedPath()` already checks `selection.size() > 0` internally before doing anything, and the crash only happens when a path *is* selected (that's precisely the case where a popup is open and closing) — so the guard was always true exactly when the crash could occur, and never prevented the reentrant call. Caught during review before merge; this revision replaces it with a `try/catch` around the call that swallows this one specific, known-benign NPE, which does actually stop the crash while leaving every other code path (and every other exception) untouched.

Sentry: https://gephi.sentry.io/issues/GEPHI-5BR (110 users / 175 events)

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

This guards a JDK-internal Swing re-entrancy race that only manifests with real AWT/NEWT native windowing and precise timing between popup teardown and focus events. It isn't reasonably reproducible in this module's existing unit test setup (a single plain `ArrayUtilsTest`, no AWT/Swing test harness), so no deterministic regression test was added; the change itself is a narrow, easily-reviewed guard.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 API Changes
- [ ] 👍 Additional documentation in docs
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed
