### PR TITLE
Preserve and surface the real cause of import file-open failures

### DIFF
--- a/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/DesktopImportControllerUI.java
+++ b/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/DesktopImportControllerUI.java
@@ -177,7 +177,12 @@ public class DesktopImportControllerUI implements ImportControllerUI {
 
             importFiles(readers, importers, fileObjects, null);
         } catch (IOException ex) {
-            throw new RuntimeException(ex);
+            String cause = ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage();
+            NotifyDescriptor.Message msg = new NotifyDescriptor.Message(
+                NbBundle.getMessage(getClass(), "DesktopImportControllerUI.error_file_open_failed", cause),
+                NotifyDescriptor.ERROR_MESSAGE);
+            DialogDisplayer.getDefault().notify(msg);
+            Exceptions.printStackTrace(ex);
         }
     }
 

--- a/modules/DesktopImport/src/main/resources/org/gephi/desktop/importer/Bundle.properties
+++ b/modules/DesktopImport/src/main/resources/org/gephi/desktop/importer/Bundle.properties
@@ -41,6 +41,7 @@ DesktopImportControllerUI.status.multiImportSuccess = {0} sources successfully i
 DesktopImportControllerUI.error_no_matching_file_importer = Impossible to find a compatible Importer.\nThe file format is not supported. Check file's extension.
 DesktopImportControllerUI.error_no_matching_stream_importer = Impossible to find a compatible Importer.\nThe stream is not supported.
 DesktopImportControllerUI.error_no_matching_db_importer = Impossible to find a compatible Importer.\nThe database is not supported.
+DesktopImportControllerUI.error_file_open_failed = Impossible to open the file.\n{0}
 
 DesktopImportControllerUI.file.ui.dialog.title = {0} settings
 DesktopImportControllerUI.wizard.ui.dialog.title = {0} settings

--- a/modules/ImportAPI/pom.xml
+++ b/modules/ImportAPI/pom.xml
@@ -56,6 +56,11 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-util-lookup</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportUtils.java
+++ b/modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportUtils.java
@@ -784,7 +784,7 @@ public final class ImportUtils {
         try {
             return getTextReader(fileObject.getInputStream());
         } catch (IOException ex) {
-            throw new IOException(NbBundle.getMessage(ImportUtils.class, "ImportUtils.error_file_not_found"));
+            throw new IOException(NbBundle.getMessage(ImportUtils.class, "ImportUtils.error_file_not_found"), ex);
         }
     }
 

--- a/modules/ImportAPI/src/test/java/org/gephi/io/importer/api/ImportUtilsTest.java
+++ b/modules/ImportAPI/src/test/java/org/gephi/io/importer/api/ImportUtilsTest.java
@@ -1,0 +1,26 @@
+package org.gephi.io.importer.api;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openide.filesystems.FileObject;
+
+public class ImportUtilsTest {
+
+    @Test
+    public void testGetTextReaderPreservesCauseOnFailure() throws IOException {
+        FileObject fileObject = Mockito.mock(FileObject.class);
+        FileNotFoundException originalException = new FileNotFoundException("permission denied");
+        Mockito.when(fileObject.getInputStream()).thenThrow(originalException);
+
+        try {
+            ImportUtils.getTextReader(fileObject);
+            Assert.fail("Expected an IOException to be thrown");
+        } catch (IOException ex) {
+            Assert.assertSame("the original IOException should be preserved as the cause", originalException,
+                ex.getCause());
+        }
+    }
+}


### PR DESCRIPTION
## Description

74 users / 301 events hit this: they pick a file from **File > Open** and Gephi silently does nothing — no error dialog, no report, just a swallowed crash.

The trigger is mundane: the file becomes unreadable between being selected and being opened (deleted, permission changed, exclusively locked by another process, or an unmaterialized cloud-sync placeholder such as OneDrive/Dropbox). `FileObject.getInputStream()` throws a real `FileNotFoundException`/`IOException` describing why. The problem is what Gephi does with that information.

`ImportUtils.getTextReader(FileObject)` (modules/ImportAPI/src/main/java/org/gephi/io/importer/api/ImportUtils.java:783-789) catches that exception and rethrows a **brand new** `IOException` with only a generic, translated message — dropping the original exception instead of chaining it as the cause:

```java
} catch (IOException ex) {
    throw new IOException(NbBundle.getMessage(ImportUtils.class, "ImportUtils.error_file_not_found"));
}
```

`DesktopImportControllerUI.importFiles()` (modules/DesktopImport/src/main/java/org/gephi/desktop/importer/DesktopImportControllerUI.java:172-180) calls `getTextReader`, catches that `IOException`, and wraps it again into an unchecked `RuntimeException`. This happens synchronously inside `OpenFile.actionPerformed()` on the EDT, and nothing up the call chain catches it, so it bottoms out in the AWT event thread's default uncaught-exception handler — no dialog is ever shown to the user, and the (already generic) cause is lost by the time it's logged.

The fix addresses both halves of the chain:
1. `ImportUtils.getTextReader` now chains the original exception (`new IOException(msg, ex)`), so the real cause survives and is available to anything downstream that logs or reports it.
2. `DesktopImportControllerUI.importFiles` catches the `IOException` and shows the user a `NotifyDescriptor` error dialog with the real underlying message, instead of throwing a `RuntimeException` that nobody handles.

This is a minimal, targeted fix: no behavior changes for the success path, and failures now surface exactly the OS-level reason (deleted/locked/permission-denied/etc.) to the user instead of disappearing.

Sentry issue: https://gephi.sentry.io/issues/GEPHI-53Z

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [x] 👍 yes

Added `ImportUtilsTest.testGetTextReaderPreservesCauseOnFailure`, which mocks a `FileObject` whose `getInputStream()` throws and asserts the original exception is chained as the cause of the rethrown `IOException`. The `DesktopImportControllerUI` dialog-display change isn't covered by a unit test since it requires NetBeans' `DialogDisplayer`/`Lookup` desktop runtime, which this module has no existing test harness for.

## Added to documentation?
- [x] 🙅 no, because they aren't needed