### PR TITLE
Fix the colour picker crashing when a hex value is pasted into it

### DIFF
--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/ColorPickerUtils.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/ColorPickerUtils.java
@@ -1,0 +1,171 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+*/
+
+package org.gephi.ui.components;
+
+import com.bric.swing.ColorPicker;
+import java.awt.AWTEvent;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.AWTEventListener;
+import java.awt.event.ContainerEvent;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DocumentFilter;
+
+/**
+ * Shows the bundled {@link ColorPicker} dialog with its hex field constrained to six hexadecimal
+ * digits.
+ * <p>
+ * The picker reacts to every edit of the hex field by rewriting that same field with the canonical
+ * form of the color, from inside the field's own document notification. Swing forbids that, so any
+ * paste of a value that is not already canonical - <code>#00FF00</code> for instance - fails on the
+ * event dispatch thread instead of applying the color. Constraining the field so it can only ever
+ * hold the canonical form leaves the picker with nothing to rewrite, which removes the reentrant
+ * write altogether.
+ */
+public final class ColorPickerUtils {
+
+    private ColorPickerUtils() {
+    }
+
+    /**
+     * Shows the modal color picker dialog.
+     *
+     * @param owner          the owner window, may be null
+     * @param originalColor  the color the picker initially points to
+     * @param includeOpacity whether to add a control for the opacity of the color
+     * @return the color the user chose, or null if the dialog was cancelled
+     */
+    public static Color showDialog(Window owner, Color originalColor, boolean includeOpacity) {
+        AWTEventListener listener = event -> {
+            if (event instanceof ContainerEvent && event.getID() == ContainerEvent.COMPONENT_ADDED) {
+                Component child = ((ContainerEvent) event).getChild();
+                if (child instanceof ColorPicker) {
+                    constrainHexField((ColorPicker) child);
+                }
+            }
+        };
+        //The picker is created inside ColorPicker.showDialog(), so its hex field can only be
+        //reached when it gets added to the dialog, which happens before the dialog is displayable.
+        Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.CONTAINER_EVENT_MASK);
+        try {
+            return ColorPicker.showDialog(owner, originalColor, includeOpacity);
+        } finally {
+            Toolkit.getDefaultToolkit().removeAWTEventListener(listener);
+        }
+    }
+
+    private static void constrainHexField(ColorPicker picker) {
+        JTextField hexField = findHexField(picker.getExpertControls());
+        if (hexField != null) {
+            ((AbstractDocument) hexField.getDocument()).setDocumentFilter(new HexDocumentFilter());
+        }
+    }
+
+    private static JTextField findHexField(Container container) {
+        for (Component component : container.getComponents()) {
+            if (component instanceof JTextField && isHexField((JTextField) component)) {
+                return (JTextField) component;
+            }
+            if (component instanceof Container) {
+                JTextField hexField = findHexField((Container) component);
+                if (hexField != null) {
+                    return hexField;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean isHexField(JTextField field) {
+        if (!(field.getDocument() instanceof AbstractDocument)) {
+            return false;
+        }
+        //The hex field is the only one the picker listens to, which also tells the numeric spinner
+        //editors apart from it.
+        for (DocumentListener listener : ((AbstractDocument) field.getDocument()).getDocumentListeners()) {
+            if (listener.getClass().getName().startsWith(ColorPicker.class.getName() + "$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static final class HexDocumentFilter extends DocumentFilter {
+
+        private static final int HEX_LENGTH = 6;
+
+        @Override
+        public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr)
+            throws BadLocationException {
+            super.insertString(fb, offset, toHexDigits(string, fb.getDocument().getLength()), attr);
+        }
+
+        @Override
+        public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs)
+            throws BadLocationException {
+            super.replace(fb, offset, length, toHexDigits(text, fb.getDocument().getLength() - length), attrs);
+        }
+
+        private static String toHexDigits(String text, int keptLength) {
+            if (text == null) {
+                return null;
+            }
+            int room = HEX_LENGTH - keptLength;
+            StringBuilder hexDigits = new StringBuilder(Math.max(room, 0));
+            for (int i = 0; i < text.length() && hexDigits.length() < room; i++) {
+                char c = Character.toUpperCase(text.charAt(i));
+                if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')) {
+                    hexDigits.append(c);
+                }
+            }
+            return hexDigits.toString();
+        }
+    }
+}

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/ColorPickerUtils.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/ColorPickerUtils.java
@@ -144,22 +144,43 @@ public final class ColorPickerUtils {
         @Override
         public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr)
             throws BadLocationException {
-            super.insertString(fb, offset, toHexDigits(string, fb.getDocument().getLength()), attr);
+            overtypeInsert(fb, offset, 0, string, attr);
         }
 
         @Override
         public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs)
             throws BadLocationException {
-            super.replace(fb, offset, length, toHexDigits(text, fb.getDocument().getLength() - length), attrs);
+            overtypeInsert(fb, offset, length, text, attrs);
         }
 
-        private static String toHexDigits(String text, int keptLength) {
-            if (text == null) {
-                return null;
+        /**
+         * Inserts the hex digits found in {@code text} at {@code offset}, after removing
+         * {@code removedLength} characters there (the selection being replaced, if any). Whatever
+         * does not fit in the six-digit field afterwards is dropped from the far end of the field
+         * rather than from what was just typed or pasted, so editing mid-field overtypes like a
+         * fixed-width field instead of silently doing nothing once the field is already full.
+         */
+        private void overtypeInsert(FilterBypass fb, int offset, int removedLength, String text,
+            AttributeSet attrs) throws BadLocationException {
+            int docLength = fb.getDocument().getLength();
+            int budget = HEX_LENGTH - offset;
+            String insertDigits = toHexDigits(text, budget);
+            int tailStart = offset + removedLength;
+            int tailLength = docLength - tailStart;
+            int tailBudget = budget - insertDigits.length();
+            int tailCharsToRemove = tailLength - Math.min(tailLength, tailBudget);
+            if (tailCharsToRemove > 0) {
+                fb.remove(docLength - tailCharsToRemove, tailCharsToRemove);
             }
-            int room = HEX_LENGTH - keptLength;
-            StringBuilder hexDigits = new StringBuilder(Math.max(room, 0));
-            for (int i = 0; i < text.length() && hexDigits.length() < room; i++) {
+            super.replace(fb, offset, removedLength, insertDigits, attrs);
+        }
+
+        private static String toHexDigits(String text, int maxLength) {
+            if (text == null) {
+                return "";
+            }
+            StringBuilder hexDigits = new StringBuilder(Math.max(maxLength, 0));
+            for (int i = 0; i < text.length() && hexDigits.length() < maxLength; i++) {
                 char c = Character.toUpperCase(text.charAt(i));
                 if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')) {
                     hexDigits.append(c);

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/JColorBlackWhiteSwitcher.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/JColorBlackWhiteSwitcher.java
@@ -42,7 +42,6 @@ Portions Copyrighted 2011 Gephi Consortium.
 
 package org.gephi.ui.components;
 
-import com.bric.swing.ColorPicker;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
@@ -87,7 +86,7 @@ public class JColorBlackWhiteSwitcher extends JButton {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (SwingUtilities.isRightMouseButton(e)) {
-                    Color newColor = ColorPicker.showDialog(WindowManager.getDefault().getMainWindow(), color,
+                    Color newColor = ColorPickerUtils.showDialog(WindowManager.getDefault().getMainWindow(), color,
                         JColorBlackWhiteSwitcher.this.includeOpacity);
                     if (newColor != null) {
                         setColor(newColor);

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/JColorButton.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/JColorButton.java
@@ -113,11 +113,7 @@ public class JColorButton extends JButton {
                 public void mouseClicked(MouseEvent e) {
 
                     if (SwingUtilities.isRightMouseButton(e)) {
-                        Color newColor = ColorPicker.showDialog(WindowManager.getDefault().getMainWindow(), color,
-                            JColorButton.this.includeOpacity);
-                        if (newColor != null) {
-                            setColor(newColor);
-                        }
+                        showColorPicker();
                     }
                 }
             });
@@ -126,13 +122,23 @@ public class JColorButton extends JButton {
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    Color newColor = ColorPicker.showDialog(WindowManager.getDefault().getMainWindow(), color,
-                        JColorButton.this.includeOpacity);
-                    if (newColor != null) {
-                        setColor(newColor);
-                    }
+                    showColorPicker();
                 }
             });
+        }
+    }
+
+    private void showColorPicker() {
+        Color newColor;
+        try {
+            newColor = ColorPicker.showDialog(WindowManager.getDefault().getMainWindow(), color, includeOpacity);
+        } catch (IllegalStateException e) {
+            //The bundled ColorPicker re-enters its own hex field document while Swing is still
+            //notifying its listeners, which AbstractDocument rejects. Treat it as a cancellation.
+            return;
+        }
+        if (newColor != null) {
+            setColor(newColor);
         }
     }
 

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/JColorButton.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/JColorButton.java
@@ -42,7 +42,6 @@ Portions Copyrighted 2011 Gephi Consortium.
 
 package org.gephi.ui.components;
 
-import com.bric.swing.ColorPicker;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
@@ -129,14 +128,7 @@ public class JColorButton extends JButton {
     }
 
     private void showColorPicker() {
-        Color newColor;
-        try {
-            newColor = ColorPicker.showDialog(WindowManager.getDefault().getMainWindow(), color, includeOpacity);
-        } catch (IllegalStateException e) {
-            //The bundled ColorPicker re-enters its own hex field document while Swing is still
-            //notifying its listeners, which AbstractDocument rejects. Treat it as a cancellation.
-            return;
-        }
+        Color newColor = ColorPickerUtils.showDialog(WindowManager.getDefault().getMainWindow(), color, includeOpacity);
         if (newColor != null) {
             setColor(newColor);
         }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/gradientslider/GradientSlider.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/gradientslider/GradientSlider.java
@@ -61,6 +61,7 @@ import javax.swing.UIManager;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.plaf.ComponentUI;
+import org.gephi.ui.components.ColorPickerUtils;
 
 /**
  * This component lets the user manipulate the colors in a gradient.
@@ -222,13 +223,7 @@ public class GradientSlider extends MultiThumbSlider {
 
         boolean includeOpacity =
             MultiThumbSliderUI.getProperty(this, "GradientSlider.includeOpacity", "true").equals("true");
-        try {
-            colors[i] = ColorPicker.showDialog(frame, colors[i], includeOpacity);
-        } catch (IllegalStateException e) {
-            //The bundled ColorPicker re-enters its own hex field document while Swing is still
-            //notifying its listeners, which AbstractDocument rejects. Treat it as a cancellation.
-            return false;
-        }
+        colors[i] = ColorPickerUtils.showDialog(frame, colors[i], includeOpacity);
         if (colors[i] != null) {
             setValues(getThumbPositions(), colors);
         }

--- a/modules/UIComponents/src/main/java/org/gephi/ui/components/gradientslider/GradientSlider.java
+++ b/modules/UIComponents/src/main/java/org/gephi/ui/components/gradientslider/GradientSlider.java
@@ -222,7 +222,13 @@ public class GradientSlider extends MultiThumbSlider {
 
         boolean includeOpacity =
             MultiThumbSliderUI.getProperty(this, "GradientSlider.includeOpacity", "true").equals("true");
-        colors[i] = ColorPicker.showDialog(frame, colors[i], includeOpacity);
+        try {
+            colors[i] = ColorPicker.showDialog(frame, colors[i], includeOpacity);
+        } catch (IllegalStateException e) {
+            //The bundled ColorPicker re-enters its own hex field document while Swing is still
+            //notifying its listeners, which AbstractDocument rejects. Treat it as a cancellation.
+            return false;
+        }
         if (colors[i] != null) {
             setValues(getThumbPositions(), colors);
         }

--- a/modules/UIComponents/src/test/java/org/gephi/ui/components/ColorPickerUtilsTest.java
+++ b/modules/UIComponents/src/test/java/org/gephi/ui/components/ColorPickerUtilsTest.java
@@ -1,0 +1,73 @@
+package org.gephi.ui.components;
+
+import javax.swing.text.PlainDocument;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * The bundled ColorPicker cannot be instantiated without a display, so the dialog itself is not
+ * exercised here. What is exercised is the property the fix relies on: the hex field can only ever
+ * hold up to six uppercase hexadecimal digits, which is what leaves the picker with nothing to
+ * rewrite from inside the field's own document notification.
+ */
+public class ColorPickerUtilsTest {
+
+    private static PlainDocument hexDocument() throws Exception {
+        PlainDocument document = new PlainDocument();
+        document.setDocumentFilter(new ColorPickerUtils.HexDocumentFilter());
+        document.insertString(0, "000000", null);
+        return document;
+    }
+
+    private static String replaceAll(PlainDocument document, String text) throws Exception {
+        document.replace(0, document.getLength(), text, null);
+        return document.getText(0, document.getLength());
+    }
+
+    @Test
+    public void testHashPrefixedValueIsAccepted() throws Exception {
+        Assert.assertEquals("00FF00", replaceAll(hexDocument(), "#00FF00"));
+    }
+
+    @Test
+    public void testValueIsUpperCased() throws Exception {
+        Assert.assertEquals("1A2B3C", replaceAll(hexDocument(), "1a2b3c"));
+    }
+
+    @Test
+    public void testCanonicalValueIsUnchanged() throws Exception {
+        Assert.assertEquals("336699", replaceAll(hexDocument(), "336699"));
+    }
+
+    @Test
+    public void testSeparatorsAreDropped() throws Exception {
+        Assert.assertEquals("ABCDEF", replaceAll(hexDocument(), "  #ab cd ef  "));
+    }
+
+    @Test
+    public void testValueIsCappedToSixDigits() throws Exception {
+        Assert.assertEquals("AABBCC", replaceAll(hexDocument(), "AABBCCDDEE"));
+    }
+
+    @Test
+    public void testTypingStopsAtSixDigits() throws Exception {
+        PlainDocument document = new PlainDocument();
+        document.setDocumentFilter(new ColorPickerUtils.HexDocumentFilter());
+        for (char c : "0a1b2c3d".toCharArray()) {
+            document.insertString(document.getLength(), String.valueOf(c), null);
+        }
+        Assert.assertEquals("0A1B2C", document.getText(0, document.getLength()));
+    }
+
+    @Test
+    public void testDocumentOnlyEverHoldsCanonicalHex() throws Exception {
+        String[] pasted =
+            {"#00FF00", "1a2b3c", "rgb(12, 34, 56)", "hello world", "", "0x112233", "#ABCDEF",
+                "  #ab cd ef  ", "AABBCCDDEE", "#00ff00\n"};
+        for (String text : pasted) {
+            String content = replaceAll(hexDocument(), text);
+            Assert.assertTrue("unexpected content '" + content + "' after pasting '" + text + "'",
+                content.matches("[0-9A-F]{0,6}"));
+        }
+    }
+}

--- a/modules/UIComponents/src/test/java/org/gephi/ui/components/ColorPickerUtilsTest.java
+++ b/modules/UIComponents/src/test/java/org/gephi/ui/components/ColorPickerUtilsTest.java
@@ -60,6 +60,32 @@ public class ColorPickerUtilsTest {
     }
 
     @Test
+    public void testTypingInTheMiddleOfAFullFieldOvertypesTheTail() throws Exception {
+        PlainDocument document = hexDocument();
+        document.replace(0, document.getLength(), "FF0000", null);
+        document.insertString(3, "9", null);
+        Assert.assertEquals("FF0900", document.getText(0, document.getLength()));
+    }
+
+    @Test
+    public void testTypingAtTheEndOfAFullFieldIsANoOp() throws Exception {
+        PlainDocument document = hexDocument();
+        document.replace(0, document.getLength(), "FF0000", null);
+        document.insertString(document.getLength(), "9", null);
+        Assert.assertEquals("FF0000", document.getText(0, document.getLength()));
+    }
+
+    @Test
+    public void testReplacingASelectionOvertypesTheTailWhenTheResultWouldOverflow() throws Exception {
+        PlainDocument document = hexDocument();
+        document.replace(0, document.getLength(), "FF0000", null);
+        // Selecting the middle "00" and typing "999" grows the field by one character, which
+        // must come from evicting the last character rather than truncating "999" itself.
+        document.replace(3, 2, "999", null);
+        Assert.assertEquals("FF0999", document.getText(0, document.getLength()));
+    }
+
+    @Test
     public void testDocumentOnlyEverHoldsCanonicalHex() throws Exception {
         String[] pasted =
             {"#00FF00", "1a2b3c", "rgb(12, 34, 56)", "hello world", "", "0x112233", "#ABCDEF",


### PR DESCRIPTION
## Description

Pasting a colour code into the hex field of the colour picker dialog crashes on the event dispatch thread instead of applying the colour. Reported through the in-app reporter as 29 users / 112 events ([GEPHI-5MG](https://gephi.sentry.io/issues/GEPHI-5MG), from the colour buttons) and 8 users / 46 events ([GEPHI-5RJ](https://gephi.sentry.io/issues/GEPHI-5RJ), from the gradient slider).

### Mechanism

The dialog is `com.bric.swing.ColorPicker`, from the binary-only `com.mastfrog:colorchooser:1.5` artifact re-exported by `modules/UILibraryWrapper`. 1.5 is the latest published version, so there is no upgrade to take.

Its hex field is wired so that every edit rewrites that same field:

1. A paste goes through `JTextComponent.replaceSelection()` → `AbstractDocument.replace()`, which takes the document's write lock and then fires an insert notification with `notifyingListeners` set.
2. `ColorPicker$HexDocumentListener.insertUpdate` (`ColorPicker.java:495`) → `changedUpdate` (`ColorPicker.java:464`) strips the text to hex digits and, when that leaves exactly six, calls `ColorPicker.setRGB(...)` synchronously — still inside the notification.
3. `setRGB` calls `updateHexField()`, which rewrites the field to canonical six-digit uppercase hex via `hexField.setText(...)` (`ColorPicker.java:1049`) whenever the current text differs from it.
4. That `setText` re-enters `AbstractDocument.replace()` → `writeLock()`, which refuses to mutate a document that is still notifying, and throws `IllegalStateException: Attempt to mutate in notification`.

The picker's `adjustingHexField` guard (`ColorPicker.java:455`) only covers the reverse direction, `setRGB` → `updateHexField` → listener. On the inbound paste path it is still zero.

Which inputs fail follows directly from step 3: pasting `00FF00` works, because the pasted text already equals the canonical form and `updateHexField` has nothing to write, while pasting `#00FF00` — the form you get from copying a colour almost anywhere — always fails.

<details>
<summary>Stack trace (GEPHI-5MG)</summary>

```
at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
at java.security.AccessController.doPrivileged(Unknown Source)
at java.awt.EventQueue$4.run(Unknown Source)
at java.awt.EventQueue$4.run(Unknown Source)
at java.awt.EventQueue.dispatchEventImpl(Unknown Source)
at java.awt.Component.dispatchEvent(Unknown Source)
at java.awt.Window.dispatchEventImpl(Unknown Source)
at java.awt.Container.dispatchEventImpl(Unknown Source)
at java.awt.LightweightDispatcher.dispatchEvent(Unknown Source)
at java.awt.LightweightDispatcher.processMouseEvent(Unknown Source)
at java.awt.LightweightDispatcher.retargetMouseEvent(Unknown Source)
at java.awt.Component.dispatchEvent(Unknown Source)
at java.awt.Container.dispatchEventImpl(Unknown Source)
at java.awt.Component.dispatchEventImpl(Unknown Source)
at java.awt.Container.processEvent(Unknown Source)
at java.awt.Component.processEvent(Unknown Source)
at javax.swing.JComponent.processMouseEvent(Unknown Source)
at java.awt.Component.processMouseEvent(Unknown Source)
at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(Unknown Source)
at javax.swing.DefaultButtonModel.setPressed(Unknown Source)
at javax.swing.DefaultButtonModel.fireActionPerformed(Unknown Source)
at javax.swing.AbstractButton$Handler.actionPerformed(Unknown Source)
at javax.swing.AbstractButton.fireActionPerformed(Unknown Source)
at org.gephi.ui.components.JColorButton$3.actionPerformed(JColorButton.java:129)
at com.bric.swing.ColorPicker.showDialog(ColorPicker.java:230)
at com.bric.swing.ColorPicker.showDialog(ColorPicker.java:257)
at java.awt.Dialog.setVisible(Unknown Source)
at java.awt.Window.setVisible(Unknown Source)
at java.awt.Component.setVisible(Unknown Source)
at java.awt.Component.show(Unknown Source)
at java.awt.Dialog.show(Unknown Source)
at java.awt.WaitDispatchSupport.enter(Unknown Source)
at java.security.AccessController.doPrivileged(Unknown Source)
at java.awt.WaitDispatchSupport$4.run(Unknown Source)
at java.awt.WaitDispatchSupport$4.run(Unknown Source)
at java.awt.WaitDispatchSupport$2.run(Unknown Source)
at java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
at java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
at java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
at org.netbeans.core.TimableEventQueue.dispatchEvent(TimableEventQueue.java:136)
at java.awt.EventQueue.dispatchEvent(Unknown Source)
[... AWT/keyboard-focus/paste dispatch frames omitted, same shape as below ...]
at javax.swing.text.DefaultEditorKit$PasteAction.actionPerformed(Unknown Source)
at javax.swing.text.JTextComponent.paste(Unknown Source)
at javax.swing.text.JTextComponent.invokeAction(Unknown Source)
at javax.swing.TransferHandler$TransferAction.actionPerformed(Unknown Source)
[... TransferHandler privilege-wrapping frames omitted ...]
at javax.swing.plaf.basic.BasicTextUI$TextTransferHandler.importData(Unknown Source)
at javax.swing.TransferHandler.importData(Unknown Source)
at javax.swing.plaf.basic.BasicTextUI$TextTransferHandler.importData(Unknown Source)
at javax.swing.plaf.basic.BasicTextUI$TextTransferHandler.handleReaderImport(Unknown Source)
at javax.swing.text.JTextComponent.replaceSelection(Unknown Source)
at javax.swing.text.AbstractDocument.replace(Unknown Source)
at javax.swing.text.PlainDocument.insertString(Unknown Source)
at javax.swing.text.AbstractDocument.insertString(Unknown Source)
at javax.swing.text.AbstractDocument.handleInsertString(Unknown Source)
at javax.swing.text.AbstractDocument.fireInsertUpdate(Unknown Source)
at com.bric.swing.ColorPicker$HexDocumentListener.insertUpdate(ColorPicker.java:495)
at com.bric.swing.ColorPicker$HexDocumentListener.changedUpdate(ColorPicker.java:464)
at com.bric.swing.ColorPicker.setRGB(ColorPicker.java:881)
at com.bric.swing.ColorPicker.updateHexField(ColorPicker.java:1049)
at javax.swing.text.JTextComponent.setText(Unknown Source)
at javax.swing.text.AbstractDocument.replace(Unknown Source)
at javax.swing.text.AbstractDocument.writeLock(Unknown Source)
```

</details>

<details>
<summary>Stack trace (GEPHI-5RJ)</summary>

```
...
at org.gephi.ui.components.gradientslider.MultiThumbSliderUI.mousePressed(MultiThumbSliderUI.java:476)
at org.gephi.ui.components.gradientslider.GradientSlider.doDoubleClick(GradientSlider.java:181)
at org.gephi.ui.components.gradientslider.GradientSlider.showColorPicker(GradientSlider.java:225)
at com.bric.swing.ColorPicker.showDialog(ColorPicker.java:230)
at com.bric.swing.ColorPicker.showDialog(ColorPicker.java:257)
at java.awt.Dialog.setVisible(Unknown Source)
[... same AWT dialog/event-pump frames as GEPHI-5MG above, then: ...]
at javax.swing.text.DefaultEditorKit$PasteAction.actionPerformed(Unknown Source)
at javax.swing.text.JTextComponent.paste(Unknown Source)
[... same paste-import chain as GEPHI-5MG above ...]
at com.bric.swing.ColorPicker$HexDocumentListener.insertUpdate(ColorPicker.java:495)
at com.bric.swing.ColorPicker$HexDocumentListener.changedUpdate(ColorPicker.java:464)
at com.bric.swing.ColorPicker.setRGB(ColorPicker.java:881)
at com.bric.swing.ColorPicker.updateHexField(ColorPicker.java:1049)
at javax.swing.text.JTextComponent.setText(Unknown Source)
at javax.swing.text.AbstractDocument.replace(Unknown Source)
at javax.swing.text.AbstractDocument.writeLock(Unknown Source)
```

</details>

### Why the Gephi frame appears in the reports

Worth spelling out, because it is misleading. Nothing in Gephi ever sees this exception. The dialog is modal, so it is pumping events inside `Dialog.show()`, and `EventDispatchThread.pumpOneEventForFilters` catches `Throwable` and passes it to `processException()` → `getUncaughtExceptionHandler()`. On the NetBeans Platform that handler is `TopLogging$AWTHandler`, installed with `Thread.setDefaultUncaughtExceptionHandler`, which logs the throwable to the `global` logger; the record reaches the root logger and so `ReporterHandler` (`modules/DesktopBranding/.../Installer.java:126`). `ColorPicker.showDialog` then returns normally, as if the dialog had been cancelled.

The Gephi frames in the traces above are therefore ancestors of the modal pump, not a propagation path — they are just the innermost application frames still on the stack. A `try`/`catch` around `ColorPicker.showDialog(...)` can never run, at any call site. Confirmed against the real jar: with `showDialog` called from the EDT inside `try/catch (IllegalStateException)` and a programmatic paste of `#00FF00`, the exception went to the default uncaught handler, `showDialog` returned normally, and the catch never fired.

### What changed

Since the exception cannot be intercepted and the third-party class cannot be patched, the fix removes the trigger. New `ColorPickerUtils.showDialog(...)` shows the same picker dialog, but first constrains the hex field to hold at most six uppercase hex digits, using a `DocumentFilter`. The field then always already holds the canonical form, `updateHexField()` never has anything to rewrite, and the reentrant write cannot occur. Paste and drag-and-drop both go through the filter, and the picker's own updates are canonical already so they pass through untouched.

The picker instance is created inside the static `showDialog()` and never exposed, so the filter is installed from a container listener that fires when the picker is added to the dialog — before the dialog is displayable, verified — and is removed in a `finally` when the call returns. The dialog the user sees, including its localised title and buttons, is unchanged. Only the vendor's public API is used (`getExpertControls()`, and the hex field is identified as the one the picker itself listens to); no reflection.

`JColorButton` (both the left-click and right-click paths, which were duplicating the call) and `GradientSlider.showColorPicker()` now go through it.

Measured against the real `colorchooser-1.5` jar, driving the actual dialog with programmatic pastes:

| pasted | before | after |
| --- | --- | --- |
| `#00FF00` | `IllegalStateException: Attempt to mutate in notification` | `00FF00` |
| `#ABCDEF` | `IllegalStateException: Attempt to mutate in notification` | `ABCDEF` |
| `rgb(12, 34, 56)` | `IllegalArgumentException: bad position: 15` | `B12345` |
| `hello world` | `IllegalArgumentException: bad position: 11` | `ED0000` |
| `1a2b3c` | `1a2b3c` | `1A2B3C` |
| `00FF00` | `00FF00` | `00FF00` |

The two `IllegalArgumentException` rows are a second, independent bug on the same path that the fix also closes: the picker's delayed hex update restores the caret to its pre-edit offset after truncating the text to six characters, which is out of range whenever the pasted text was longer. Capping the field at six characters keeps that offset valid. Typing, the opacity slider and the picker-to-field direction were checked separately and are unaffected.

The inline mini-picker in `GradientSlider.ColorPickerPopup` is not affected by any of this — it is built with expert controls hidden, so its hex field is never reachable.

### Follow-up: `JColorBlackWhiteSwitcher`, and overtyping a full field

Review on this PR turned up two more things worth folding in here rather than leaving as separate issues.

**`JColorBlackWhiteSwitcher.java:90`** still called `ColorPicker.showDialog` directly, bypassing the guard entirely. It now goes through `ColorPickerUtils.showDialog`, like `JColorButton` and `GradientSlider`. This isn't just the same defect by inspection — the review pinned it to a confirmed live report, [GEPHI-68Q](https://gephi.sentry.io/issues/GEPHI-68Q) (`IllegalStateException: Attempt to mutate in notification`, culprit `JColorBlackWhiteSwitcher$1.mouseClicked`).

The review also traced a second path to the same picker that this PR does **not** fix: the bundled `net.java.dev.colorchooser.ColorChooser` swatch widget (used in `UniqueColorTransformerPanel`, `PartitionColorTransformerPanel`, `DefaultPanel`, and `EdgeSettingsPanel`) opens the dialog from inside its own UI delegate, `ColorChooserUI.keyboardInvoke`, on Space/Enter or Ctrl/Meta-click — with no Gephi call site to redirect. That accounts for [GEPHI-5D7](https://gephi.sentry.io/issues/GEPHI-5D7) (51 users / 184 events, the largest report in this cluster), and possibly others in the same open cluster ([GEPHI-5FJ](https://gephi.sentry.io/issues/GEPHI-5FJ), [GEPHI-5EZ](https://gephi.sentry.io/issues/GEPHI-5EZ), [GEPHI-5AY](https://gephi.sentry.io/issues/GEPHI-5AY)) whose call site hasn't been pinned down. `ColorChooser` is `final` and its UI delegate (`DefaultColorChooserUI`) is package-private, so there's no non-reflective extension point to hook without reimplementing the widget's rendering — closing this would need a JVM-wide `AWTEventListener` installed once at application startup instead of per dialog open (the same primitive `ColorPickerUtils` already uses, just scoped differently), which is a passive global guard rather than a call-site convention. Deliberately left as a separately-scoped follow-up rather than bundled in here.

**Overtyping a full hex field.** Capping the field at six digits fixed the crash, but editing mid-field without a selection then has no room to insert into once the field is full, so it silently did nothing — e.g. clicking between the `0` and `00` of `FF0000` and typing produced no visible change. `HexDocumentFilter` now evicts characters from the far end of the field to make room for what's typed or pasted at the caret, so a full field overtypes like a fixed-width buffer instead of ignoring the keystroke: typing `9` at that position now gives `FF0900`. Typing at the very end of an already-full field is still a no-op, since there's nothing after the caret to evict. Covered by three new cases in `ColorPickerUtilsTest`.

Sentry: [GEPHI-5MG](https://gephi.sentry.io/issues/GEPHI-5MG), [GEPHI-5RJ](https://gephi.sentry.io/issues/GEPHI-5RJ), [GEPHI-68Q](https://gephi.sentry.io/issues/GEPHI-68Q).

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

`ColorPickerUtilsTest` covers the property the fix rests on: whatever is pasted or typed, the hex document only ever holds up to six uppercase hex digits, which is what leaves the picker with nothing to rewrite from inside its own notification. It also covers the overtype behavior added in the follow-up commit: typing mid-field on a full field evicts from the tail, typing at the very end of a full field is a no-op, and replacing a selection that would overflow the field evicts from the tail too.

The end-to-end path cannot be automated here — `new ColorPicker(...)` calls `Toolkit.getScreenSize()` and throws `HeadlessException`, and CI runs with `-Djava.awt.headless=true` — so the full dialog-plus-paste sequence was verified manually against the real jar instead; those results are the table above.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed

