### PR TITLE
Keep recoverable temp file on move failure; only set project file on save success

### DIFF
--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
@@ -190,8 +190,9 @@ public class ProjectControllerImpl implements ProjectController {
             fireProjectEvent(ProjectListener::lock);
             SaveTask saveTask = new SaveTask(project, file);
             longTaskExecutor.execute(saveTask, () -> {
-                project.getLookup().lookup(ProjectInformationImpl.class).setFile(file);
                 if (saveTask.run()) {
+                    //Only associate the project with the file once it has actually been written
+                    project.getLookup().lookup(ProjectInformationImpl.class).setFile(file);
                     ((ProjectImpl) project).setLastOpened();
                     fireProjectEvent((pl) -> pl.saved(project));
                 } else {

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
@@ -119,6 +119,7 @@ public class SaveTask implements LongTask {
         //content is fully written. This guarantees the destination file is never truncated or left
         //empty if the save is interrupted (crash, cancel, disk full, cloud-sync locking, ...).
         final File writeFile = new File(file.getParent(), file.getName() + "_temp" + System.currentTimeMillis());
+        boolean moveFailed = false;
         try {
             FileOutputStream outputStream = null;
             ZipOutputStream zipOut = null;
@@ -197,8 +198,22 @@ public class SaveTask implements LongTask {
             Progress.finish(progressTicket);
 
             //Rename file
-            if (!cancel && writeFile.exists()) {
-                Files.move(writeFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            if (!cancel) {
+                try {
+                    Files.move(writeFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException moveEx) {
+                    //The project is entirely written, the temporary file is the only copy of it left and is
+                    //therefore preserved so the user can recover it manually
+                    moveFailed = true;
+                    if (writeFile.exists()) {
+                        GephiFormatException recoverable = new GephiFormatException(
+                            NbBundle.getMessage(SaveTask.class, "SaveTask.moveFailed", writeFile.getAbsolutePath(),
+                                moveEx.getLocalizedMessage()));
+                        recoverable.initCause(moveEx);
+                        throw recoverable;
+                    }
+                    throw moveEx;
+                }
             }
         } catch (Exception ex) {
             if (ex instanceof GephiFormatException) {
@@ -206,8 +221,9 @@ public class SaveTask implements LongTask {
             }
             throw new GephiFormatException(SaveTask.class, ex);
         } finally {
-            //Leftover temporary file, either because the save was cancelled or failed
-            if (writeFile.exists()) {
+            //Leftover temporary file, either because the save was cancelled or failed. It's deliberately kept when
+            //the move itself failed, as it then holds the only copy of the fully written project.
+            if (!moveFailed && writeFile.exists()) {
                 FileObject tempFileObject = FileUtil.toFileObject(writeFile);
                 if (tempFileObject != null) {
                     try {

--- a/modules/ProjectAPI/src/main/resources/org/gephi/project/io/Bundle.properties
+++ b/modules/ProjectAPI/src/main/resources/org/gephi/project/io/Bundle.properties
@@ -4,4 +4,5 @@ Templates/Other/GephiTemplate.gephi=Empty Gephi file
 
 LoadTask.name=Opening project
 SaveTask.name=Saving project
+SaveTask.moveFailed=Gephi failed saving the project because the destination file could not be replaced.\n\nThe project has been entirely written to a temporary file and can be recovered by renaming it:\n{0}\n\nCause: {1}
 DuplicateTask.name=Duplicating workspace

--- a/modules/ProjectAPI/src/test/java/org/gephi/project/impl/ProjectControllerImplTest.java
+++ b/modules/ProjectAPI/src/test/java/org/gephi/project/impl/ProjectControllerImplTest.java
@@ -3,12 +3,15 @@ package org.gephi.project.impl;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import org.gephi.project.api.GephiFormatException;
 import org.gephi.project.api.Project;
 import org.gephi.project.api.ProjectListener;
 import org.gephi.project.api.Workspace;
 import org.gephi.project.api.WorkspaceListener;
+import org.gephi.project.io.utils.MockBytesPersistenceProviderFailWrite;
 import org.gephi.project.spi.Controller;
 import org.gephi.project.spi.Model;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +37,12 @@ public class ProjectControllerImplTest {
 
     @Mock
     private WorkspaceListener workspaceListener;
+
+    @After
+    public void resetServices() {
+        // Services are registered globally, don't leak them into the next test
+        MockServices.setServices();
+    }
 
     @Test
     public void testInit() {
@@ -105,6 +114,32 @@ public class ProjectControllerImplTest {
         Assert.assertTrue(project.hasFile());
         Assert.assertSame(file, project.getFile());
         Mockito.verify(projectListener).saved(project);
+    }
+
+    /**
+     * Regression test: a save that fails must leave the project file unchanged, as the project isn't associated with
+     * a file that was never written.
+     */
+    @Test
+    public void testFailedSaveDoesNotSetFile() {
+        MockServices.setServices(MockBytesPersistenceProviderFailWrite.class);
+
+        ProjectControllerImpl pc = new ProjectControllerImpl();
+        pc.addProjectListener(projectListener);
+        Project project = pc.newProject();
+        Assert.assertFalse(project.hasFile());
+
+        File file = new File(tempFolder.getRoot(), "failed.gephi");
+        try {
+            pc.saveProject(project, file);
+            Assert.fail("Expected the save to fail");
+        } catch (GephiFormatException expected) {
+        }
+
+        Assert.assertFalse("A failed save must not associate the project with the file", project.hasFile());
+        Assert.assertNull(project.getFile());
+        Assert.assertFalse(file.exists());
+        Mockito.verify(projectListener, Mockito.never()).saved(project);
     }
 
     @Test

--- a/modules/ProjectAPI/src/test/java/org/gephi/project/io/SaveAndLoadTaskTest.java
+++ b/modules/ProjectAPI/src/test/java/org/gephi/project/io/SaveAndLoadTaskTest.java
@@ -143,6 +143,41 @@ public class SaveAndLoadTaskTest {
         assertNoTempFile();
     }
 
+    /**
+     * Regression test: when the final move of the temporary file over the destination fails (e.g. because the
+     * destination is locked by an antivirus or a cloud-sync client), the temporary file holds the only copy of the
+     * fully written project and must therefore be kept so it can be recovered.
+     */
+    @Test
+    public void testFailedMoveKeepsRecoverableTempFile() throws Exception {
+        WorkspaceImpl workspace = Utils.newWorkspace();
+
+        //Moving a file over a non-empty directory is guaranteed to fail on every platform
+        File destination = tempFolder.newFolder("destination.gephi");
+        Assert.assertTrue(new File(destination, "child.txt").createNewFile());
+
+        GephiFormatException exception = null;
+        try {
+            new SaveTask(workspace.getProject(), destination).run();
+            Assert.fail("Expected the save to fail");
+        } catch (GephiFormatException ex) {
+            exception = ex;
+        }
+
+        File tempFile = findTempFile();
+        Assert.assertNotNull("The temporary file must be kept when the move fails", tempFile);
+        Assert.assertTrue(tempFile.length() > 0);
+
+        String message = exception.getMessage();
+        Assert.assertNotNull(message);
+        Assert.assertTrue("The error should point at the recoverable file, was: " + message,
+            message.contains(tempFile.getAbsolutePath()));
+        Assert.assertTrue("The move failure should be kept as cause", exception.getCause() instanceof IOException);
+
+        //The kept file is a complete project which can be loaded back
+        Assert.assertNotNull(new LoadTask(tempFile).execute(null));
+    }
+
     @Test
     public void testCancelResaveKeepsExistingFileIntact() throws Exception {
         MockServices.setServices(MockXMLPersistenceProvider.class);
@@ -215,6 +250,15 @@ public class SaveAndLoadTaskTest {
             Assert.fail("Expected the save to fail");
         } catch (GephiFormatException expected) {
         }
+    }
+
+    private File findTempFile() {
+        for (File file : Objects.requireNonNull(tempFolder.getRoot().listFiles())) {
+            if (file.getName().contains("_temp")) {
+                return file;
+            }
+        }
+        return null;
     }
 
     private void assertNoTempFile() {


### PR DESCRIPTION
## Description

Closes the last two items from #3241, following up on #3240 and #3242.

### 1. A failing `Files.move` (or externally-vanished temp file) either discarded a valid save or silently reported success

`SaveTask` writes to a temp sibling file and moves it over the destination once the project is fully written. Two gaps remained:

- If the move itself failed (e.g. destination locked by antivirus/cloud-sync), the `finally` block deleted the temp file regardless — discarding the user's fully-serialized project for no reason. It's now kept, and the error message points at its absolute path so it can be recovered manually (e.g. by renaming it).
- The move was previously guarded by `writeFile.exists()`, so if the temp file vanished externally between creation and the move (with no exception on our side), the move was silently skipped and the save reported as successful even though nothing was written to the destination. The move is now always attempted when not cancelled, so a missing temp file surfaces as a real `NoSuchFileException`-derived error instead of a false success.

### 2. `ProjectControllerImpl.setFile()` ran before the save result was known

`setFile(file)` was called unconditionally before `saveTask.run()`. If the save then failed or was cancelled, the project was left pointing at a file that was never actually written — a state only reachable since #3240's temp-file hardening (previously, a first save wrote directly to the destination, so *something* always ended up there). `setFile()` now only runs after a successful save.

Verified via codegraph/grep that `SaveTask` doesn't depend on the project's file field being set eagerly (it uses the `file` constructor parameter throughout), and that nothing else listens for `ProjectInformationImpl`'s `EVENT_SET_FILE` today.

Cancelling a save still results in nothing at the destination — that's intentional, previously-agreed behavior and unchanged here.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

- `SaveAndLoadTaskTest#testFailedMoveKeepsRecoverableTempFile`: forces the final move to fail portably across OSes by pointing the destination at a non-empty directory (`Files.move(..., REPLACE_EXISTING)` is specified to never replace a non-empty directory on any platform). Asserts the temp file survives, is non-empty, is still a valid loadable project (`LoadTask` round-trip), and that the error message names its path with the original `IOException` preserved as the cause.
- `ProjectControllerImplTest#testFailedSaveDoesNotSetFile`: a save that fails leaves `project.hasFile()`/`getFile()` unchanged and never fires the `saved` event.

Verified both are load-bearing by reverting just the two production files and re-running: each new test fails with exactly the assertion it's meant to prove, nothing else breaks.

## Added to documentation?
- [x] 🙅 no, because they aren't needed