### PR TITLE
Fix infinite logging recursion in Gephi's output handler

### DIFF
--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/Installer.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/Installer.java
@@ -381,11 +381,12 @@ public class Installer extends ModuleInstall {
         Logger.getLogger("").addHandler(new OutputHandler());
     }
 
-    private static class OutputHandler extends Handler {
+    static class OutputHandler extends Handler {
 
         private final InputOutput io;
         private final OutputWriter outputWriter;
         private final MsgFormatter formatter;
+        private final ThreadLocal<Boolean> publishing = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
         public OutputHandler() {
             io = IOProvider.getDefault().getIO("Log", true);
@@ -401,6 +402,21 @@ public class Installer extends ModuleInstall {
                 return;
             }
 
+            if (publishing.get()) {
+                //Avoid infinite recursion when writing to the output document
+                //itself triggers a log record (e.g. NetBeans output window
+                //trimming its buffer)
+                return;
+            }
+            publishing.set(Boolean.TRUE);
+            try {
+                doPublish(record);
+            } finally {
+                publishing.set(Boolean.FALSE);
+            }
+        }
+
+        void doPublish(LogRecord record) {
             Color color = Color.BLACK;
             if (record.getLevel().equals(Level.WARNING)) {
                 color = Color.ORANGE;

--- a/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/OutputHandlerTest.java
+++ b/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/OutputHandlerTest.java
@@ -1,0 +1,29 @@
+package org.gephi.branding.desktop;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OutputHandlerTest {
+
+    @Test
+    public void testReentrantPublishIsIgnored() {
+        AtomicInteger callCount = new AtomicInteger();
+        Installer.OutputHandler handler = new Installer.OutputHandler() {
+            @Override
+            void doPublish(LogRecord record) {
+                callCount.incrementAndGet();
+                //Simulate the output write triggering a new log record on the
+                //same thread, as happens with NetBeans' output window
+                //bookkeeping (e.g. AbstractLines.checkLimits())
+                publish(record);
+            }
+        };
+
+        handler.publish(new LogRecord(Level.INFO, "test message"));
+
+        Assert.assertEquals(1, callCount.get());
+    }
+}


### PR DESCRIPTION
## Description

Sentry recorded 787 crashes across 52 users where the Gephi desktop app dies with a `StackOverflowError` originating from `Installer$OutputHandler.publish`.

`Installer.installOutputLogger()` (modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/Installer.java:380-381) attaches `OutputHandler` to the **root** `java.util.logging.Logger`, so it receives every log record produced anywhere in the JVM, including records logged internally by the NetBeans platform itself. NetBeans' output window implementation (`org.netbeans.core.output2.AbstractLines`) logs an INFO message ("Removing old lines...") whenever a pane's line/char limit is exceeded, and it does so from inside the very `OutWriter.print()` call that writes a line into the pane.

`OutputHandler.publish()` (previously lines 397-421) formats the incoming record and writes it straight into that same output document via `IOColorLines.println`/`outputWriter.println`. Once the "Log" output pane accumulates enough lines to hit NetBeans' limit, that write triggers `checkLimits()`, which logs its own INFO record, which routes back through the root logger into `OutputHandler.publish()`, which writes into the document again, re-triggering `checkLimits()` — an unbounded, purely synchronous recursion on the same thread until the stack overflows.

The fix adds a thread-local reentrancy guard around the body of `publish()`: while a thread is already inside `publish()`, any nested call it triggers (directly or transitively) short-circuits instead of writing to the output document again. This targets the actual failure mode (recursive re-entry into the handler) rather than special-casing the one logger name currently known to trigger it, so it also protects against similar recursion from other NetBeans (or third-party) loggers in the future. The write logic itself is unchanged, just moved into a small `doPublish()` method so it can be exercised in isolation from a test.

Sentry issue: https://gephi.sentry.io/issues/GEPHI-5JP

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no, because they aren't needed