### PR TITLE
Fix ForceAtlas2 producing NaN coordinates for nodes with zero net displacement

### DIFF
--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
@@ -343,7 +343,7 @@ public class ForceAtlas2 implements Layout {
                         double factor = 0.1 * speed / (1f + Math.sqrt(speed * swinging));
 
                         double df = Math.sqrt(Math.pow(nLayout.dx, 2) + Math.pow(nLayout.dy, 2));
-                        factor = Math.min(factor * df, 10.) / df;
+                        factor = df == 0 ? 0 : Math.min(factor * df, 10.) / df;
 
                         double x = n.x() + nLayout.dx * factor;
                         double y = n.y() + nLayout.dy * factor;

--- a/modules/LayoutPlugin/src/test/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2Test.java
+++ b/modules/LayoutPlugin/src/test/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2Test.java
@@ -1,0 +1,98 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+ */
+package org.gephi.layout.plugin.forceAtlas2;
+
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.graph.api.Node;
+import org.gephi.graph.api.UndirectedGraph;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ForceAtlas2Test {
+
+    @Test
+    public void testAdjustSizesDoesNotProduceNaNForNodeWithZeroNetDisplacement() {
+        GraphModel graphModel = GraphModel.Factory.newInstance();
+        UndirectedGraph graph = graphModel.getUndirectedGraph();
+
+        Node nodeA = graphModel.factory().newNode("A");
+        nodeA.setX(10f);
+        nodeA.setY(0f);
+        nodeA.setSize(1f);
+        graph.addNode(nodeA);
+
+        Node nodeB = graphModel.factory().newNode("B");
+        nodeB.setX(-10f);
+        nodeB.setY(0f);
+        nodeB.setSize(1f);
+        graph.addNode(nodeB);
+
+        // Isolated node sitting exactly at the origin: repulsion from A and B
+        // cancels out by symmetry and gravity is zero at the origin, so its
+        // net displacement (dx, dy) is exactly (0, 0).
+        Node nodeC = graphModel.factory().newNode("C");
+        nodeC.setX(0f);
+        nodeC.setY(0f);
+        nodeC.setSize(1f);
+        graph.addNode(nodeC);
+
+        Edge edge = graphModel.factory().newEdge(nodeA, nodeB, false);
+        graph.addEdge(edge);
+
+        ForceAtlas2 layout = new ForceAtlas2(new ForceAtlas2Builder());
+        layout.setGraphModel(graphModel);
+        layout.resetPropertiesValues();
+        layout.setAdjustSizes(true);
+        layout.setBarnesHutOptimize(false);
+        layout.setThreadsCount(1);
+        layout.initAlgo();
+        try {
+            layout.goAlgo();
+        } finally {
+            layout.endAlgo();
+        }
+
+        Assert.assertFalse("Node C x should not be NaN", Float.isNaN(nodeC.x()));
+        Assert.assertFalse("Node C y should not be NaN", Float.isNaN(nodeC.y()));
+    }
+}

--- a/modules/LayoutPlugin/src/test/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2Test.java
+++ b/modules/LayoutPlugin/src/test/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2Test.java
@@ -39,6 +39,7 @@ Contributor(s):
 
 Portions Copyrighted 2011 Gephi Consortium.
  */
+
 package org.gephi.layout.plugin.forceAtlas2;
 
 import org.gephi.graph.api.Edge;


### PR DESCRIPTION
## Description

Users running the ForceAtlas2 layout with "Prevent Overlap" enabled would intermittently see the layout crash. This is the most-reported layout bug in Sentry (GEPHI-5KC: 119 users / 1176 events), with several duplicates surfacing through different code paths (GEPHI-5RY, GEPHI-5PG, GEPHI-5KW: 7 users / 97 events, GEPHI-5R2: 8 users / 49 events) — all the same underlying defect, just observed via different `NodeImpl` setters (`setX`, `setY`, `setPosition`).

**Mechanism**: in the anti-overlap branch of the position-update loop (`ForceAtlas2.java:332-354`), each node's per-step displacement is rescaled by a `factor` that is capped and then divided by `df`, the node's net force magnitude:

```java
double df = Math.sqrt(Math.pow(nLayout.dx, 2) + Math.pow(nLayout.dy, 2));
factor = Math.min(factor * df, 10.) / df;
```

There's no guard for `df == 0`. This happens whenever a node's net force is exactly zero in a given iteration — for example an isolated (degree-0) node sitting at a position where repulsion from the rest of the graph cancels out by symmetry and gravity vanishes (gravity is computed relative to the origin, so a node exactly at `(0,0)` receives no gravitational pull; see `ForceFactory.java`'s `apply(Node n, double g)`, which is a no-op when `distance == 0`). In that case `Math.min(0, 10.) / 0` evaluates to `0.0 / 0.0 = NaN`, which then flows into the new `x`/`y` and is rejected by `NodeImpl.setX`/`setY`/`setPosition` with `IllegalArgumentException`, crashing the layout mid-run.

**Fix**: guard the division so a node with zero net displacement simply gets a zero factor (it isn't moving anyway), mirroring the zero-guard pattern already used in this same file for inverted edge weights (`getEdgeWeight`: `w == 0 ? 0 : 1 / w`):

```java
factor = df == 0 ? 0 : Math.min(factor * df, 10.) / df;
```

This is the minimal correction: it only changes behavior for the previously-undefined `df == 0` case and leaves every other node's rescaling untouched.

Sentry issue: https://gephi.sentry.io/issues/GEPHI-5KC

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [x] 👍 yes

Added `ForceAtlas2Test` with a deterministic 3-node reproduction: two connected nodes (A, B) placed symmetrically around the origin so the graph has genuine motion (keeping the auto-speed calculation well-defined), and a third isolated node (C) placed exactly at the origin, whose repulsion from A and B cancels exactly by symmetry while gravity at the origin is zero — giving it `df == 0` in a single `goAlgo()` call. Without the fix this reliably throws `IllegalArgumentException: x cannot be NaN` from `NodeImpl.setX`; with the fix, C's coordinates stay finite.

## Added to documentation?
- [x] 🙅 no, because they aren't needed