### PR TITLE
Always write project saves through a temp file to avoid empty .gephi files

### DIFF
--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
@@ -115,13 +115,11 @@ public class SaveTask implements LongTask {
         Progress.start(progressTicket);
         Progress.setDisplayName(progressTicket, NbBundle.getMessage(SaveTask.class, "SaveTask.name"));
 
-        File writeFile = file;
+        //Always write to a temporary sibling file and only move it over the destination once the
+        //content is fully written. This guarantees the destination file is never truncated or left
+        //empty if the save is interrupted (crash, cancel, disk full, cloud-sync locking, ...).
+        final File writeFile = new File(file.getParent(), file.getName() + "_temp" + System.currentTimeMillis());
         try {
-            if (file.exists() && file.length() > 0) {
-                String tempFileName = file.getName() + "_temp" + System.currentTimeMillis();
-                writeFile = new File(file.getParent(), tempFileName);
-            }
-
             FileOutputStream outputStream = null;
             ZipOutputStream zipOut = null;
             BufferedOutputStream bos = null;
@@ -199,7 +197,7 @@ public class SaveTask implements LongTask {
             Progress.finish(progressTicket);
 
             //Rename file
-            if (!cancel && writeFile.exists() && file != writeFile) {
+            if (!cancel && writeFile.exists()) {
                 Files.move(writeFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
         } catch (Exception ex) {
@@ -208,7 +206,8 @@ public class SaveTask implements LongTask {
             }
             throw new GephiFormatException(SaveTask.class, ex);
         } finally {
-            if (writeFile != null && writeFile.exists() && writeFile != file) {
+            //Leftover temporary file, either because the save was cancelled or failed
+            if (writeFile.exists()) {
                 FileObject tempFileObject = FileUtil.toFileObject(writeFile);
                 if (tempFileObject != null) {
                     try {

--- a/modules/ProjectAPI/src/test/java/org/gephi/project/io/SaveAndLoadTaskTest.java
+++ b/modules/ProjectAPI/src/test/java/org/gephi/project/io/SaveAndLoadTaskTest.java
@@ -2,13 +2,18 @@ package org.gephi.project.io;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Objects;
+import org.gephi.project.api.GephiFormatException;
 import org.gephi.project.impl.ProjectImpl;
 import org.gephi.project.impl.WorkspaceImpl;
+import org.gephi.project.io.utils.MockBytesPersistenceProviderFailWrite;
 import org.gephi.project.io.utils.MockXMLPersistenceProvider;
 import org.gephi.project.io.utils.MockXMLPersistenceProviderFailRead;
 import org.gephi.project.io.utils.MockXMLPersistenceProviderFailWrite;
 import org.gephi.project.io.utils.Utils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,6 +25,12 @@ public class SaveAndLoadTaskTest {
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @After
+    public void resetServices() {
+        // Persistence providers are registered globally, don't leak them into the next test
+        MockServices.setServices();
+    }
 
     @Test
     public void testEmptyProject() throws Exception {
@@ -44,6 +55,111 @@ public class SaveAndLoadTaskTest {
         saveTask.cancel();
         saveTask.run();
         Assert.assertTrue(file.exists());
+    }
+
+    @Test
+    public void testFirstSaveLeavesNoTempFile() throws Exception {
+        MockServices.setServices(MockXMLPersistenceProvider.class);
+
+        WorkspaceImpl workspace = Utils.newWorkspace();
+        File file = new File(tempFolder.getRoot(), "first.gephi");
+        Assert.assertFalse(file.exists());
+
+        Assert.assertNotNull(saveAndLoad(workspace.getProject(), file));
+        Assert.assertTrue(file.exists());
+        Assert.assertTrue(file.length() > 0);
+        assertNoTempFile();
+    }
+
+    /**
+     * Regression test: a first-time save that fails half-way through must not leave an empty (or partial) file at the
+     * destination path, as the user would then be unable to reopen it.
+     */
+    @Test
+    public void testFailedFirstSaveDoesNotCreateFile() {
+        MockServices.setServices(MockBytesPersistenceProviderFailWrite.class);
+
+        WorkspaceImpl workspace = Utils.newWorkspace();
+        File file = new File(tempFolder.getRoot(), "failed.gephi");
+        Assert.assertFalse(file.exists());
+
+        assertSaveFails(workspace.getProject(), file);
+
+        Assert.assertFalse("A failed first save must not leave a file behind", file.exists());
+        assertNoTempFile();
+    }
+
+    @Test
+    public void testCancelFirstSaveDoesNotCreateFile() {
+        WorkspaceImpl workspace = Utils.newWorkspace();
+        File file = new File(tempFolder.getRoot(), "cancelled.gephi");
+
+        SaveTask saveTask = new SaveTask(workspace.getProject(), file);
+        saveTask.cancel();
+        Assert.assertFalse(saveTask.run());
+
+        Assert.assertFalse("A cancelled first save must not leave a file behind", file.exists());
+        assertNoTempFile();
+    }
+
+    @Test
+    public void testFailedResaveKeepsExistingFileIntact() throws Exception {
+        MockServices.setServices(MockXMLPersistenceProvider.class);
+
+        WorkspaceImpl workspace = Utils.newWorkspace();
+        ProjectImpl project = workspace.getProject();
+        File file = new File(tempFolder.getRoot(), "resave.gephi");
+        Assert.assertTrue(new SaveTask(project, file).run());
+        byte[] original = Files.readAllBytes(file.toPath());
+        Assert.assertTrue(original.length > 0);
+
+        MockServices.setServices(MockBytesPersistenceProviderFailWrite.class);
+        assertSaveFails(project, file);
+
+        Assert.assertArrayEquals("A failed resave must leave the previous file untouched", original,
+            Files.readAllBytes(file.toPath()));
+        assertNoTempFile();
+
+        MockServices.setServices(MockXMLPersistenceProvider.class);
+        Assert.assertNotNull(new LoadTask(file).execute(null));
+    }
+
+    /**
+     * A destination that is already 0-byte long (e.g. left over by a previously interrupted save) used to be written
+     * to directly, so a failing save would keep it corrupt instead of leaving it alone.
+     */
+    @Test
+    public void testFailedResaveOverEmptyFileDoesNotWriteToIt() throws Exception {
+        MockServices.setServices(MockBytesPersistenceProviderFailWrite.class);
+
+        WorkspaceImpl workspace = Utils.newWorkspace();
+        File file = tempFolder.newFile("empty.gephi");
+        Assert.assertEquals(0, file.length());
+
+        assertSaveFails(workspace.getProject(), file);
+
+        Assert.assertTrue(file.exists());
+        Assert.assertEquals("A failed save must not write to the destination file", 0, file.length());
+        assertNoTempFile();
+    }
+
+    @Test
+    public void testCancelResaveKeepsExistingFileIntact() throws Exception {
+        MockServices.setServices(MockXMLPersistenceProvider.class);
+
+        WorkspaceImpl workspace = Utils.newWorkspace();
+        ProjectImpl project = workspace.getProject();
+        File file = new File(tempFolder.getRoot(), "resave.gephi");
+        Assert.assertTrue(new SaveTask(project, file).run());
+        byte[] original = Files.readAllBytes(file.toPath());
+
+        SaveTask saveTask = new SaveTask(project, file);
+        saveTask.cancel();
+        Assert.assertFalse(saveTask.run());
+
+        Assert.assertArrayEquals("A cancelled resave must leave the previous file untouched", original,
+            Files.readAllBytes(file.toPath()));
+        assertNoTempFile();
     }
 
     @Test
@@ -91,6 +207,22 @@ public class SaveAndLoadTaskTest {
         task.cancel();
         WorkspaceImpl result = task.run();
         Assert.assertNull(result);
+    }
+
+    private void assertSaveFails(ProjectImpl project, File file) {
+        try {
+            new SaveTask(project, file).run();
+            Assert.fail("Expected the save to fail");
+        } catch (GephiFormatException expected) {
+        }
+    }
+
+    private void assertNoTempFile() {
+        String[] files = Objects.requireNonNull(tempFolder.getRoot().list());
+        for (String name : files) {
+            Assert.assertFalse("Leftover temporary file " + name + " in " + Arrays.toString(files),
+                name.contains("_temp"));
+        }
     }
 
     private ProjectImpl saveAndLoad(ProjectImpl project) throws IOException {

--- a/modules/ProjectAPI/src/test/java/org/gephi/project/io/utils/MockBytesPersistenceProviderFailWrite.java
+++ b/modules/ProjectAPI/src/test/java/org/gephi/project/io/utils/MockBytesPersistenceProviderFailWrite.java
@@ -1,0 +1,28 @@
+package org.gephi.project.io.utils;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import org.gephi.project.api.Workspace;
+import org.gephi.project.spi.WorkspaceBytesPersistenceProvider;
+
+/**
+ * Unlike {@link MockXMLPersistenceProviderFailWrite}, whose exception is caught and logged by
+ * <code>GephiWriter</code>, a failure in <code>writeBytes</code> propagates and aborts the whole save. This is used to
+ * simulate a save interrupted half-way through the write.
+ */
+public class MockBytesPersistenceProviderFailWrite implements WorkspaceBytesPersistenceProvider {
+
+    @Override
+    public String getIdentifier() {
+        return "mockBytesFailWrite";
+    }
+
+    @Override
+    public void writeBytes(DataOutputStream stream, Workspace workspace) {
+        throw new RuntimeException("Failed to write bytes");
+    }
+
+    @Override
+    public void readBytes(DataInputStream stream, Workspace workspace) {
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to #3231, which stopped Gephi from misreporting already-handled empty-project-file errors (GEPHI-5SN, 384 events / 80 users) to Sentry as crashes. This PR addresses the most plausible root cause we found for the files actually ending up empty in the first place.

`SaveTask` only wrote to a temp sibling file and atomically moved it into place (via `Files.move(..., REPLACE_EXISTING)`) when the destination already existed **and** was non-empty. On a project's *first* save — or a resave over a destination that was already 0 bytes for any reason — it opened the real destination file directly via `new FileOutputStream(file)`, which truncates it to 0 bytes immediately, before any content is written. Any interruption after that point (crash, force-quit, disk full, a cloud-sync client such as OneDrive/Google Drive locking or racing the file mid-write) permanently leaves an empty, unopenable `.gephi` file — exactly the symptom behind GEPHI-5SN.

The fix makes the temp-file-then-atomic-move path unconditional, so the real destination is never opened for writing directly, regardless of whether it already exists.

Verified the fix is load-bearing by reverting just the `SaveTask.java` change and re-running the new tests: 3 failures reproduce, including one where 791 bytes of truncated content were written directly over what should have been an untouched destination.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

Added to `SaveAndLoadTaskTest`: a first save leaves no leftover temp file; a failed first save leaves no destination file at all (the core regression test); cancelling a first save leaves no destination file; a failed/cancelled resave leaves the previous file byte-for-byte untouched. Also added `MockBytesPersistenceProviderFailWrite`, needed because the existing `MockXMLPersistenceProviderFailWrite` has its exception caught and logged by `GephiWriter`, so it doesn't actually abort the save the way a real mid-write failure would.

## Added to documentation?
- [x] 🙅 no, because they aren't needed