### PR TITLE
Stop reporting handled NetBeans Platform diagnostics as crashes

### DIFF
--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReporterHandler.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReporterHandler.java
@@ -62,6 +62,7 @@ import org.openide.util.NbPreferences;
 public class ReporterHandler extends java.util.logging.Handler implements Callable<JButton>, ActionListener {
 
     private static final String PLATFORM_LOGGER_PREFIX = "org.netbeans.";
+    private static final String PROXY_AUTO_CONFIG_LOGGER = "org.netbeans.core.network.proxy.ProxyAutoConfig";
 
     private Report currentReport;
     private final ReportController reportController = new ReportController();
@@ -91,18 +92,27 @@ public class ReporterHandler extends java.util.logging.Handler implements Callab
     }
 
     /**
-     * NetBeans Platform code reports its own recoverable problems through
-     * java.util.logging at INFO or WARNING and then carries on with a fallback:
-     * an unreachable autoupdate catalog, a missing PAC script engine, an
-     * unreadable window-system config file, a cache file it could not delete.
-     * When it does consider a problem fatal it either logs at SEVERE or goes
-     * through Exceptions.printStackTrace(), which uses a level above SEVERE.
-     * Those records are not crashes and must not become crash reports.
+     * NetBeans Platform code reports problems it has already recovered from
+     * through java.util.logging below WARNING and then carries on with a
+     * fallback: an unreachable autoupdate catalog, an unreadable window-system
+     * config file, a cache file it could not delete. Those records are not
+     * crashes and must not become crash reports. A platform record at WARNING
+     * or above is still reported, because the platform does use WARNING for
+     * problems worth a maintainer's attention, such as a TopComponent whose
+     * settings file cannot be deserialized (PersistenceManager, line 591).
+     * ProxyAutoConfig is the one exception: it never logs above WARNING and
+     * every failure there ends with a working, possibly no-op, PAC evaluator.
      */
     static boolean isHandledPlatformDiagnostic(LogRecord record) {
         String loggerName = record.getLoggerName();
-        return loggerName != null && loggerName.startsWith(PLATFORM_LOGGER_PREFIX) &&
-            record.getLevel().intValue() < Level.SEVERE.intValue();
+        if (loggerName == null || !loggerName.startsWith(PLATFORM_LOGGER_PREFIX)) {
+            return false;
+        }
+        int level = record.getLevel().intValue();
+        if (PROXY_AUTO_CONFIG_LOGGER.equals(loggerName)) {
+            return level <= Level.WARNING.intValue();
+        }
+        return level < Level.WARNING.intValue();
     }
 
     @Override
@@ -112,13 +122,9 @@ public class ReporterHandler extends java.util.logging.Handler implements Callab
         }
         Throwable throwable = record.getThrown();
         if (throwable instanceof OutOfMemoryError) {
-            Handler[] handlers = Logger.getLogger("").getHandlers();
-            for (Handler h : handlers) {
-                h.close();
-            }
-            NotifyDescriptor nd = new NotifyDescriptor.Message(MEMORY_ERROR, NotifyDescriptor.ERROR_MESSAGE);
-            DialogDisplayer.getDefault().notify(nd);
-            LifecycleManager.getDefault().exit();
+            //Checked before the platform filter so an OutOfMemoryError still
+            //stops Gephi whichever logger it was reported through
+            notifyOutOfMemory();
             return;
         }
         if (isHandledPlatformDiagnostic(record)) {
@@ -139,6 +145,20 @@ public class ReporterHandler extends java.util.logging.Handler implements Callab
         }
 
         currentReport = report;
+    }
+
+    void notifyOutOfMemory() {
+        Handler[] handlers = Logger.getLogger("").getHandlers();
+        for (Handler h : handlers) {
+            h.close();
+        }
+        NotifyDescriptor nd = new NotifyDescriptor.Message(MEMORY_ERROR, NotifyDescriptor.ERROR_MESSAGE);
+        DialogDisplayer.getDefault().notify(nd);
+        LifecycleManager.getDefault().exit();
+    }
+
+    Report getCurrentReport() {
+        return currentReport;
     }
 
     @Override

--- a/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReporterHandler.java
+++ b/modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReporterHandler.java
@@ -46,6 +46,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.concurrent.Callable;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import javax.swing.JButton;
@@ -59,6 +60,8 @@ import org.openide.util.NbPreferences;
  * @author Mathieu Bastian
  */
 public class ReporterHandler extends java.util.logging.Handler implements Callable<JButton>, ActionListener {
+
+    private static final String PLATFORM_LOGGER_PREFIX = "org.netbeans.";
 
     private Report currentReport;
     private final ReportController reportController = new ReportController();
@@ -87,6 +90,21 @@ public class ReporterHandler extends java.util.logging.Handler implements Callab
         return message;
     }
 
+    /**
+     * NetBeans Platform code reports its own recoverable problems through
+     * java.util.logging at INFO or WARNING and then carries on with a fallback:
+     * an unreachable autoupdate catalog, a missing PAC script engine, an
+     * unreadable window-system config file, a cache file it could not delete.
+     * When it does consider a problem fatal it either logs at SEVERE or goes
+     * through Exceptions.printStackTrace(), which uses a level above SEVERE.
+     * Those records are not crashes and must not become crash reports.
+     */
+    static boolean isHandledPlatformDiagnostic(LogRecord record) {
+        String loggerName = record.getLoggerName();
+        return loggerName != null && loggerName.startsWith(PLATFORM_LOGGER_PREFIX) &&
+            record.getLevel().intValue() < Level.SEVERE.intValue();
+    }
+
     @Override
     public void publish(LogRecord record) {
         if (record.getThrown() == null) {
@@ -101,6 +119,9 @@ public class ReporterHandler extends java.util.logging.Handler implements Callab
             NotifyDescriptor nd = new NotifyDescriptor.Message(MEMORY_ERROR, NotifyDescriptor.ERROR_MESSAGE);
             DialogDisplayer.getDefault().notify(nd);
             LifecycleManager.getDefault().exit();
+            return;
+        }
+        if (isHandledPlatformDiagnostic(record)) {
             return;
         }
 

--- a/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/reporter/ReporterHandlerTest.java
+++ b/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/reporter/ReporterHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+*/
+
+package org.gephi.branding.desktop.reporter;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReporterHandlerTest {
+
+    /**
+     * The level Exceptions.printStackTrace() logs at (Exceptions.OwnLevel.UNKNOWN),
+     * which sits just above SEVERE.
+     */
+    private static final Level UNKNOWN = new Level("SEVERE", Level.SEVERE.intValue() + 1) {
+    };
+
+    private static LogRecord logRecord(String loggerName, Level level) {
+        LogRecord record = new LogRecord(level, null);
+        record.setLoggerName(loggerName);
+        record.setThrown(new IOException("boom"));
+        return record;
+    }
+
+    @Test
+    public void testHandledPlatformDiagnosticsAreNotReported() {
+        //Every (logger, level) pair below is a NetBeans Platform catch block that
+        //logs and then recovers, so none of them is a crash
+        Assert.assertTrue(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.modules.autoupdate.ui.actions.AutoupdateCheckScheduler", Level.INFO)));
+        Assert.assertTrue(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.core.network.proxy.ProxyAutoConfig", Level.WARNING)));
+        Assert.assertTrue(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.core.windows.persistence.WindowManagerParser", Level.INFO)));
+        Assert.assertTrue(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.core.windows.persistence", Level.INFO)));
+        Assert.assertTrue(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.Stamps", Level.INFO)));
+    }
+
+    @Test
+    public void testPlatformErrorsAreStillReported() {
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.core.windows.persistence.WindowManagerParser", Level.SEVERE)));
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.Stamps", UNKNOWN)));
+    }
+
+    @Test
+    public void testGephiErrorsAreStillReported() {
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.gephi.desktop.project.ProjectControllerUIImpl", Level.WARNING)));
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.gephi.desktop.project.ProjectControllerUIImpl", Level.SEVERE)));
+        //Gephi logs a lot through the root logger, whose name is the empty string
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(logRecord("", Level.WARNING)));
+        //Exceptions.printStackTrace(), the usual route for uncaught Gephi errors
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.openide.util.Exceptions", UNKNOWN)));
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(logRecord(null, Level.WARNING)));
+    }
+}

--- a/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/reporter/ReporterHandlerTest.java
+++ b/modules/DesktopBranding/src/test/java/org/gephi/branding/desktop/reporter/ReporterHandlerTest.java
@@ -89,6 +89,17 @@ public class ReporterHandlerTest {
     }
 
     @Test
+    public void testTopComponentDeserializationWarningIsStillReported() {
+        //PersistenceManager.getTopComponentPersistentForID() logs the failure to
+        //instantiate a TopComponent at WARNING on the same logger it uses at INFO
+        //when saving, then returns null. That null is what later surfaces as
+        //"Cannot find TopComponent with preferredID", so the WARNING is the only
+        //record that says why, and it has to keep reaching Sentry
+        Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
+            logRecord("org.netbeans.core.windows.persistence", Level.WARNING)));
+    }
+
+    @Test
     public void testGephiErrorsAreStillReported() {
         Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
             logRecord("org.gephi.desktop.project.ProjectControllerUIImpl", Level.WARNING)));
@@ -100,5 +111,39 @@ public class ReporterHandlerTest {
         Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(
             logRecord("org.openide.util.Exceptions", UNKNOWN)));
         Assert.assertFalse(ReporterHandler.isHandledPlatformDiagnostic(logRecord(null, Level.WARNING)));
+    }
+
+    @Test
+    public void testFilteredRecordDoesNotBecomeAReport() {
+        ReporterHandler handler = new CountingOutOfMemoryHandler();
+
+        handler.publish(logRecord("org.netbeans.Stamps", Level.INFO));
+        Assert.assertNull(handler.getCurrentReport());
+
+        handler.publish(logRecord("org.gephi.project.io.LoadTask", Level.SEVERE));
+        Assert.assertNotNull(handler.getCurrentReport());
+    }
+
+    @Test
+    public void testOutOfMemoryIsHandledEvenFromAFilteredLogger() {
+        CountingOutOfMemoryHandler handler = new CountingOutOfMemoryHandler();
+
+        LogRecord record = logRecord("org.netbeans.Stamps", Level.INFO);
+        record.setThrown(new OutOfMemoryError("Java heap space"));
+        handler.publish(record);
+
+        Assert.assertEquals(1, handler.outOfMemoryCount);
+        Assert.assertNull(handler.getCurrentReport());
+    }
+
+    private static class CountingOutOfMemoryHandler extends ReporterHandler {
+
+        private int outOfMemoryCount;
+
+        @Override
+        void notifyOutOfMemory() {
+            //The real implementation closes every root logger handler and exits Gephi
+            outOfMemoryCount++;
+        }
     }
 }


### PR DESCRIPTION
## Description

Removes about 1190 phantom crash reports from ~172 users across seven Sentry issues. None of these were real application crashes: Gephi kept running normally in every case, but the crash reporter was turning NetBeans Platform's own already-handled diagnostics into "crashes".

### Mechanism

`Installer.restored()` attaches `ReporterHandler` to the **root** logger:

```java
// modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/Installer.java:126
Logger.getLogger("").addHandler(new ReporterHandler());
```

So it receives every `LogRecord` produced anywhere in the JVM. `ReporterHandler.publish()` then forwarded *any* record carrying a non-null `Throwable` to Sentry, with `OutOfMemoryError` as the only special case:

```java
// modules/DesktopBranding/src/main/java/org/gephi/branding/desktop/reporter/ReporterHandler.java:91-121 (before this PR)
if (record.getThrown() == null) { return; }
...
reportController.captureExceptionToSentry(report);
```

NetBeans Platform does not use that channel for crashes. It logs its own recoverable problems at INFO/WARNING and then continues with a fallback. Verified against the NetBeans `RELEASE290` bytecode that Gephi actually ships, one catch block per issue:

| Sentry issue | Exception | Catch + log site | Level | Logger | What NetBeans does next |
| --- | --- | --- | --- | --- | --- |
| GEPHI-64E | `IOException` HTTP 429 | `AutoupdateCheckScheduler.java:138` | `INFO` | `org.netbeans.modules.autoupdate.ui.actions.AutoupdateCheckScheduler` | adds the message to its `problems` collection and finishes the check |
| GEPHI-5KX | `PacParsingException` | `ProxyAutoConfig.java:115` | `WARNING` | `org.netbeans.core.network.proxy.ProxyAutoConfig` | falls back to `PacScriptEvaluatorFactory.getNoOpEvaluator()` |
| GEPHI-5SS | `FSException` (`.nbattrs` rename) | `WindowManagerParser.java:452` | `INFO` | `org.netbeans.core.windows.persistence.WindowManagerParser` | `continue` — skips that mode and loads the rest |
| GEPHI-5YA / GEPHI-5SV / GEPHI-6AF | `IOException` wrapping `SAXParseException` | `WindowManagerParser.java:452` | `INFO` | `org.netbeans.core.windows.persistence.WindowManagerParser` | same `continue` |
| GEPHI-5RP | `FSException` (`WindowManager.wswmgr`) | `PersistenceManager.java:1142` | `INFO` | `org.netbeans.core.windows.persistence` | logs and returns from `saveWindowSystem()` |
| GEPHI-5NE | `IOException: Could not delete …all-layers.dat` | `Stamps.java:718-720` | `INFO` | `org.netbeans.Stamps` | logs and carries on flushing the other caches |

Every one of these stack traces is rooted entirely in `org.netbeans.*` / JDK frames — the trace Sentry shows is where the throwable was *created*, not a propagation path out of NetBeans, because NetBeans swallows it one or two frames later. In other words, the exception never reached Gephi code and never terminated anything.

<details>
<summary>GEPHI-64E — <code>IOException: HTTP 429</code> fetching the autoupdate catalog</summary>

```
at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2012)
at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
at org.netbeans.modules.autoupdate.ui.actions.AutoupdateCheckScheduler$4.run(AutoupdateCheckScheduler.java:130)
at org.netbeans.api.autoupdate.UpdateUnitProvider.refresh(UpdateUnitProvider.java:171)
at org.netbeans.modules.autoupdate.services.UpdateUnitProviderImpl.refresh(UpdateUnitProviderImpl.java:165)
at org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogProvider.refresh(AutoupdateCatalogProvider.java:134)
at org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogCache.writeCatalogToCache(AutoupdateCatalogCache.java:75)
at org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogCache.copy(AutoupdateCatalogCache.java:222)
at org.netbeans.modules.autoupdate.updateprovider.DownloadListener.notifyException(DownloadListener.java:78)
Caused by: IOException: Server returned HTTP response code: 429 for URL: https://raw.githubusercontent.com/gephi/gephi/gh-pages/0.11/autoupdate/updates.xml
at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(Unknown Source)
at sun.net.www.protocol.http.HttpURLConnection.getInputStream(Unknown Source)
[... JDK HTTP internals ...]
```

</details>

<details>
<summary>GEPHI-5KX — <code>PacParsingException: Cannot find secure PAC script engine</code></summary>

```
at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2012)
at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
at org.netbeans.core.network.proxy.ProxyAutoConfig$1.run(ProxyAutoConfig.java:82)
at org.netbeans.core.network.proxy.ProxyAutoConfig.initEngine(ProxyAutoConfig.java:114)
at org.netbeans.core.network.proxy.pac.impl.NbPacScriptEvaluatorFactory.createPacScriptEvaluator(NbPacScriptEvaluatorFactory.java:45)
at org.netbeans.core.network.proxy.pac.impl.NbPacScriptEvaluator.<init>(NbPacScriptEvaluator.java:209)
at org.netbeans.core.network.proxy.pac.impl.NbPacScriptEvaluator.getScriptEngine(NbPacScriptEvaluator.java:316)
```

The frame that immediately encloses `initEngine`'s `createPacScriptEvaluator` call is the `catch (PacParsingException)` at line 115.

</details>

### What changed

`ReporterHandler.publish()` now skips a record when it comes from a logger under `org.netbeans.` **and** is logged below `WARNING`, with one carve-out for `org.netbeans.core.network.proxy.ProxyAutoConfig`, which is allowed up to and including `WARNING`:

```java
static boolean isHandledPlatformDiagnostic(LogRecord record) {
    String loggerName = record.getLoggerName();
    if (loggerName == null || !loggerName.startsWith(PLATFORM_LOGGER_PREFIX)) {
        return false;
    }
    int level = record.getLevel().intValue();
    if (PROXY_AUTO_CONFIG_LOGGER.equals(loggerName)) {
        return level <= Level.WARNING.intValue();
    }
    return level < Level.WARNING.intValue();
}
```

The threshold is `WARNING`, not `SEVERE`, because the platform genuinely does use `WARNING` for problems a maintainer wants to see. The one that matters here is `PersistenceManager.getTopComponentPersistentForID()`: it catches `NoClassDefFoundError`/`ClassNotFoundException`/`ClassCastException`/`IOException` from `InstanceCookie.instanceCreate()` at `PersistenceManager.java:590` and logs the throwable at line 591 via `LOG.log(warningLevelForDeserTC(tcID), …, t)`, where that helper (line 601) returns `WARNING` the first time it sees a given TopComponent id and `FINE` after that — on `org.netbeans.core.windows.persistence`, the *same* logger `saveWindowSystem()` uses at `INFO` for GEPHI-5RP. It then returns `null` at line 596, and that `null` is what later surfaces as `IllegalStateException: Cannot find TopComponent with preferredID …`. Suppressing the WARNING would have kept the downstream symptom while throwing away the one record that says why it happened, so it stays reported. Only six of the seven target issues log at `INFO`; `ProxyAutoConfig` is the sole `WARNING` among them, hence the explicit single-logger carve-out rather than a broader level change.

Why this cannot swallow a genuine Gephi error:

- **Gephi's own loggers are untouched.** Gephi classes log under `org.gephi.*`, or through the root logger (`Logger.getLogger("")`, whose `getLoggerName()` is `""`). Neither matches the `org.netbeans.` prefix, at any level. There is no `Logger.getLogger("org.netbeans…")` anywhere in Gephi.
- **Uncaught errors are untouched.** They arrive via `Exceptions.printStackTrace()`, which logs under `org.openide.util.Exceptions` at `Exceptions.OwnLevel.UNKNOWN` = `SEVERE + 1` — wrong prefix *and* above the threshold. This is also why GEPHI-5FS keeps reporting.
- **Platform `WARNING`/`SEVERE` records are untouched**, apart from the single `ProxyAutoConfig` logger, which never logs above `WARNING` and always ends up with a working (possibly no-op) evaluator whatever fails.
- **The `OutOfMemoryError` path is untouched.** The filter is checked after the OOM branch, and there is now a test that pins that ordering.

For reference, NetBeans' own root-logger handler is stricter still: `NotifyExcPanel.shallNotify()` uses `netbeans.exception.report.min.level` = 1001 (strictly above `SEVERE`) to decide whether an exception is worth auto-reporting at all.

The condition lives in `ReporterHandler.isHandledPlatformDiagnostic(LogRecord)` so it is unit testable without a Sentry client, an AWT toolkit, or NetBeans preferences.

### Sentry issues

- https://gephi.sentry.io/issues/GEPHI-64E
- https://gephi.sentry.io/issues/GEPHI-5KX
- https://gephi.sentry.io/issues/GEPHI-5SS
- https://gephi.sentry.io/issues/GEPHI-5NE
- https://gephi.sentry.io/issues/GEPHI-5YA
- https://gephi.sentry.io/issues/GEPHI-5SV
- https://gephi.sentry.io/issues/GEPHI-5RP

GEPHI-6AF (first seen 2026-08-23) is the same `WindowManagerParser.java:452` mechanism as GEPHI-5YA/GEPHI-5SV and is covered by this change too:

- https://gephi.sentry.io/issues/GEPHI-6AF

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed

New `ReporterHandlerTest` (6 tests) asserts the exact `(logger name, level)` pair behind each target issue is filtered; that `org.gephi.*`, root-logger, `Exceptions.printStackTrace()`-level and null-logger-name records still get through; that the `PersistenceManager` TopComponent-deserialization `WARNING` specifically still gets through; and, through the real `publish()`, that a filtered record produces no `Report` while an `OutOfMemoryError` from a filtered logger still takes the OOM path.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
