### PR TITLE
Fix NPE when saving a project with an empty text-equals filter value

### DIFF
--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelPersistenceProvider.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelPersistenceProvider.java
@@ -165,7 +165,8 @@ public class FilterModelPersistenceProvider implements WorkspaceXMLPersistencePr
         try {
             writer.writeStartElement("parameter");
             writer.writeAttribute("index", String.valueOf(index));
-            writer.writeCharacters(serialization.toText(property.getValue(), property.getValueType()));
+            String text = serialization.toText(property.getValue(), property.getValueType());
+            writer.writeCharacters(text != null ? text : "");
             writer.writeEndElement();
         } catch (Exception e) {
             Exceptions.printStackTrace(e);

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/PersistenceProviderTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/PersistenceProviderTest.java
@@ -7,6 +7,7 @@ import org.gephi.filters.plugin.graph.HasSelfLoopBuilder;
 import org.gephi.filters.plugin.operator.INTERSECTIONBuilder;
 import org.gephi.filters.spi.Filter;
 import org.gephi.filters.spi.FilterBuilder;
+import org.gephi.graph.api.Column;
 import org.gephi.project.io.utils.GephiFormat;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -57,6 +58,17 @@ public class PersistenceProviderTest {
 
         FilterQueryImpl query = new FilterQueryImpl(null, egoFilter);
         query.setName("* Foo");
+        filterModel.addFirst(query);
+        GephiFormat.testXMLPersistenceProvider(new FilterModelPersistenceProvider(), filterModel.getWorkspace());
+    }
+
+    @Test
+    public void testEqualStringFilterWithoutPattern() throws Exception {
+        FilterModelImpl filterModel = Utils.newFilterModelWithGraph();
+        Column column = filterModel.getGraphModel().getNodeTable().addColumn("country", String.class);
+        AttributeEqualBuilder.EqualStringFilter filter = new AttributeEqualBuilder.EqualStringFilter.Node(column);
+
+        FilterQueryImpl query = new FilterQueryImpl(null, filter);
         filterModel.addFirst(query);
         GephiFormat.testXMLPersistenceProvider(new FilterModelPersistenceProvider(), filterModel.getWorkspace());
     }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/AttributeEqualBuilder.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/AttributeEqualBuilder.java
@@ -143,7 +143,7 @@ public class AttributeEqualBuilder implements CategoryBuilder {
 
     public static abstract class EqualStringFilter<K extends Element> extends AbstractAttributeFilter<K> {
 
-        private String pattern;
+        private String pattern = "";
         private boolean useRegex;
         private Pattern regex;
 

--- a/modules/FiltersPlugin/src/test/java/org/gephi/filters/plugin/attribute/AttributeEqualBuilderTest.java
+++ b/modules/FiltersPlugin/src/test/java/org/gephi/filters/plugin/attribute/AttributeEqualBuilderTest.java
@@ -1,0 +1,23 @@
+package org.gephi.filters.plugin.attribute;
+
+import org.gephi.filters.spi.FilterBuilder;
+import org.gephi.graph.GraphGenerator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AttributeEqualBuilderTest {
+
+    @Test
+    public void testEqualStringFilterDefaultPatternIsNotNull() {
+        GraphGenerator graphGenerator = GraphGenerator.build().generateTinyGraph().addStringNodeColumn();
+
+        AttributeEqualBuilder builder = new AttributeEqualBuilder();
+        FilterBuilder[] builders = builder.getBuilders(graphGenerator.getWorkspace());
+        Assert.assertEquals(1, builders.length);
+
+        AttributeEqualBuilder.EqualStringFilter filter =
+            (AttributeEqualBuilder.EqualStringFilter) builders[0].getFilter(graphGenerator.getWorkspace());
+        Assert.assertNotNull(filter.getPattern());
+        Assert.assertEquals("", filter.getPattern());
+    }
+}


### PR DESCRIPTION
## Description
When a user adds an "Attributes > Equal" filter for a text column via the Filters panel but never types a value into it before saving the project, the save silently produces broken output today — and on some XML stream implementations, throws an exception in the process.

The root cause is in `EqualStringFilter` (`modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/attribute/AttributeEqualBuilder.java`): its `pattern` field has no initializer and is never set unless the user calls `setPattern(...)`. Sibling filters like `EgoBuilder.EgoFilter` default their equivalent field to `""`, but this one doesn't, so `pattern` stays `null` for a freshly added, untouched filter.

When the project is saved, `FilterModelPersistenceProvider.writeParameter` (`modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelPersistenceProvider.java:168`) serializes every filter property by calling `Serialization.toText(value, type)` and passing the result straight to `writer.writeCharacters(...)`. `Serialization.toText` returns `null` for a `null` input value by design, so `writeCharacters(null)` gets called. Depending on the `XMLStreamWriter` implementation in use, that throws an NPE — this is what shows up in Sentry as GEPHI-5SY.

The fix is two-fold and minimal:
- `writeParameter` now guards the serialized text and writes `""` instead of `null`, so no filter property (not just this one) can ever push a null into the XML writer.
- `EqualStringFilter.pattern` now defaults to `""`, matching `EgoFilter`, so the null case doesn't occur in the first place for this filter.

https://gephi.sentry.io/issues/GEPHI-5SY

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [x] 👍 yes

Added `AttributeEqualBuilderTest.testEqualStringFilterDefaultPatternIsNotNull` (FiltersPlugin), which fails before the fix (asserts the filter built via `AttributeEqualBuilder` never has a null pattern), and a persistence round-trip test in `PersistenceProviderTest` covering an `EqualStringFilter` left without a pattern.

## Added to documentation?
- [x] 🙅 no, because they aren't needed