### PR TITLE
Report statistics execution failures with the failing algorithm name

### DIFF
--- a/modules/StatisticsAPI/pom.xml
+++ b/modules/StatisticsAPI/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-dialogs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-util-lookup</artifactId>
         </dependency>
         <dependency>

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsControllerImpl.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsControllerImpl.java
@@ -63,6 +63,8 @@ import org.gephi.utils.longtask.api.LongTaskListener;
 import org.gephi.utils.longtask.spi.LongTask;
 import org.gephi.utils.progress.Progress;
 import org.gephi.utils.progress.ProgressTicket;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
@@ -112,9 +114,14 @@ public class StatisticsControllerImpl implements StatisticsController, Controlle
             executor.setLongTaskListener(listener);
         }
         executor.setDefaultErrorHandler(t -> {
-            String message = NbBundle.getMessage(StatisticsControllerImpl.class,
-                "StatisticsControllerImpl.errorHandler.critical", builder.getName(), t.toString());
-            Exceptions.printStackTrace(Exceptions.attachLocalizedMessage(t, message));
+            Exceptions.printStackTrace(t);
+            String cause = t.getLocalizedMessage() != null ? t.getLocalizedMessage() : t.toString();
+            DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(NbBundle
+                .getMessage(StatisticsControllerImpl.class, "StatisticsControllerImpl.errorHandler.critical",
+                    builder.getName(), cause), NotifyDescriptor.ERROR_MESSAGE));
+            if (listener != null) {
+                listener.taskFinished(statistics instanceof LongTask ? (LongTask) statistics : null);
+            }
         });
 
         final StatisticsModelImpl model = getModel();

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsControllerImpl.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsControllerImpl.java
@@ -63,7 +63,9 @@ import org.gephi.utils.longtask.api.LongTaskListener;
 import org.gephi.utils.longtask.spi.LongTask;
 import org.gephi.utils.progress.Progress;
 import org.gephi.utils.progress.ProgressTicket;
+import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 
@@ -104,11 +106,16 @@ public class StatisticsControllerImpl implements StatisticsController, Controlle
 
     @Override
     public void execute(final Statistics statistics, LongTaskListener listener) {
-        StatisticsBuilder builder = getBuilder(statistics.getClass());
+        final StatisticsBuilder builder = getBuilder(statistics.getClass());
         LongTaskExecutor executor = new LongTaskExecutor(true, "Statistics " + builder.getName(), 10);
         if (listener != null) {
             executor.setLongTaskListener(listener);
         }
+        executor.setDefaultErrorHandler(t -> {
+            String message = NbBundle.getMessage(StatisticsControllerImpl.class,
+                "StatisticsControllerImpl.errorHandler.critical", builder.getName(), t.toString());
+            Exceptions.printStackTrace(Exceptions.attachLocalizedMessage(t, message));
+        });
 
         final StatisticsModelImpl model = getModel();
         if (statistics instanceof DynamicStatistics) {

--- a/modules/StatisticsAPI/src/main/resources/org/gephi/statistics/Bundle.properties
+++ b/modules/StatisticsAPI/src/main/resources/org/gephi/statistics/Bundle.properties
@@ -1,0 +1,1 @@
+StatisticsControllerImpl.errorHandler.critical={0} failed to execute due to the following error: {1}

--- a/modules/StatisticsAPI/src/test/java/org/gephi/statistics/StatisticsControllerImplTest.java
+++ b/modules/StatisticsAPI/src/test/java/org/gephi/statistics/StatisticsControllerImplTest.java
@@ -1,6 +1,9 @@
 package org.gephi.statistics;
 
+import java.awt.Dialog;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Handler;
@@ -13,13 +16,16 @@ import org.gephi.statistics.spi.StatisticsBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.netbeans.junit.MockServices;
-import org.openide.util.Exceptions;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 
 public class StatisticsControllerImplTest {
 
     @Test
     public void testExecuteFailingStatistics() throws Exception {
-        MockServices.setServices(MockStatisticsBuilder.class);
+        MockServices.setServices(MockStatisticsBuilder.class, MockDialogDisplayer.class);
+        MockDialogDisplayer.MESSAGES.clear();
 
         final StatisticsModelImpl model = new StatisticsModelImpl(new WorkspaceImpl(null, 0));
         StatisticsControllerImpl controller = new StatisticsControllerImpl() {
@@ -29,14 +35,12 @@ public class StatisticsControllerImplTest {
             }
         };
 
-        CountDownLatch reported = new CountDownLatch(1);
-        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        AtomicReference<Throwable> logged = new AtomicReference<>();
         Handler handler = new Handler() {
             @Override
             public void publish(LogRecord record) {
                 if (record.getThrown() instanceof NumberFormatException) {
-                    thrown.set(record.getThrown());
-                    reported.countDown();
+                    logged.set(record.getThrown());
                 }
             }
 
@@ -49,19 +53,22 @@ public class StatisticsControllerImplTest {
             }
         };
 
+        CountDownLatch taskFinished = new CountDownLatch(1);
         Logger rootLogger = Logger.getLogger("");
         rootLogger.addHandler(handler);
         try {
-            controller.execute(new MockStatistics(), null);
-            Assert.assertTrue("The statistics failure isn't reported", reported.await(10, TimeUnit.SECONDS));
+            controller.execute(new MockStatistics(), task -> taskFinished.countDown());
+
+            String message = MockDialogDisplayer.MESSAGES.poll(10, TimeUnit.SECONDS);
+            Assert.assertNotNull("The statistics failure isn't reported to the user", message);
+            Assert.assertTrue("The reported failure doesn't name the statistics",
+                message.contains(MockStatisticsBuilder.NAME));
+            Assert.assertTrue("The listener isn't notified of the failure", taskFinished.await(10, TimeUnit.SECONDS));
         } finally {
             rootLogger.removeHandler(handler);
         }
 
-        String message = Exceptions.findLocalizedMessage(thrown.get());
-        Assert.assertNotNull("The reported failure has no message for the user", message);
-        Assert.assertTrue("The reported failure doesn't name the statistics",
-            message.contains(MockStatisticsBuilder.NAME));
+        Assert.assertNotNull("The statistics failure isn't logged", logged.get());
     }
 
     public static class MockStatistics implements Statistics {
@@ -94,6 +101,22 @@ public class StatisticsControllerImplTest {
         @Override
         public Class<? extends Statistics> getStatisticsClass() {
             return MockStatistics.class;
+        }
+    }
+
+    public static class MockDialogDisplayer extends DialogDisplayer {
+
+        static final BlockingQueue<String> MESSAGES = new LinkedBlockingQueue<>();
+
+        @Override
+        public Object notify(NotifyDescriptor descriptor) {
+            MESSAGES.add(String.valueOf(descriptor.getMessage()));
+            return NotifyDescriptor.CLOSED_OPTION;
+        }
+
+        @Override
+        public Dialog createDialog(DialogDescriptor descriptor) {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/modules/StatisticsAPI/src/test/java/org/gephi/statistics/StatisticsControllerImplTest.java
+++ b/modules/StatisticsAPI/src/test/java/org/gephi/statistics/StatisticsControllerImplTest.java
@@ -1,0 +1,99 @@
+package org.gephi.statistics;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.project.impl.WorkspaceImpl;
+import org.gephi.statistics.spi.Statistics;
+import org.gephi.statistics.spi.StatisticsBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.netbeans.junit.MockServices;
+import org.openide.util.Exceptions;
+
+public class StatisticsControllerImplTest {
+
+    @Test
+    public void testExecuteFailingStatistics() throws Exception {
+        MockServices.setServices(MockStatisticsBuilder.class);
+
+        final StatisticsModelImpl model = new StatisticsModelImpl(new WorkspaceImpl(null, 0));
+        StatisticsControllerImpl controller = new StatisticsControllerImpl() {
+            @Override
+            public StatisticsModelImpl getModel() {
+                return model;
+            }
+        };
+
+        CountDownLatch reported = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record.getThrown() instanceof NumberFormatException) {
+                    thrown.set(record.getThrown());
+                    reported.countDown();
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        Logger rootLogger = Logger.getLogger("");
+        rootLogger.addHandler(handler);
+        try {
+            controller.execute(new MockStatistics(), null);
+            Assert.assertTrue("The statistics failure isn't reported", reported.await(10, TimeUnit.SECONDS));
+        } finally {
+            rootLogger.removeHandler(handler);
+        }
+
+        String message = Exceptions.findLocalizedMessage(thrown.get());
+        Assert.assertNotNull("The reported failure has no message for the user", message);
+        Assert.assertTrue("The reported failure doesn't name the statistics",
+            message.contains(MockStatisticsBuilder.NAME));
+    }
+
+    public static class MockStatistics implements Statistics {
+
+        @Override
+        public void execute(GraphModel graphModel) {
+            throw new NumberFormatException("Infinite or NaN");
+        }
+
+        @Override
+        public String getReport() {
+            return "";
+        }
+    }
+
+    public static class MockStatisticsBuilder implements StatisticsBuilder {
+
+        public static final String NAME = "Mock statistics";
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public Statistics getStatistics() {
+            return new MockStatistics();
+        }
+
+        @Override
+        public Class<? extends Statistics> getStatisticsClass() {
+            return MockStatistics.class;
+        }
+    }
+}


### PR DESCRIPTION
## Description

When a statistics algorithm throws, the user gets an anonymous "unexpected exception" crash report, no indication of which algorithm failed, and a Statistics panel row that keeps spinning for the rest of the session — 16 users and 48 events, all from a third-party "Bridging Centrality" plugin whose metric computation feeds a NaN value into `new BigDecimal(...)`.

**Mechanism**

* `StatisticsControllerUIImpl.execute()` (`modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java:149`) marks the statistics as running (`StatisticsModelUIImpl.setRunning(statistics, true)`) and calls `StatisticsControllerImpl.execute(Statistics, LongTaskListener)` (`modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsControllerImpl.java:106`).
* That method creates its own executor (`StatisticsControllerImpl.java:108`) and sets a `LongTaskListener` on it, but never sets an error handler, and both `executor.execute(...)` calls pass `null` as the trailing error-handler argument (`StatisticsControllerImpl.java:122` and `:131`).
* The algorithm runs inside `LongTaskExecutor.RunningLongTask.call()`, whose `catch (Throwable e)` (`modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java:364`) tries the per-task handler, then the executor's default handler, and — both being `null` here — falls through to the last-resort `Logger.getLogger("").log(Level.SEVERE, "", e)` (`LongTaskExecutor.java:375`).
* That log record carries no message, so the raw throwable is all that is left: the root-logger handler installed at `modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/Installer.java:126` picks it up in `ReporterHandler.publish()` and turns it into a Gephi crash report (`ReporterHandler.java:116`), with nothing telling the user that a statistics algorithm — here a plugin Gephi has no control over — is what failed.
* The failing task is then completed with `finished(this, false)` (`LongTaskExecutor.java:383`), i.e. without notifying the listener — failure is the only completion path that skips it, cancellation notifies via `InterruptTimerTask` (`LongTaskExecutor.java:457`). So `StatisticsControllerUIImpl`'s listener never runs, the statistics stays in `StatisticsModelUIImpl`'s running list (`StatisticsModelUIImpl.java:118`), and `StatisticsFrontEnd.refreshModel()` keeps that row busy with a "Cancel" button that only calls `statistics.cancel()` and can never clear the flag. `StatisticsUI.unsetup()` is skipped as well.

<details>
<summary>Stack trace (GEPHI-5GK)</summary>

```
at java.lang.Thread.run(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
at java.util.concurrent.FutureTask.run(Unknown Source)
at org.gephi.utils.longtask.api.LongTaskExecutor$RunningLongTask.call(LongTaskExecutor.java:336)
at org.gephi.statistics.StatisticsControllerImpl$2.run(StatisticsControllerImpl.java:129)
at org.gephi.statistics.StatisticsControllerImpl.executeStatic(StatisticsControllerImpl.java:148)
at ia.ppgco.facom.ufu.br.gephi.plugin.bridgingcoefficient.BridgingCentralityMetric.execute(BridgingCentralityMetric.java:89)
at ia.ppgco.facom.ufu.br.gephi.plugin.bridgingcoefficient.BridgingCentralityMetric.execute(BridgingCentralityMetric.java:117)
at ia.ppgco.facom.ufu.br.gephi.plugin.bridgingcoefficient.BridgingCentralityMetric.saveCalculatedValues(BridgingCentralityMetric.java:321)
at java.math.BigDecimal.<init>(Unknown Source)
at java.math.BigDecimal.<init>(Unknown Source)
```

</details>

**What changed**

`StatisticsControllerImpl.execute(Statistics, LongTaskListener)` now sets a default error handler on the executor it creates — the piece every other long-task user already has (`LayoutModelImpl`, `DesktopGeneratorController`, `DesktopExportController`, `DesktopImportControllerUI`). The handler:

1. reports the throwable with `Exceptions.printStackTrace(t)`, unmodified, so the existing crash report and its Sentry grouping are untouched;
2. shows a `NotifyDescriptor.Message` naming the statistics that failed and the error it failed with, so the user learns which algorithm gave up — same way `StatisticsFrontEnd` already tells the user a statistics can't run;
3. notifies the `LongTaskListener` (which is right there in scope), so the Statistics panel leaves the running state and the row can be run again.

An earlier revision of this PR attached the message to the throwable with `Exceptions.attachLocalizedMessage()` instead. That only reached the log annotation: the localized text is stored in a `LogRecord` whose message is the `"msg"` placeholder, so `AnnException.getMessage()` stays empty, `ReporterHandler.createMessage()` walks past the zero-frame annotation and still reports `NumberFormatException: Infinite or NaN`, and the throwable passed to `Sentry.captureException()` only gained an empty extra cause. Hence the plain dialog and an untouched throwable.

This cannot fix the plugin's NaN computation and does not try to: the report stays (a plugin crashing for 16 users is worth seeing, and the stack trace already names the plugin), but the failure is no longer anonymous to the user and no longer leaves the panel stuck.

Two sibling call sites still pass no error handler to their executor — `ScreenshotControllerImpl.takeScreenshot()` (VisualizationImpl) and `ProjectControllerImpl`'s `longTaskExecutor` (ProjectAPI). Left out of this PR.

Sentry issue: https://gephi.sentry.io/issues/GEPHI-5GK

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed

`StatisticsControllerImplTest` runs a statistics that throws `NumberFormatException("Infinite or NaN")` through `execute(Statistics, LongTaskListener)`, with a mock `DialogDisplayer` in the lookup, and asserts that the failure is logged, that the message shown to the user names the statistics, and that the listener is notified. Each assertion fails without the corresponding part of the fix.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren’t needed
