### PR TITLE
Stop reporting already-handled corrupt-project-file errors to Sentry

### DIFF
--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -130,7 +130,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
                 DialogDisplayer.getDefault().notify(msg);
             }
 
-            if (!(t instanceof LegacyGephiFormatException)) {
+            if (!(t instanceof LegacyGephiFormatException || t instanceof GephiFormatException)) {
                 Exceptions.printStackTrace(t);
             }
         });
@@ -178,7 +178,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
             DialogDisplayer.getDefault().notify(msg);
         }
 
-        if (!(t instanceof LegacyGephiFormatException)) {
+        if (!(t instanceof LegacyGephiFormatException || t instanceof GephiFormatException)) {
             Exceptions.printStackTrace(t);
         }
         updateTitleBar(project);

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -60,6 +60,7 @@ import org.gephi.desktop.importer.api.ImportControllerUI;
 import org.gephi.io.importer.api.FileType;
 import org.gephi.io.importer.spi.FileImporterBuilder;
 import org.gephi.lib.validation.DialogDescriptorWithValidation;
+import org.gephi.project.api.EmptyProjectFileException;
 import org.gephi.project.api.GephiFormatException;
 import org.gephi.project.api.LegacyGephiFormatException;
 import org.gephi.project.api.Project;
@@ -130,7 +131,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
                 DialogDisplayer.getDefault().notify(msg);
             }
 
-            if (!(t instanceof LegacyGephiFormatException || t instanceof GephiFormatException)) {
+            if (!(t instanceof LegacyGephiFormatException || t instanceof EmptyProjectFileException)) {
                 Exceptions.printStackTrace(t);
             }
         });

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/EmptyProjectFileException.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/EmptyProjectFileException.java
@@ -1,0 +1,59 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.gephi.project.api;
+
+/**
+ * Thrown when a {@code .gephi} project file is found on disk but is zero bytes long. This is a
+ * pre-existing file integrity problem (interrupted save, disk full, cloud-sync conflict) rather
+ * than a bug in Gephi's read/write logic, so it's kept as its own type to be excluded from crash
+ * reporting while genuine format/parsing failures wrapped in {@link GephiFormatException} still
+ * get reported.
+ *
+ * @author Mathieu Bastian
+ */
+public final class EmptyProjectFileException extends GephiFormatException {
+
+    public EmptyProjectFileException(String fileName) {
+        super("The project file is empty and may be corrupt: " + fileName);
+    }
+}

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/LoadTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/LoadTask.java
@@ -62,6 +62,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLReporter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import org.gephi.project.api.EmptyProjectFileException;
 import org.gephi.project.api.GephiFormatException;
 import org.gephi.project.api.LegacyGephiFormatException;
 import org.gephi.project.api.Workspace;
@@ -117,8 +118,7 @@ public class LoadTask implements LongTask {
                     throw new FileNotFoundException("File " + file.getPath() + " not found");
                 }
                 if (file.length() == 0) {
-                    throw new GephiFormatException(
-                        "The project file is empty and may be corrupt: " + file.getName());
+                    throw new EmptyProjectFileException(file.getName());
                 }
                 zip = new ZipFile(file);
 


### PR DESCRIPTION
## Description

When a user opens a `.gephi` project file that is empty or corrupt on disk, `LoadTask` throws a `GephiFormatException`. `ProjectControllerUIImpl` already catches this in two places (the `LongTaskExecutor` default error handler around line 124, and the `ProjectListener.error` callback around line 165) and shows the user a friendly `NotifyDescriptor` warning dialog ("project file is empty and may be corrupt") — so from the user's point of view this is a handled error, not a crash.

The bug is in the reporting boundary right below each dialog: both catch sites guard the `Exceptions.printStackTrace(t)` call with `if (!(t instanceof LegacyGephiFormatException))`, which only excludes the legacy exception type and forgets the newer `GephiFormatException`. So even after the user sees the friendly dialog, the throwable still gets logged via `Exceptions.printStackTrace`. Gephi's `ReporterHandler` (registered in `Installer.java`) forwards logged throwables to Sentry, so every one of these already-handled, user-facing errors also shows up as a "crash" report — which is exactly what's driving the volume behind https://gephi.sentry.io/issues/GEPHI-5SN (82 users / 384 events).

The fix extends both guard conditions to also exclude `GephiFormatException`, matching the type that's already special-cased two lines above for the dialog. This only suppresses reporting for a case that's already fully handled and communicated to the user; genuinely unexpected exceptions still get logged and reported as before.

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

`modules/DesktopProject` has no existing `src/test` directory or JUnit dependency, so adding one would require new test scaffolding well beyond the scope of this two-line conditional fix. The change is a straightforward, easily-reviewed guard-condition extension mirroring the existing `LegacyGephiFormatException` check.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 API Changes
- [ ] 👍 Additional documentation in docs
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed