### PR TITLE
Null-check graph model/edge before use in async pencil-tool click dispatch

### DIFF
--- a/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
@@ -154,6 +154,11 @@ public class EdgePencil implements Tool {
                     boolean directed = edgePencilPanel.isDirected;
                     Edge edge =
                         Lookup.getDefault().lookup(GraphElementsController.class).createEdge(sourceNode, n, directed);
+                    if (edge == null) {
+                        sourceNode = null;
+                        edgePencilPanel.setStatus(NbBundle.getMessage(EdgePencil.class, "EdgePencil.status1"));
+                        return false;
+                    }
                     edge.setWeight(weight);
                     edge.setColor(color);
                     sourceNode = null;

--- a/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/NodePencil.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/NodePencil.java
@@ -100,6 +100,9 @@ public class NodePencil implements Tool {
                 size = nodePencilPanel.getNodeSize();
                 GraphController gc = Lookup.getDefault().lookup(GraphController.class);
                 GraphModel gm = gc.getGraphModel();
+                if (gm == null) {
+                    return false;
+                }
                 Graph graph = gm.getGraph();
                 Node node = gm.factory().newNode();
                 node.setX(position3d[0]);

--- a/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/EdgePencilTest.java
+++ b/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/EdgePencilTest.java
@@ -1,0 +1,87 @@
+/*
+ Copyright 2008-2010 Gephi
+ Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s):
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+package org.gephi.tools.plugin;
+
+import java.lang.reflect.Field;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.graph.api.Node;
+import org.gephi.project.api.ProjectController;
+import org.gephi.tools.spi.NodeClickEventListener;
+import org.gephi.tools.spi.ToolEventListener;
+import org.gephi.ui.tools.plugin.EdgePencilPanel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openide.util.Lookup;
+
+public class EdgePencilTest {
+
+    @Test
+    public void testClickNodesWithStaleSourceNodeDoesNotThrow() throws Exception {
+        ProjectController projectController = Lookup.getDefault().lookup(ProjectController.class);
+        projectController.newProject();
+
+        GraphController graphController = Lookup.getDefault().lookup(GraphController.class);
+        GraphModel graphModel = graphController.getGraphModel();
+        Graph graph = graphModel.getGraph();
+
+        Node n1 = graphModel.factory().newNode();
+        Node n2 = graphModel.factory().newNode();
+        graph.addNode(n1);
+        graph.addNode(n2);
+
+        EdgePencil edgePencil = new EdgePencil();
+        Field panelField = EdgePencil.class.getDeclaredField("edgePencilPanel");
+        panelField.setAccessible(true);
+        panelField.set(edgePencil, new EdgePencilPanel());
+
+        ToolEventListener[] listeners = edgePencil.getListeners();
+        NodeClickEventListener listener = (NodeClickEventListener) listeners[0];
+
+        Assert.assertTrue(listener.clickNodes(new Node[] {n1}));
+        // Source node is removed from the graph before the edge is confirmed, so
+        // GraphElementsController#createEdge is expected to return null.
+        graph.removeNode(n1);
+        Assert.assertFalse(listener.clickNodes(new Node[] {n2}));
+    }
+}

--- a/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/EdgePencilTest.java
+++ b/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/EdgePencilTest.java
@@ -39,6 +39,7 @@
 
  Portions Copyrighted 2011 Gephi Consortium.
  */
+
 package org.gephi.tools.plugin;
 
 import java.lang.reflect.Field;

--- a/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/EdgePencilTest.java
+++ b/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/EdgePencilTest.java
@@ -62,27 +62,31 @@ public class EdgePencilTest {
         ProjectController projectController = Lookup.getDefault().lookup(ProjectController.class);
         projectController.newProject();
 
-        GraphController graphController = Lookup.getDefault().lookup(GraphController.class);
-        GraphModel graphModel = graphController.getGraphModel();
-        Graph graph = graphModel.getGraph();
+        try {
+            GraphController graphController = Lookup.getDefault().lookup(GraphController.class);
+            GraphModel graphModel = graphController.getGraphModel();
+            Graph graph = graphModel.getGraph();
 
-        Node n1 = graphModel.factory().newNode();
-        Node n2 = graphModel.factory().newNode();
-        graph.addNode(n1);
-        graph.addNode(n2);
+            Node n1 = graphModel.factory().newNode();
+            Node n2 = graphModel.factory().newNode();
+            graph.addNode(n1);
+            graph.addNode(n2);
 
-        EdgePencil edgePencil = new EdgePencil();
-        Field panelField = EdgePencil.class.getDeclaredField("edgePencilPanel");
-        panelField.setAccessible(true);
-        panelField.set(edgePencil, new EdgePencilPanel());
+            EdgePencil edgePencil = new EdgePencil();
+            Field panelField = EdgePencil.class.getDeclaredField("edgePencilPanel");
+            panelField.setAccessible(true);
+            panelField.set(edgePencil, new EdgePencilPanel());
 
-        ToolEventListener[] listeners = edgePencil.getListeners();
-        NodeClickEventListener listener = (NodeClickEventListener) listeners[0];
+            ToolEventListener[] listeners = edgePencil.getListeners();
+            NodeClickEventListener listener = (NodeClickEventListener) listeners[0];
 
-        Assert.assertTrue(listener.clickNodes(new Node[] {n1}));
-        // Source node is removed from the graph before the edge is confirmed, so
-        // GraphElementsController#createEdge is expected to return null.
-        graph.removeNode(n1);
-        Assert.assertFalse(listener.clickNodes(new Node[] {n2}));
+            Assert.assertTrue(listener.clickNodes(new Node[] {n1}));
+            // Source node is removed from the graph before the edge is confirmed, so
+            // GraphElementsController#createEdge is expected to return null.
+            graph.removeNode(n1);
+            Assert.assertFalse(listener.clickNodes(new Node[] {n2}));
+        } finally {
+            projectController.closeCurrentProject();
+        }
     }
 }

--- a/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/NodePencilTest.java
+++ b/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/NodePencilTest.java
@@ -39,6 +39,7 @@
 
  Portions Copyrighted 2011 Gephi Consortium.
  */
+
 package org.gephi.tools.plugin;
 
 import java.lang.reflect.Field;

--- a/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/NodePencilTest.java
+++ b/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/NodePencilTest.java
@@ -1,0 +1,73 @@
+/*
+ Copyright 2008-2010 Gephi
+ Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s):
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+package org.gephi.tools.plugin;
+
+import java.lang.reflect.Field;
+import org.gephi.project.api.ProjectController;
+import org.gephi.tools.spi.MouseClickEventListener;
+import org.gephi.tools.spi.ToolEventListener;
+import org.gephi.ui.tools.plugin.NodePencilPanel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openide.util.Lookup;
+
+public class NodePencilTest {
+
+    @Test
+    public void testMouseClickWithoutOpenProjectDoesNotThrow() throws Exception {
+        ProjectController projectController = Lookup.getDefault().lookup(ProjectController.class);
+        if (projectController.hasCurrentProject()) {
+            projectController.closeCurrentProject();
+        }
+        Assert.assertNull(projectController.getCurrentWorkspace());
+
+        NodePencil nodePencil = new NodePencil();
+        Field panelField = NodePencil.class.getDeclaredField("nodePencilPanel");
+        panelField.setAccessible(true);
+        panelField.set(nodePencil, new NodePencilPanel());
+
+        ToolEventListener[] listeners = nodePencil.getListeners();
+        MouseClickEventListener listener = (MouseClickEventListener) listeners[0];
+
+        Assert.assertFalse(listener.mouseClick(new int[] {0, 0}, new float[] {0f, 0f}));
+    }
+}

--- a/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/NodePencilTest.java
+++ b/modules/ToolsPlugin/src/test/java/org/gephi/tools/plugin/NodePencilTest.java
@@ -56,9 +56,6 @@ public class NodePencilTest {
     @Test
     public void testMouseClickWithoutOpenProjectDoesNotThrow() throws Exception {
         ProjectController projectController = Lookup.getDefault().lookup(ProjectController.class);
-        if (projectController.hasCurrentProject()) {
-            projectController.closeCurrentProject();
-        }
         Assert.assertNull(projectController.getCurrentWorkspace());
 
         NodePencil nodePencil = new NodePencil();


### PR DESCRIPTION
## Description

`VizEngine.scheduleNextConcurrentWorldUpdateIfDone` (`modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/VizEngine.java:721-748`) queues each mouse click made with the Node/Edge pencil tools onto a background executor as part of the async world-update pipeline; the click is actually dispatched later, inside `processInputEvents`, from the `CompletableFuture` task (`VizEngine.java:663`, `VizEngine.java:866`). By the time that task runs, the graph the user was pointing at may no longer be in the same state it was when the click was captured — the workspace can have been closed, or a node involved in the click can have been removed (e.g. by an undo or a concurrent edit).

Both pencil tools assumed their graph lookups always succeed and dereferenced the result unconditionally:

- `NodePencil` (`NodePencil.java:102-103`) calls `GraphController.getGraphModel()`, which is documented to return `null` "if project is empty", then immediately calls `gm.getGraph()`. When the async click runs after the project has emptied out, this NPEs on the render thread (GEPHI-5HN, 59 users / 552 events).
- `EdgePencil` (`EdgePencil.java:155-157`) calls `GraphElementsController.createEdge(...)`, documented to return "New edge if the edge was created succesfully, null otherwise", then immediately calls `edge.setWeight(...)`. When the async click's source/target node is no longer valid in the graph store, `createEdge` catches the internal failure and returns `null`, and the very next line NPEs (GEPHI-5MZ, 7 users / 69 events).

Both crashes surface as an `ExecutionException`/`GLException` wrapping the NPE, unwound from `VizEngine.runWorldUpdated` on the render thread, which is why the visible symptom looks like a rendering-engine crash even though the root cause is in the tool code.

The fix adds the null checks the documented contracts already call for: if `getGraphModel()` returns `null`, `NodePencil` no-ops the click instead of dereferencing it; if `createEdge(...)` returns `null`, `EdgePencil` resets its pending-source-node state and no-ops instead of dereferencing the edge. This doesn't change behavior for any successful click and matches the existing return-`false`/"nothing happened" convention already used elsewhere in these listeners (e.g. `EdgePencil`'s cancel-click case). A more thorough fix would cancel/guard pending world-update tasks when a workspace closes, but that's a larger change to `VizEngine`'s scheduling and out of scope for this crash fix.

Sentry: https://gephi.sentry.io/issues/GEPHI-5HN, https://gephi.sentry.io/issues/GEPHI-5MZ

## Checklist
- [x] Merged with master beforehand

## Added tests?
- [x] 👍 yes

Added `NodePencilTest` and `EdgePencilTest` (new test sources for this module). Each reproduces the exact NPE from the corresponding Sentry stack trace against the pre-fix code (verified locally by reverting the fix and confirming both tests fail with the same NPE messages: `"gm" is null` at `NodePencil.java:103` and `"edge" is null` at `EdgePencil.java:157`), then asserts the click is safely no-op'd after the fix:
- `NodePencilTest` calls the tool's mouse-click listener with no project open, so `GraphController.getGraphModel()` returns `null`.
- `EdgePencilTest` clicks a source node, then removes that node from the graph before the second click, so `GraphElementsController.createEdge(...)` fails internally and returns `null`.

## Added to documentation?
- [x] 🙅 no, because they aren't needed