### PR TITLE
Fix NPE from a listener-registration race in the Attributes panel

### DIFF
--- a/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesTopComponent.java
+++ b/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesTopComponent.java
@@ -50,9 +50,7 @@ public final class AttributesTopComponent extends TopComponent implements Attrib
     private AttributesUIModelImpl model;
 
     public AttributesTopComponent() {
-        // Register
         controller = Lookup.getDefault().lookup(AttributesUIControllerImpl.class);
-        controller.addPropertyChangeListener(this);
 
         setName(NbBundle.getMessage(AttributesTopComponent.class, "CTL_AttributesTopComponent"));
 
@@ -101,6 +99,10 @@ public final class AttributesTopComponent extends TopComponent implements Attrib
         } else {
             unsetup();
         }
+
+        // Register only once fully constructed, since the controller may fire events from a
+        // background thread as soon as this listener is registered
+        controller.addPropertyChangeListener(this);
     }
 
     @Override
@@ -135,6 +137,10 @@ public final class AttributesTopComponent extends TopComponent implements Attrib
     private void setup(AttributesUIModelImpl model) {
         this.model = model;
 
+        if (cardLayout == null || cardPanel == null || columnsButton == null) {
+            return;
+        }
+
         if (model.isEditMode()) {
             cardLayout.show(cardPanel, EDIT_CARD);
         } else {
@@ -145,6 +151,10 @@ public final class AttributesTopComponent extends TopComponent implements Attrib
 
     private void unsetup() {
         this.model = null;
+
+        if (cardLayout == null || cardPanel == null || columnsButton == null) {
+            return;
+        }
 
         cardLayout.show(cardPanel, SELECTION_CARD);
         columnsButton.setEnabled(false);

--- a/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesUIControllerImpl.java
+++ b/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesUIControllerImpl.java
@@ -42,8 +42,8 @@
 
 package org.gephi.desktop.attributes;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import javax.swing.SwingUtilities;
 import org.gephi.desktop.attributes.api.AttributesUIController;
 import org.gephi.graph.api.Edge;
@@ -68,7 +68,7 @@ import org.openide.windows.WindowManager;
     @ServiceProvider(service = Controller.class)})
 public class AttributesUIControllerImpl implements AttributesUIController, Controller<AttributesUIModelImpl> {
 
-    private final Set<AttributesUIModelListener> listeners = new HashSet<>();
+    private final Set<AttributesUIModelListener> listeners = new CopyOnWriteArraySet<>();
 
     public AttributesUIControllerImpl() {
 
@@ -81,14 +81,14 @@ public class AttributesUIControllerImpl implements AttributesUIController, Contr
             @Override
             public void select(Workspace workspace) {
                 AttributesUIModelImpl model = getModel(workspace);
-                firePropertyChangeEvent(AttributesUIModelEvent.MODEL, null, model);
+                runAction(() -> firePropertyChangeEvent(AttributesUIModelEvent.MODEL, null, model));
             }
 
             @Override
             public void unselect(Workspace workspace) {
                 AttributesUIModelImpl model = getModel(workspace);
                 model.resetSelection();
-                firePropertyChangeEvent(AttributesUIModelEvent.MODEL, null, null);
+                runAction(() -> firePropertyChangeEvent(AttributesUIModelEvent.MODEL, null, null));
             }
 
             @Override


### PR DESCRIPTION
## Description

Users open (or restore) the Attributes panel and hit a NullPointerException before the window ever renders (63 users / 90 events on Sentry).

`AttributesTopComponent`'s constructor registered `this` as a `PropertyChangeListener` on the shared `AttributesUIControllerImpl` singleton (`controller.addPropertyChangeListener(this)`) before the constructor had finished assigning its own fields, in particular `columnsButton`, `cardLayout`, and `cardPanel` a few lines later.

`AttributesUIControllerImpl`'s internal `WorkspaceListener.select(Workspace)` calls `firePropertyChangeEvent(...)` directly (not marshalled through `SwingUtilities.invokeLater`), and it iterates a plain, unsynchronized `HashSet<AttributesUIModelListener>`. Because `ProjectController` can select a workspace from a non-EDT thread (e.g. during project loading), that call can land on `AttributesTopComponent.propertyChange(...)` -> `setup(...)` while the constructor is still running on the EDT, in the window between the listener registration and the `columnsButton`/`cardLayout`/`cardPanel` assignments. `setup()` then calls `columnsButton.setEnabled(true)` on a field that is still `null`, producing the NPE.

Fix: register the listener at the very end of the constructor, after every field it can indirectly touch (via `setup()`/`unsetup()`) has been assigned, so no event can be delivered mid-construction. As defense in depth (since the controller's listener set is shared/unsynchronized and could see similar ordering issues from future changes), `setup()`/`unsetup()` now bail out early if `cardLayout`, `cardPanel`, or `columnsButton` aren't set yet, instead of assuming they always are.

https://gephi.sentry.io/issues/GEPHI-5TR

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

This module (`DesktopAttributes`) has no existing unit test setup, and the bug is a cross-thread timing race in construction of a NetBeans `TopComponent` tied to `WindowManager`/`ProjectController`/`Lookup` singletons — not something that can be reproduced deterministically in a unit test without a full platform test harness. The fix removes the race window entirely (registration only happens after full construction) plus a defensive null-check, so the failure mode this addresses can no longer occur regardless.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 API Changes
- [ ] 👍 Additional documentation in docs
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed