### PR TITLE
#3246 Confine Data Laboratory and Timeline workspace-event UI updates to the EDT

### DIFF
--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
@@ -155,7 +155,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     private volatile AvailableColumnsModel edgeAvailableColumnsModel;
     //Observers for auto-refreshing:
     private volatile boolean autoRefreshEnabled = false;
-    private DataTablesObservers dataTablesObservers;
+    private volatile DataTablesObservers dataTablesObservers;
     //Timer for the observers:
     private java.util.Timer observersTimer;
     //Table
@@ -341,8 +341,9 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
                                         if (!autoRefreshEnabled) {
                                             return;
                                         }
-                                        if (dataTablesObservers != null) {
-                                            if (dataTablesObservers.hasChanges()) {
+                                        DataTablesObservers observers = dataTablesObservers;
+                                        if (observers != null) {
+                                            if (observers.hasChanges()) {
                                                 graphChanged();//Execute refresh
                                             }
                                         }
@@ -480,18 +481,39 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
      * @param refreshTableOnly True to refresh only table values, false to
      *                         refresh all UI including manipulators
      */
-    private void refreshOnce(boolean refreshTableOnly) {
-        if (refreshOnceHelperThread == null || !refreshOnceHelperThread.isAlive() ||
-            (refreshOnceHelperThread.refreshTableOnly && !refreshTableOnly)) {
-            refreshOnceHelperThread = new RefreshOnceHelperThread(refreshTableOnly);
-            refreshOnceHelperThread.start();
-        } else {
-            refreshOnceHelperThread.eventAttended();
-        }
+    private void refreshOnce(final boolean refreshTableOnly) {
+        runAction(new Runnable() {
+
+            @Override
+            public void run() {
+                if (refreshOnceHelperThread == null || !refreshOnceHelperThread.isAlive() ||
+                    (refreshOnceHelperThread.refreshTableOnly && !refreshTableOnly)) {
+                    refreshOnceHelperThread = new RefreshOnceHelperThread(refreshTableOnly);
+                    refreshOnceHelperThread.start();
+                } else {
+                    refreshOnceHelperThread.eventAttended();
+                }
+            }
+        });
     }
 
     private void refreshAllOnce() {
         refreshOnce(false);
+    }
+
+    /**
+     * Runs the given action on the EDT, inline if already there, otherwise
+     * deferred via {@link SwingUtilities#invokeLater}. {@link WorkspaceListener}
+     * callbacks can fire on the EDT or on a background thread depending on the
+     * caller, so any code touching Swing state or the {@link #refreshOnceHelperThread}
+     * field must go through this helper.
+     */
+    private void runAction(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+        } else {
+            SwingUtilities.invokeLater(action);
+        }
     }
 
     /**
@@ -1599,11 +1621,17 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
                     Thread.sleep(CHECK_TIME_INTERVAL);
                 } while (moreEvents);
 
-                if (refreshTableOnly) {
-                    DataTableTopComponent.this.refreshTable();
-                } else {
-                    DataTableTopComponent.this.refreshAll();
-                }
+                SwingUtilities.invokeLater(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        if (refreshTableOnly) {
+                            DataTableTopComponent.this.refreshTable();
+                        } else {
+                            DataTableTopComponent.this.refreshAll();
+                        }
+                    }
+                });
             } catch (InterruptedException ex) {
                 Exceptions.printStackTrace(ex);
             }

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineTopComponent.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineTopComponent.java
@@ -326,16 +326,16 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
         });
     }
 
-    private void setup(TimelineModel model) {
-        if (drawer != null) {
-            innerPanel.remove(drawer);
-            drawer = null;
-        }
-        if (model != null) {
-            SwingUtilities.invokeLater(new Runnable() {
+    private void setup(final TimelineModel model) {
+        runAction(new Runnable() {
 
-                @Override
-                public void run() {
+            @Override
+            public void run() {
+                if (drawer != null) {
+                    innerPanel.remove(drawer);
+                    drawer = null;
+                }
+                if (model != null) {
                     // Add Drawer
                     drawer = new TimelineDrawer(controller, model);
                     GridBagConstraints gridBagConstraints = new java.awt.GridBagConstraints();
@@ -348,21 +348,11 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                     innerPanel.add(drawer, gridBagConstraints);
 
                     enableTimeline(model);
-                }
-            });
-        } else {
-            SwingUtilities.invokeLater(new Runnable() {
-
-                @Override
-                public void run() {
-                    if (drawer != null) {
-                        innerPanel.remove(drawer);
-                    }
-                    drawer = null;
+                } else {
                     enableTimeline(null);
                 }
-            });
-        }
+            }
+        });
     }
 
     @Override
@@ -378,8 +368,25 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
         } else if (event.getEventType().equals(TimelineModelEvent.EventType.PLAY_STOP)) {
             setPlaying(false);
         }
-        if (drawer != null) {
-            drawer.consumeEvent(event);
+        runAction(() -> {
+            if (drawer != null) {
+                drawer.consumeEvent(event);
+            }
+        });
+    }
+
+    /**
+     * Runs the given action on the EDT, inline if already there, otherwise
+     * deferred via {@link SwingUtilities#invokeLater}. {@link org.gephi.project.api.WorkspaceListener}
+     * delivery (relayed here through {@link TimelineController}) can land on the EDT or on a
+     * background thread depending on the caller, so any code touching Swing state or the
+     * {@link #drawer} field must go through this helper.
+     */
+    private void runAction(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+        } else {
+            SwingUtilities.invokeLater(action);
         }
     }
 


### PR DESCRIPTION
## Description

This addresses findings 1 and 2 of #3246 (`ProjectControllerImpl.fireWorkspaceEvent` delivers `WorkspaceListener` callbacks synchronously on whatever thread called `openWorkspace()`/`closeCurrentWorkspace()`/etc, sometimes the EDT and sometimes a background thread, notably during project loading). It does not touch `ProjectControllerImpl` or `WorkspaceListener` itself; that part of the plan is tracked separately in the issue.

### Finding 1: `DataTableTopComponent.java`

`WorkspaceListener.select()` calls `activateWorkspace()`, which calls `refreshAllOnce()` -> `refreshOnce(boolean)` (`DataTableTopComponent.java:493-495`). `refreshOnce` read and wrote the `refreshOnceHelperThread` field with no guard, and the raw background `Thread` it started (`RefreshOnceHelperThread`, `DataTableTopComponent.java:1602`) called `refreshTable()`/`refreshAll()` directly from its `run()` method after sleeping, mutating `bannerPanel`, `nodesButton`, `edgesButton`, and triggering `initNodesView()`/`refreshFilterColumns()`/`refreshAppliedFilter()`/`refreshColumnManipulators()`/`refreshGeneralActionsButtons()` on that background thread. The same path runs from the constructor (`DataTableTopComponent.java:247`).

Fix: `refreshOnce` now wraps its body in a `runAction(Runnable)` helper (run inline if already on the EDT, otherwise `SwingUtilities.invokeLater`, following the pattern already used by `AttributesUIControllerImpl.runAction`), so `refreshOnceHelperThread` is only ever read or written on the EDT. `RefreshOnceHelperThread.run()` now hops back to the EDT via `SwingUtilities.invokeLater` before calling `refreshTable()`/`refreshAll()`. I traced every caller of `refreshOnce`/`refreshAllOnce`/`refreshTable`/`refreshAll` in the file (constructor, `activateWorkspace`, `selectDisplayTable`, `refreshCurrentTable`, `componentOpened`, `availableColumnsButtonActionPerformed`, and the two calls inside `RefreshOnceHelperThread`/`refreshAll` itself); after this change every one of them ends up executing the field access and the Swing mutation on the EDT.

Separately, `dataTablesObservers` (`DataTableTopComponent.java:158`) is nulled by `deactivateAll()` from the `unselect()` callback on one thread while the `TimerTask` scheduled in `initEvents()` (`DataTableTopComponent.java:341-349`) checked it twice (`!= null` then `.hasChanges()`) on the timer thread, so the field could become null between the two reads and NPE. It is now `volatile` and snapshotted into a local before both uses.

### Finding 2: `TimelineTopComponent.java`

`TimelineControllerImpl.select()` fires a `MODEL` event synchronously on whatever thread called `select()` (`TimelineControllerImpl.java:101-103`), which reaches `TimelineTopComponent.timelineModelChanged()` -> `setup()` (`TimelineTopComponent.java:329` before this change). The first block of `setup()`, `innerPanel.remove(drawer)`, ran directly on that thread with no EDT guard; only the two branches after it were wrapped in `SwingUtilities.invokeLater`.

Fix: the whole body of `setup()` now goes through the same `runAction` helper used above, so the removal and the two branches that follow it execute together on the EDT. The `drawer` field, written inside that block, was also read unguarded at the tail of `timelineModelChanged()` (`if (drawer != null) { drawer.consumeEvent(event); }`); that read is now dispatched through `runAction` too.

**Ordering-semantics note:** for a `MODEL` event, this read now executes after `setup()`'s dispatched action instead of immediately on the caller's thread, so it can observe the newly-created `drawer` rather than a stale one. This has no observable effect: `TimelineDrawer.consumeEvent()` only acts on `INTERVAL`, `CUSTOM_BOUNDS`, `MIN_MAX`, and `CHART` event types (a no-op for `MODEL`), and in the previous code the synchronous top-of-`setup()` removal already nulled `drawer` before this check ran, so the call was effectively already skipped for `MODEL` events with a pre-existing drawer. For the other event types (`INTERVAL`/`CUSTOM_BOUNDS`/`MIN_MAX`/`CHART`), which don't call `setup()`, the only change is that a call arriving off-EDT is now deferred by one EDT dispatch cycle before `repaint()` is requested, which is not observable since `repaint()` itself only schedules a future repaint rather than painting synchronously.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

Neither `modules/DesktopDataLaboratory` nor `modules/DesktopTimeline` has a `src/test/java` tree, and both classes are NetBeans `TopComponent`/Swing classes whose bug here is a timing race between the EDT and a background thread. A meaningful regression test would need to stand up the NetBeans window system and reliably win a race against the EDT, which isn't achievable deterministically; a test that doesn't reliably exercise the race would assert nothing real.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

This is an internal thread-safety fix with no API or user-visible behavior change.