### PR TITLE
Fix partition filters corrupting project files when the null bucket is selected

### DIFF
--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/GenericPropertyEditor.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/GenericPropertyEditor.java
@@ -74,8 +74,12 @@ public class GenericPropertyEditor extends PropertyEditorSupport {
                 bos = new ByteArrayOutputStream();
                 oos = new ObjectOutputStream(bos);
                 oos.writeObject(val);
+                oos.flush();
+                return java.util.Base64.getEncoder().encodeToString(bos.toByteArray());
             } catch (Exception e) {
                 Exceptions.printStackTrace(e);
+                //Partially written bytes can't be read back, don't persist them
+                return null;
             } finally {
                 if (oos != null) {
                     try {
@@ -89,9 +93,6 @@ public class GenericPropertyEditor extends PropertyEditorSupport {
                     } catch (IOException ex) {
                     }
                 }
-            }
-            if (bos != null) {
-                return java.util.Base64.getEncoder().encodeToString(bos.toByteArray());
             }
         }
         return "null";

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/GenericPropertyEditorTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/GenericPropertyEditorTest.java
@@ -1,0 +1,37 @@
+package org.gephi.filters;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.gephi.filters.plugin.partition.PartitionBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GenericPropertyEditorTest {
+
+    @Test
+    public void testPartitionFilterWithNullPartRoundTrip() {
+        PartitionBuilder.PartitionFilter filter = new PartitionBuilder.NodePartitionFilter(null, null);
+        filter.addPart(null);
+        filter.addPart("foo");
+
+        GenericPropertyEditor writer = new GenericPropertyEditor();
+        writer.setValue(filter.getParts());
+        String text = writer.getAsText();
+        Assert.assertNotNull(text);
+        Assert.assertNotEquals("null", text);
+
+        GenericPropertyEditor reader = new GenericPropertyEditor();
+        reader.setAsText(text);
+        Assert.assertEquals(filter.getParts(), reader.getValue());
+    }
+
+    @Test
+    public void testNotSerializableValueIsNotPersisted() {
+        Set<Object> parts = new HashSet<>();
+        parts.add(new Object());
+
+        GenericPropertyEditor writer = new GenericPropertyEditor();
+        writer.setValue(parts);
+        Assert.assertNull(writer.getAsText());
+    }
+}

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/InterEdgesBuilder.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/InterEdgesBuilder.java
@@ -44,6 +44,7 @@ package org.gephi.filters.plugin.partition;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.swing.Icon;
 import javax.swing.JPanel;
 import org.gephi.appearance.api.AppearanceController;
@@ -173,9 +174,7 @@ public class InterEdgesBuilder implements CategoryBuilder {
         public boolean evaluate(Graph graph, Edge edge) {
             Object srcValue = partition.getValue(edge.getSource(), graph);
             Object destValue = partition.getValue(edge.getTarget(), graph);
-            srcValue = srcValue == null ? NULL : srcValue;
-            destValue = destValue == null ? NULL : destValue;
-            return parts.contains(srcValue) && parts.contains(destValue) && srcValue.equals(destValue);
+            return parts.contains(srcValue) && parts.contains(destValue) && Objects.equals(srcValue, destValue);
         }
 
         @Override

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/IntraEdgesBuilder.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/IntraEdgesBuilder.java
@@ -44,6 +44,7 @@ package org.gephi.filters.plugin.partition;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.swing.Icon;
 import javax.swing.JPanel;
 import org.gephi.appearance.api.AppearanceController;
@@ -174,9 +175,7 @@ public class IntraEdgesBuilder implements CategoryBuilder {
         public boolean evaluate(Graph graph, Edge edge) {
             Object srcValue = partition.getValue(edge.getSource(), graph);
             Object destValue = partition.getValue(edge.getTarget(), graph);
-            srcValue = srcValue == null ? NULL : srcValue;
-            destValue = destValue == null ? NULL : destValue;
-            return parts.contains(srcValue) && parts.contains(destValue) && !srcValue.equals(destValue);
+            return parts.contains(srcValue) && parts.contains(destValue) && !Objects.equals(srcValue, destValue);
         }
     }
 }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/PartitionBuilder.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/PartitionBuilder.java
@@ -228,7 +228,6 @@ public class PartitionBuilder implements CategoryBuilder {
 
     public static abstract class PartitionFilter implements Filter {
 
-        protected static final Object NULL = new Object();
         protected Partition partition;
         protected final AppearanceModel appearanceModel;
         protected FilterProperty[] filterProperties;
@@ -255,7 +254,7 @@ public class PartitionBuilder implements CategoryBuilder {
         public boolean evaluate(Graph graph, Node node) {
             Object value = partition.getValue(node, graph);
             if (value == null) {
-                return parts.contains(NULL);
+                return parts.contains(null);
             } else if (flattenList && partition.getColumn().isArray()) {
                 return listContains(value);
             } else {
@@ -277,7 +276,7 @@ public class PartitionBuilder implements CategoryBuilder {
         public boolean evaluate(Graph graph, Edge edge) {
             Object value = partition.getValue(edge, graph);
             if (value == null) {
-                return parts.contains(NULL);
+                return parts.contains(null);
             } else if (flattenList && partition.getColumn().isArray()) {
                 return listContains(value);
             } else {
@@ -289,21 +288,13 @@ public class PartitionBuilder implements CategoryBuilder {
         }
 
         public void addPart(Object value) {
-            if (value == null) {
-                if (parts.add(NULL)) {
-                    getProperties()[1].setValue(parts);
-                }
-            } else if (parts.add(value)) {
+            if (parts.add(value)) {
                 getProperties()[1].setValue(parts);
             }
         }
 
         public void removePart(Object value) {
-            if (value == null) {
-                if (parts.remove(NULL)) {
-                    getProperties()[1].setValue(parts);
-                }
-            } else if (parts.remove(value)) {
+            if (parts.remove(value)) {
                 getProperties()[1].setValue(parts);
             }
         }

--- a/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/PartitionBuilder.java
+++ b/modules/FiltersPlugin/src/main/java/org/gephi/filters/plugin/partition/PartitionBuilder.java
@@ -359,7 +359,7 @@ public class PartitionBuilder implements CategoryBuilder {
         }
 
         public void setParts(Set<Object> parts) {
-            this.parts = parts;
+            this.parts = parts != null ? parts : new HashSet<>();
         }
 
         public Column getColumn() {

--- a/modules/FiltersPlugin/src/test/java/org/gephi/filters/plugin/partition/PartitionBuilderTest.java
+++ b/modules/FiltersPlugin/src/test/java/org/gephi/filters/plugin/partition/PartitionBuilderTest.java
@@ -1,0 +1,15 @@
+package org.gephi.filters.plugin.partition;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PartitionBuilderTest {
+
+    @Test
+    public void testSetPartsWithNullFallsBackToEmptySet() {
+        PartitionBuilder.PartitionFilter filter = new PartitionBuilder.NodePartitionFilter(null, null);
+        filter.setParts(null);
+        Assert.assertNotNull(filter.getParts());
+        Assert.assertTrue(filter.getParts().isEmpty());
+    }
+}


### PR DESCRIPTION
## Description

Saving a project with a partition filter whose empty/null bucket is selected fails and writes a corrupt blob into the `.gephi` file; reopening that project then fails too, making it permanently unopenable. This accounts for [GEPHI-5PT](https://gephi.sentry.io/issues/GEPHI-5PT) (write side, 10 users / 54 events) and [GEPHI-5SM](https://gephi.sentry.io/issues/GEPHI-5SM) (read side, 11 users / 61 events).

### Mechanism

Two defects compound into a data-loss bug.

**1. The null-bucket sentinel is not serializable.** `PartitionBuilder.PartitionFilter` declared `protected static final Object NULL = new Object()` (`PartitionBuilder.java:231`) and stored it in `Set<Object> parts` whenever the user selected the "null" bucket (`PartitionBuilder.java:293`, `addPart`). `parts` is exposed as a `Set.class` filter property (`PartitionBuilder.java:341`), and `Set.class` properties are persisted by `GenericPropertyEditor` (`FilterControllerImpl.java:98`), which Java-serializes the whole set through `ObjectOutputStream` (`GenericPropertyEditor.java:76`). `java.lang.Object` does not implement `Serializable`, so `HashSet.writeObject` throws `NotSerializableException: java.lang.Object` on every save.

**2. The failed write is persisted anyway.** `GenericPropertyEditor.getAsText()` caught that exception, logged it, and then still returned `Base64.getEncoder().encodeToString(bos.toByteArray())` from the bytes `ObjectOutputStream` had written before it aborted. `FilterModelPersistenceProvider.writeParameter` (`FilterModelPersistenceProvider.java:168-169`) writes that string straight into the XML. `ObjectOutputStream` serializes the abort marker into the stream, so the truncated blob literally contains an encoded `NotSerializableException`. When the project is reopened, `readQuery` → `Serialization.fromText` → `GenericPropertyEditor.setAsText` (`GenericPropertyEditor.java:108`) reads it back and `ObjectInputStream` rethrows it as `WriteAbortedException: writing aborted; java.io.NotSerializableException: java.lang.Object`.

So a project saved once with a null-bucket partition filter selected is corrupt on disk from that moment on, and every subsequent open fails.

<details>
<summary>Stack trace (GEPHI-5PT)</summary>

```
at java.lang.Thread.run(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
at java.util.concurrent.FutureTask.run(Unknown Source)
at org.gephi.utils.longtask.api.LongTaskExecutor$RunningLongTask.call(LongTaskExecutor.java:338)
at org.gephi.desktop.project.ProjectControllerUIImpl$1.call(ProjectControllerUIImpl.java:233)
at org.gephi.desktop.project.ProjectControllerUIImpl$1.call(ProjectControllerUIImpl.java:236)
at org.gephi.project.impl.ProjectControllerImpl.saveProject(ProjectControllerImpl.java:192)
at org.gephi.utils.longtask.api.LongTaskExecutor.execute(LongTaskExecutor.java:141)
at org.gephi.utils.longtask.api.LongTaskExecutor.execute(LongTaskExecutor.java:179)
at org.gephi.utils.longtask.api.LongTaskExecutor$RunningLongTask.call(LongTaskExecutor.java:336)
at org.gephi.project.impl.ProjectControllerImpl.lambda$saveProject$6(ProjectControllerImpl.java:194)
at org.gephi.project.io.SaveTask.run(SaveTask.java:156)
at org.gephi.project.io.SaveTask.writeWorkspaceChildrenXML(SaveTask.java:274)
at org.gephi.project.io.GephiWriter.writeWorkspaceChildren(GephiWriter.java:157)
at org.gephi.filters.FilterModelPersistenceProvider.writeXML(FilterModelPersistenceProvider.java:85)
at org.gephi.filters.FilterModelPersistenceProvider.writeXML(FilterModelPersistenceProvider.java:120)
at org.gephi.filters.FilterModelPersistenceProvider.writeQuery(FilterModelPersistenceProvider.java:153)
at org.gephi.filters.FilterModelPersistenceProvider.writeParameter(FilterModelPersistenceProvider.java:168)
at org.gephi.utils.Serialization.toText(Serialization.java:227)
at org.gephi.filters.GenericPropertyEditor.getAsText(GenericPropertyEditor.java:76)
at java.io.ObjectOutputStream.writeObject(Unknown Source)
[... ObjectOutputStream internals ...]
at java.util.HashSet.writeObject(Unknown Source)
at java.io.ObjectOutputStream.writeObject(Unknown Source)
at java.io.ObjectOutputStream.writeObject0(Unknown Source)
```

</details>

<details>
<summary>Stack trace (GEPHI-5SM)</summary>

```
at java.lang.Thread.run(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
at java.util.concurrent.FutureTask.run(Unknown Source)
at org.gephi.utils.longtask.api.LongTaskExecutor$RunningLongTask.call(LongTaskExecutor.java:336)
at org.gephi.desktop.project.ProjectControllerUIImpl.lambda$openProject$6(ProjectControllerUIImpl.java:393)
at org.gephi.project.impl.ProjectControllerImpl.openProject(ProjectControllerImpl.java:143)
at org.gephi.utils.longtask.api.LongTaskExecutor.execute(LongTaskExecutor.java:165)
at org.gephi.utils.longtask.api.LongTaskExecutor.execute(LongTaskExecutor.java:179)
at org.gephi.utils.longtask.api.LongTaskExecutor$RunningLongTask.call(LongTaskExecutor.java:338)
at org.gephi.project.impl.ProjectControllerImpl.lambda$openProject$3(ProjectControllerImpl.java:144)
at org.gephi.project.io.LoadTask.execute(LoadTask.java:168)
at org.gephi.project.io.LoadTask.readWorkspaceChildrenXML(LoadTask.java:351)
at org.gephi.filters.FilterModelPersistenceProvider.readXML(FilterModelPersistenceProvider.java:100)
at org.gephi.filters.FilterModelPersistenceProvider.readXML(FilterModelPersistenceProvider.java:190)
at org.gephi.filters.FilterModelPersistenceProvider.readQuery(FilterModelPersistenceProvider.java:326)
at org.gephi.utils.Serialization.fromText(Serialization.java:289)
at org.gephi.filters.GenericPropertyEditor.setAsText(GenericPropertyEditor.java:108)
at java.io.ObjectInputStream.readObject(Unknown Source)
[... ObjectInputStream internals ...]
at java.util.HashSet.readObject(Unknown Source)
at java.io.ObjectInputStream.readObject(Unknown Source)
```

</details>

### Changes

**`PartitionBuilder.java`** — the `NULL` sentinel is removed and the null bucket is represented by `null` itself. `HashSet` accepts `null` as an element, so no marker object is needed at all: `addPart`/`removePart` collapse to a single unconditional `parts.add(value)` / `parts.remove(value)`, and `evaluate` keeps its existing branch but checks `parts.contains(null)`.

I deliberately did not swap the sentinel for a serializable class or enum. That would leave a `FiltersPlugin` class name inside the serialized payload, and the read side deserializes from `FiltersImpl` (`GenericPropertyEditor.setAsText`), which has no module dependency on `FiltersPlugin` and no custom `resolveClass` — so it would trade `NotSerializableException` for `ClassNotFoundException`, and would also break forward compatibility with older Gephi versions reading the file. Using `null` keeps the persisted set made of JDK types only, exactly as it already is for every non-null bucket.

Two behaviours that were previously inconsistent now line up as a side effect, because `selectAll()` already put a plain `null` into `parts` (`new HashSet<>(partition.getValues(graph))`) while `evaluate` looked for the sentinel: "Select all" now really selects the null bucket, and the partition panel's checkbox for that bucket is restored correctly (`PartitionPanel.java:200,207` do `currentParts.contains(p)` with a possibly-null `p`).

**`InterEdgesBuilder.java` / `IntraEdgesBuilder.java`** — these inherit `parts` and used the sentinel to avoid a null receiver in `srcValue.equals(destValue)`. They now compare with `Objects.equals(...)`, which is required since the compared values can be `null`. Semantics are unchanged: two null-valued endpoints still count as the same partition.

**`GenericPropertyEditor.java`** — `getAsText()` returns the Base64 only if `writeObject` actually succeeded, and returns `null` on failure. This is not a symptom patch for the case above (that one is fixed at the root, in `PartitionBuilder`); it is what keeps any *future* non-serializable value from silently corrupting a project file. Returning `null` rather than `"null"` is deliberate: `writeParameter` turns `null` into an empty parameter, which `readQuery` skips (`FilterModelPersistenceProvider.java:325`), leaving the property at its default. `"null"` would instead deserialize to `null` and call `setParts(null)`, NPE-ing the filter on the next evaluation.

### Tests

`GenericPropertyEditorTest` covers both halves at the serialization boundary, with no AWT/Swing needed:

- `testPartitionFilterWithNullPartRoundTrip` builds a real `PartitionFilter`, selects the null bucket via `addPart(null)`, and asserts the `parts` set survives a `getAsText()`/`setAsText()` round trip intact.
- `testNotSerializableValueIsNotPersisted` asserts a set holding a non-serializable value yields no text at all, rather than a truncated blob.

Both fail on `master` (the first with `expected:<[foo, java.lang.Object@...]> but was:<null>`, the second returning a Base64 blob with a serialized `NotSerializableException` inside it) and pass with this change.

Sentry: [GEPHI-5PT](https://gephi.sentry.io/issues/GEPHI-5PT) · [GEPHI-5SM](https://gephi.sentry.io/issues/GEPHI-5SM)

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed


## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren’t needed
