### PR TITLE
Fix two races in LongTaskExecutor making AsynchronousTest flaky

### DIFF
--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
@@ -442,14 +442,20 @@ public final class LongTaskExecutor {
                 // that thread may complete the task (and make isRunning() false) while
                 // the listener hasn't been notified yet.
                 boolean claimed = task.claimFinish();
-                if (task.future != null) {
-                    task.future.cancel(interruptCancel);
-                }
-                if (task.progress != null) {
-                    task.progress.finish();
-                }
-                if (claimed) {
-                    finished(task, true);
+                try {
+                    if (task.future != null) {
+                        task.future.cancel(interruptCancel);
+                    }
+                    if (task.progress != null) {
+                        task.progress.finish();
+                    }
+                } finally {
+                    // The completion is claimed above, so it has to be performed here even
+                    // if the cancellation failed, otherwise no other thread can complete
+                    // the task anymore.
+                    if (claimed) {
+                        finished(task, true);
+                    }
                 }
 
                 if (!inBackground) {

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
@@ -51,6 +51,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.gephi.utils.longtask.spi.LongTask;
@@ -75,7 +76,7 @@ public final class LongTaskExecutor {
     private final String name;
     private boolean interruptCancel;
     private ThreadPoolExecutor executor;
-    private RunningLongTask currentTask;
+    private volatile RunningLongTask currentTask;
     private Timer cancelTimer;
     private LongTaskListener listener;
     private LongTaskErrorHandler defaultErrorHandler;
@@ -272,13 +273,25 @@ public final class LongTaskExecutor {
         }
     }
 
-    private synchronized void finished(RunningLongTask runningLongTask) {
+    /**
+     * Completes the given task. Only the first caller which successfully
+     * claimed the completion (see <code>RunningLongTask.claimFinish()</code>)
+     * should call this method, so the listener is notified exactly once per task.
+     *
+     * @param runningLongTask the task which completed
+     * @param notifyListener  whether the listener should be notified, errors are
+     *                        reported to the error handler instead
+     */
+    private synchronized void finished(RunningLongTask runningLongTask, boolean notifyListener) {
         if (cancelTimer != null) {
             cancelTimer.cancel();
+            cancelTimer = null;
         }
         LongTask task = runningLongTask.task;
-        currentTask = null;
-        if (listener != null) {
+        if (currentTask == runningLongTask) {
+            currentTask = null;
+        }
+        if (notifyListener && listener != null) {
             listener.taskFinished(task);
         }
     }
@@ -292,6 +305,7 @@ public final class LongTaskExecutor {
         private final Runnable runnable;
         private final Callable<V> callable;
         private final LongTaskErrorHandler errorHandler;
+        private final AtomicBoolean finishClaimed = new AtomicBoolean();
         private Future<V> future;
         private ProgressTicket progress;
 
@@ -341,9 +355,9 @@ public final class LongTaskExecutor {
                     }
                 }
 
-                currentTask = null;
-
-                finished(this);
+                if (claimFinish()) {
+                    finished(this, true);
+                }
                 if (progress != null) {
                     progress.finish();
                 }
@@ -352,13 +366,22 @@ public final class LongTaskExecutor {
                 if (progress != null) {
                     progress.finish();
                 }
-                currentTask = null;
-                if (err != null) {
-                    err.fatalError(e);
-                } else if (defaultErrorHandler != null) {
-                    defaultErrorHandler.fatalError(e);
-                } else {
-                    Logger.getLogger("").log(Level.SEVERE, "", e);
+                try {
+                    if (err != null) {
+                        err.fatalError(e);
+                    } else if (defaultErrorHandler != null) {
+                        defaultErrorHandler.fatalError(e);
+                    } else {
+                        Logger.getLogger("").log(Level.SEVERE, "", e);
+                    }
+                } finally {
+                    // Failures are reported to the error handler, not to the listener, but
+                    // the task still has to be completed so the executor doesn't stay
+                    // 'running'. When the task has been interrupted by the cancel timer the
+                    // completion is already claimed by it and this is a no-op.
+                    if (claimFinish()) {
+                        finished(this, false);
+                    }
                 }
                 if (!inBackground) {
                     future = CompletableFuture.failedFuture(e);
@@ -378,6 +401,18 @@ public final class LongTaskExecutor {
                 return task.cancel();
             }
             return false;
+        }
+
+        /**
+         * Claims the completion of this task. Returns <code>true</code> for the
+         * first caller only, so that the task thread and the interrupt timer
+         * can't both complete the same task.
+         *
+         * @return <code>true</code> if the caller is responsible for completing
+         * this task, <code>false</code> if it has already been completed
+         */
+        private boolean claimFinish() {
+            return finishClaimed.compareAndSet(false, true);
         }
     }
 
@@ -403,17 +438,19 @@ public final class LongTaskExecutor {
         @Override
         public void run() {
             if (task != null) {
+                // Claim the completion before interrupting the task thread, otherwise
+                // that thread may complete the task (and make isRunning() false) while
+                // the listener hasn't been notified yet.
+                boolean claimed = task.claimFinish();
                 if (task.future != null) {
                     task.future.cancel(interruptCancel);
                 }
-                if (cancelTimer != null) {
-                    cancelTimer.cancel();
-                }
-                cancelTimer = null;
                 if (task.progress != null) {
                     task.progress.finish();
                 }
-                finished(task);
+                if (claimed) {
+                    finished(task, true);
+                }
 
                 if (!inBackground) {
                     Logger.getLogger("").warning("Task from " + name + " did not respond to cancellation request. Interrupting thread.");

--- a/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/AsynchronousTest.java
+++ b/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/AsynchronousTest.java
@@ -1,6 +1,7 @@
 package org.gephi.utils.longtask.api;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -80,10 +81,17 @@ public class AsynchronousTest {
     @Test
     public void testCancel() throws Exception {
         executor.setLongTaskListener(listener);
-        Mockito.doAnswer(new AnswersWithDelay(200, invocation -> 42)).when(callable).call();
+        // The task blocks until the test releases it, so it is guaranteed to be
+        // observed as running instead of depending on a fixed delay
+        CountDownLatch release = new CountDownLatch(1);
+        Mockito.doAnswer(invocation -> {
+            release.await();
+            return 42;
+        }).when(callable).call();
         Future<Integer> future = executor.execute(longTask, callable);
         Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executor::isRunning);
         executor.cancel();
+        release.countDown();
         future.get();
         Mockito.verify(longTask).cancel();
         Mockito.verify(listener).taskFinished(Mockito.any());
@@ -107,5 +115,25 @@ public class AsynchronousTest {
         executorWithInterruption.cancel();
         Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executorWithInterruption::isRunning, t -> !t);
         Mockito.verify(listener).taskFinished(Mockito.any());
+    }
+
+    @Test
+    public void testCancelRunnableIgnoresInterrupt() {
+        Mockito.when(longTask.cancel()).thenReturn(false);
+        Mockito.doAnswer(invocation -> {
+            try {
+                Thread.sleep(30000);
+            } catch (InterruptedException e) {
+                // The task swallows the interruption and completes normally, so both the
+                // interrupt timer and the task thread reach the completion code
+            }
+            return null;
+        }).when(runnable).run();
+        executorWithInterruption.setLongTaskListener(listener);
+        executorWithInterruption.execute(longTask, runnable);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executorWithInterruption::isRunning);
+        executorWithInterruption.cancel();
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executorWithInterruption::isRunning, t -> !t);
+        Mockito.verify(listener, Mockito.after(500).times(1)).taskFinished(Mockito.any());
     }
 }


### PR DESCRIPTION
## Description

`AsynchronousTest` has been failing intermittently on CI in two different ways. Commit 85af31566 raised the Awaitility timeouts from 10s to 30s to fight it, but both recent failures happened on commits that already had the 30s timeouts, so the bump only changed which failure surfaces. Both are races in `LongTaskExecutor` itself.

## Race 1: `currentTask` is published without any happens-before edge

`currentTask` is written by the pool worker thread in `RunningLongTask.call()` and read by `isRunning()` from any other thread, with no synchronization on either side. Nothing guarantees a poller ever observes the write.

That is the macOS failure mode: `testCancel` timed out after 30s waiting for `isRunning()` to become `true`, which no amount of extra timeout can fix.

Fix: `currentTask` is now `volatile`.

## Race 2: the failure path completed the task without notifying the listener

`RunningLongTask.call()` only called `finished()` on the success path. The `catch (Throwable)` block nulled `currentTask` directly and returned, so:

- `cancel()` schedules an `InterruptTimerTask`, which calls `future.cancel(true)` and then, separately, `finished(task)` — which is what notifies the listener.
- The interrupt makes the task throw, and the pool thread's catch block nulls `currentTask` **without** notifying the listener.
- `isRunning()` flips to `false` as a side effect of that write, so the test's `await(...).until(isRunning, t -> !t)` returns immediately.
- `verify(listener).taskFinished(...)` then runs before the Timer thread got to its own `finished()` call.

That is the Windows failure mode: `testCancelRunnableInterrupt` failed with "Wanted but not invoked: listener.taskFinished(<any>) ... there were zero interactions with this mock", not with a timeout.

Simply calling `finished()` from the catch block would swap this for the opposite bug: in the interrupt scenario the listener would be notified twice (once by the pool thread, once by `InterruptTimerTask`) and the same `verify()` would fail with `TooManyActualInvocations`.

Fix: each `RunningLongTask` now carries an `AtomicBoolean` claimed with a CAS. Only the first of {success path, failure path, `InterruptTimerTask`} performs the completion work (cancelling the cancel timer, clearing `currentTask`, notifying the listener); the others are no-ops. `InterruptTimerTask` claims the completion *before* interrupting the task thread, so the interrupted thread can never end the task ahead of the listener notification. The catch block now reaches the shared completion code instead of bypassing it, which is also what stops a pending interrupt timer from firing after a task already failed.

The error-handling contract is unchanged: failures are still reported to the error handler only, never to the listener (`testExecuteCallableException` still asserts `verify(listener, never())`). The completion in the catch block was moved after the error handler is invoked, in a `finally`, so `isRunning() == false` now also implies the error has already been reported.

## Tests

- New `testCancelRunnableIgnoresInterrupt`: the task swallows the interrupt and completes normally, so both the interrupt timer and the task thread reach the completion code. It asserts the listener is invoked exactly once. Verified it catches the double-notification regression: removing the CAS guard from the success path makes it fail with `TooManyActualInvocations`.
- `testCancel` no longer depends on a 200ms mock delay that the 100ms Awaitility polling can miss entirely; the task blocks on a latch released by the test, so it is guaranteed to be observed running. No assertion or timeout was relaxed.

## Test plan

- [x] Reproduced the Windows failure deterministically by injecting a 500ms sleep in `InterruptTimerTask.run()` before `finished(task)`: identical "zero interactions with this mock" failure on master, passing after the fix, which shows the window is closed rather than narrowed (instrumentation removed before committing)
- [x] Verified the new test catches the double-notification regression
- [x] `mvn -pl modules/LongTaskAPI test` run 25x consecutively on the final code (65 runs total across iterations), no failures
- [x] `mvn -pl modules/LongTaskAPI -P enableCheckStyle checkstyle:check`: 0 violations

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?

- [x] 👍 Relevant code documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
