### PR TITLE
#3246 Close listener-registration races in the Appearance and Preview controllers

### DIFF
--- a/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/AppearanceUIController.java
+++ b/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/AppearanceUIController.java
@@ -49,6 +49,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import javax.swing.SwingUtilities;
 import org.gephi.appearance.api.AppearanceController;
 import org.gephi.appearance.api.AppearanceModel;
 import org.gephi.appearance.api.Function;
@@ -75,50 +76,13 @@ public class AppearanceUIController {
     protected final Map<String, Map<TransformerCategory, Set<TransformerUI>>> transformers;
     //Architecture
     protected final AppearanceController appearanceController;
-    private final CopyOnWriteArraySet<AppearanceUIModelListener> listeners;
+    private final CopyOnWriteArraySet<AppearanceUIModelListener> listeners = new CopyOnWriteArraySet<>();
     //Model
-    private AppearanceUIModel model;
+    private volatile AppearanceUIModel model;
 
     public AppearanceUIController() {
         final ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
         appearanceController = Lookup.getDefault().lookup(AppearanceController.class);
-        pc.addWorkspaceListener(new WorkspaceListener() {
-            @Override
-            public void initialize(Workspace workspace) {
-            }
-
-            @Override
-            public void select(Workspace workspace) {
-                AppearanceUIModel oldModel = model;
-                model = workspace.getLookup().lookup(AppearanceUIModel.class);
-                if (model == null) {
-                    AppearanceModel appearanceModel = appearanceController.getModel(workspace);
-                    model = new AppearanceUIModel(appearanceModel);
-                    workspace.add(model);
-                }
-                model.select();
-
-                firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, model);
-            }
-
-            @Override
-            public void unselect(Workspace workspace) {
-                if (model != null) {
-                    model.unselect();
-                }
-            }
-
-            @Override
-            public void close(Workspace workspace) {
-            }
-
-            @Override
-            public void disable() {
-                AppearanceUIModel oldModel = model;
-                model = null;
-                firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, model);
-            }
-        });
 
         if (pc.getCurrentWorkspace() != null) {
             model = pc.getCurrentWorkspace().getLookup().lookup(AppearanceUIModel.class);
@@ -129,8 +93,6 @@ public class AppearanceUIController {
                 model.select();
             }
         }
-
-        listeners = new CopyOnWriteArraySet<>();
 
         transformers = new HashMap<>();
         for (String ec : ELEMENT_CLASSES) {
@@ -158,6 +120,42 @@ public class AppearanceUIController {
                 }
             }
         }
+
+        // Register only once fully constructed, since the controller may fire events from a
+        // background thread as soon as this listener is registered
+        pc.addWorkspaceListener(new WorkspaceListener() {
+            @Override
+            public void initialize(Workspace workspace) {
+            }
+
+            @Override
+            public void select(Workspace workspace) {
+                AppearanceUIModel oldModel = model;
+                AppearanceUIModel newModel = getModel(workspace);
+                newModel.select();
+                model = newModel;
+
+                runAction(() -> firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, newModel));
+            }
+
+            @Override
+            public void unselect(Workspace workspace) {
+                if (model != null) {
+                    model.unselect();
+                }
+            }
+
+            @Override
+            public void close(Workspace workspace) {
+            }
+
+            @Override
+            public void disable() {
+                AppearanceUIModel oldModel = model;
+                model = null;
+                runAction(() -> firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, null));
+            }
+        });
     }
 
     public void transform(Function function) {
@@ -310,6 +308,14 @@ public class AppearanceUIController {
         AppearanceUIModelEvent event = new AppearanceUIModelEvent(this, propertyName, oldValue, newValue);
         for (AppearanceUIModelListener listener : listeners) {
             listener.propertyChange(event);
+        }
+    }
+
+    private void runAction(Runnable runnable) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            runnable.run();
+        } else {
+            SwingUtilities.invokeLater(runnable);
         }
     }
 }

--- a/modules/DesktopAppearance/src/test/java/org/gephi/desktop/appearance/AppearanceUIControllerTest.java
+++ b/modules/DesktopAppearance/src/test/java/org/gephi/desktop/appearance/AppearanceUIControllerTest.java
@@ -1,0 +1,69 @@
+package org.gephi.desktop.appearance;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.SwingUtilities;
+import org.gephi.project.api.Project;
+import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openide.util.Lookup;
+
+/**
+ * Regression tests for the listener-registration race described in issue #3246 (finding 3):
+ * {@link AppearanceUIController} used to register its {@link org.gephi.project.api.WorkspaceListener}
+ * before its own {@code listeners}/{@code transformers} fields were assigned, and delivered
+ * workspace events synchronously on whatever thread fired them.
+ */
+public class AppearanceUIControllerTest {
+
+    private ProjectController pc;
+
+    @After
+    public void cleanup() {
+        if (pc != null && pc.hasCurrentProject()) {
+            pc.closeCurrentProject();
+        }
+    }
+
+    @Test
+    public void testUsableImmediatelyAfterConstruction() {
+        pc = Lookup.getDefault().lookup(ProjectController.class);
+        pc.newProject();
+
+        AppearanceUIController controller = new AppearanceUIController();
+
+        // A workspace event delivered right after construction must find the listener set and
+        // the transformer registry already initialized, not null.
+        Workspace workspace = pc.openNewWorkspace();
+
+        Assert.assertNotNull(controller.getModel());
+        Assert.assertNotNull(controller.getCategories(AppearanceUIController.NODE_ELEMENT));
+    }
+
+    @Test
+    public void testSelectFiredFromBackgroundThreadDefersListenerToEdt() throws InterruptedException {
+        pc = Lookup.getDefault().lookup(ProjectController.class);
+        Project project = pc.newProject();
+
+        AppearanceUIController controller = new AppearanceUIController();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean firedOnEdt = new AtomicBoolean(false);
+        controller.addPropertyChangeListener(evt -> {
+            firedOnEdt.set(SwingUtilities.isEventDispatchThread());
+            latch.countDown();
+        });
+
+        Workspace workspace = pc.newWorkspace(project);
+        Thread backgroundThread = new Thread(() -> pc.openWorkspace(workspace), "test-background-select");
+        backgroundThread.start();
+        backgroundThread.join();
+
+        Assert.assertTrue("Listener should have fired", latch.await(5, TimeUnit.SECONDS));
+        Assert.assertTrue("propertyChange must be delivered on the EDT, not the firing thread", firedOnEdt.get());
+    }
+}

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewSettingsTopComponent.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewSettingsTopComponent.java
@@ -204,13 +204,15 @@ public final class PreviewSettingsTopComponent extends TopComponent implements P
         setup(null);
 
         PreviewUIController controller = Lookup.getDefault().lookup(PreviewUIController.class);
-        controller.addPropertyChangeListener(this);
-
         PreviewUIModel m = controller.getModel();
         if (m != null) {
             setup(m);
             enableRefreshButton();
         }
+
+        // Register only once fully constructed, since the controller may fire events from a
+        // background thread as soon as this listener is registered
+        controller.addPropertyChangeListener(this);
     }
 
     @Override

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewTopComponent.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewTopComponent.java
@@ -166,11 +166,14 @@ public final class PreviewTopComponent extends TopComponent implements PropertyC
         });
 
         PreviewUIController controller = Lookup.getDefault().lookup(PreviewUIController.class);
-        controller.addPropertyChangeListener(this);
 
         PreviewUIModel m = controller.getModel();
         this.model = m;
         initTarget(model);
+
+        // Register only once fully constructed, since the controller may fire events from a
+        // background thread as soon as this listener is registered
+        controller.addPropertyChangeListener(this);
     }
 
     /**

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIControllerImpl.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewUIControllerImpl.java
@@ -46,12 +46,12 @@ import java.awt.Font;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyEditorManager;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.SwingUtilities;
 import org.gephi.desktop.preview.api.PreviewUIController;
 import org.gephi.desktop.preview.api.PreviewUIModel;
@@ -97,13 +97,24 @@ import org.openide.windows.WindowManager;
     @ServiceProvider(service = Controller.class, position = 2000)})
 public class PreviewUIControllerImpl implements PreviewUIController, Controller<PreviewUIModelImpl> {
 
-    private final List<PropertyChangeListener> listeners = new ArrayList<>();
+    private final List<PropertyChangeListener> listeners = new CopyOnWriteArrayList<>();
     private final PresetUtils presetUtils = new PresetUtils();
     private final PreviewController previewController;
 
     public PreviewUIControllerImpl() {
         previewController = Lookup.getDefault().lookup(PreviewController.class);
 
+        //Register editors
+        //Overriding default Preview API basic editors that don't support CustomEditor
+        PropertyEditorManager.registerEditor(EdgeColor.class, EdgeColorPropertyEditor.class);
+        PropertyEditorManager.registerEditor(DependantOriginalColor.class, DependantOriginalColorPropertyEditor.class);
+        PropertyEditorManager.registerEditor(DependantColor.class, DependantColorPropertyEditor.class);
+
+        // Overriding Netbeans font editor to support disabled state, #3105
+        PropertyEditorManager.registerEditor(Font.class, DisabledAwareFontEditor.class);
+
+        // Register only once fully constructed, since the controller may fire events from a
+        // background thread as soon as this listener is registered
         ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
         pc.addWorkspaceListener(new WorkspaceListener() {
             @Override
@@ -124,12 +135,13 @@ public class PreviewUIControllerImpl implements PreviewUIController, Controller<
                         }
                     }
                 }
-                fireEvent(SELECT, model);
+                runAction(() -> fireEvent(SELECT, model));
             }
 
             @Override
             public void unselect(Workspace workspace) {
-                fireEvent(UNSELECT, getModel(workspace));
+                PreviewUIModelImpl model = getModel(workspace);
+                runAction(() -> fireEvent(UNSELECT, model));
             }
 
             @Override
@@ -138,18 +150,9 @@ public class PreviewUIControllerImpl implements PreviewUIController, Controller<
 
             @Override
             public void disable() {
-                fireEvent(SELECT, null);
+                runAction(() -> fireEvent(SELECT, null));
             }
         });
-
-        //Register editors
-        //Overriding default Preview API basic editors that don't support CustomEditor
-        PropertyEditorManager.registerEditor(EdgeColor.class, EdgeColorPropertyEditor.class);
-        PropertyEditorManager.registerEditor(DependantOriginalColor.class, DependantOriginalColorPropertyEditor.class);
-        PropertyEditorManager.registerEditor(DependantColor.class, DependantColorPropertyEditor.class);
-
-        // Overriding Netbeans font editor to support disabled state, #3105
-        PropertyEditorManager.registerEditor(Font.class, DisabledAwareFontEditor.class);
     }
 
     @Override
@@ -286,6 +289,14 @@ public class PreviewUIControllerImpl implements PreviewUIController, Controller<
         PropertyChangeEvent event = new PropertyChangeEvent(this, eventName, null, data);
         for (PropertyChangeListener l : listeners) {
             l.propertyChange(event);
+        }
+    }
+
+    private void runAction(Runnable runnable) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            runnable.run();
+        } else {
+            SwingUtilities.invokeLater(runnable);
         }
     }
 }

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/RendererManager.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/RendererManager.java
@@ -106,9 +106,12 @@ public class RendererManager extends javax.swing.JPanel implements PropertyChang
         }
 
         previewController = Lookup.getDefault().lookup(PreviewController.class);
-        Lookup.getDefault().lookup(PreviewUIController.class).addPropertyChangeListener(this);
         panel.setLayout(new MigLayout("insets 3", "[pref!]"));
         setup();
+
+        // Register only once fully constructed, since the controller may fire events from a
+        // background thread as soon as this listener is registered
+        Lookup.getDefault().lookup(PreviewUIController.class).addPropertyChangeListener(this);
     }
 
     private void buildTooltip() {


### PR DESCRIPTION
## Description

Addresses findings 3 and 4 of #3246. Both are instances of the same bug class fixed in `AttributesUIControllerImpl`/`AttributesTopComponent` by PR #3232: `ProjectControllerImpl.fireWorkspaceEvent` delivers `WorkspaceListener` callbacks synchronously on whatever thread called `openWorkspace()`/`closeCurrentWorkspace()`/etc, sometimes the EDT, sometimes a background thread during project loading.

**Finding 3 — `AppearanceUIController`**

`listeners` was declared `final` at `AppearanceUIController.java:78` but only assigned at line 133, while `pc.addWorkspaceListener(...)` registered the anonymous `WorkspaceListener` at line 85, 48 lines and a `Lookup` call earlier in the same constructor. Any workspace event landing in that window reached `firePropertyChangeEvent`, which iterates `listeners`, and NPE'd on the still-unassigned final field. The same window left `transformers` (assigned at line 135) null.

`select()` (line 101) and `disable()` (line 119) both called `firePropertyChangeEvent` directly, with no thread guard. The only two implementations of `AppearanceUIModelListener`, `AppearanceTopComponent` and `AppearanceToolbar`, are plain Swing and don't guard their `propertyChange` entry point, so an event fired from a background thread ran their Swing-touching code off the EDT.

Fix: `listeners` is now initialized at its declaration. `pc.addWorkspaceListener(...)` is registered last, after `transformers` is populated, with a comment explaining why. `model` is `volatile`. `select()` and `disable()` snapshot `oldModel`/the new model into locals and defer `firePropertyChangeEvent` through a `runAction` helper (inline if already on the EDT, `SwingUtilities.invokeLater` otherwise) so listener fan-out always lands on the EDT, while the model mutation itself (`model.select()`, the field assignment) stays on the calling thread, matching `AttributesUIControllerImpl`'s pattern. `select()` now reuses the existing `getModel(Workspace)` helper instead of duplicating its lookup-or-create logic inline, which also gives the lambda a single-assignment local to capture.

**Finding 4 — `PreviewUIControllerImpl` and its three second-layer listeners**

`listeners` was a plain `ArrayList` (`PreviewUIControllerImpl.java:100`), mutated on the EDT by `addPropertyChangeListener` (called from three TopComponent/panel constructors) and iterated by `fireEvent` from whatever thread fires `select()`/`unselect()`/`disable()`, an unsynchronized read/write race with a real `ConcurrentModificationException` window. `pc.addWorkspaceListener(...)` was registered at line 108, before the `PropertyEditorManager.registerEditor(...)` calls that finish the constructor at line 152. `select()`/`unselect()`/`disable()` fired events with no dispatch guard, same as finding 3.

Fix: `listeners` is now a `CopyOnWriteArrayList` (keeps the existing `contains` guard and ordering in `addPropertyChangeListener`). `pc.addWorkspaceListener(...)` is registered last. `select()`/`unselect()`/`disable()` defer their `fireEvent` call through the same `runAction` pattern, snapshotting the model into a local first. The `REFRESHING`/`REFRESHED` events fired from the `"Refresh Preview"` background thread in `refreshPreview()` are untouched, since that path is a separate mechanism from workspace-event delivery. `PreviewTopComponent` already defers both of those branches to the EDT. `PreviewSettingsTopComponent` does not: its `REFRESHING` branch calls `enableRefreshButton()`/`disableRefreshButton()` inline, and those are unguarded `setEnabled()` calls, so every Refresh click touches Swing off the EDT. That is a real bug, but it is not a `WorkspaceListener` delivery race, so it is tracked as finding 11 of #3246 rather than widened into this PR.

The three second-layer listeners each registered before finishing their own constructor: `PreviewTopComponent.java:169` before assigning `this.model`/calling `initTarget(model)` (172-173); `PreviewSettingsTopComponent.java:207` before `setup(m)`/`enableRefreshButton()` (211-212); `RendererManager.java:109` before `panel.setLayout(...)`/`setup()` (110-111). All three are Swing components built by the NetBeans window system (`RendererManager` itself is instantiated inside `PreviewSettingsTopComponent`'s own constructor), so their construction always runs on the EDT, and registering the listener no longer risks a synchronous cross-thread delivery once `PreviewUIControllerImpl` only ever delivers `SELECT`/`UNSELECT` on the EDT. I moved each `addPropertyChangeListener(this)` call to the end of its constructor anyway, matching the hardening PR #3232 applied to `AttributesTopComponent`: it costs nothing (pure reordering, no behavior change), and it removes reliance on the unenforced assumption that these components are always constructed on the EDT.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

Added `AppearanceUIControllerTest` covering finding 3: one test constructs the controller and immediately drives a real workspace-select event through it to confirm the listener set and transformer registry are usable right away; the other starts a plain background `Thread` that calls `ProjectController.openWorkspace(...)` and asserts the registered listener's `propertyChange` only runs once `SwingUtilities.isEventDispatchThread()` is true, never on the firing thread. I verified this second test fails against the pre-fix code (reverting the `runAction` wrap makes it fail deterministically) before confirming it passes against the fix.

I did not add a test for finding 4. `PreviewUIControllerImpl`'s workspace-select path unconditionally builds a `PreviewUIModelImpl`, which needs a real `PreviewController`/`GraphModel`-backed workspace to construct without throwing, and `PreviewSettingsTopComponent`/`PreviewTopComponent`/`RendererManager` are NetBeans `TopComponent`/`JPanel` subclasses that pull in Swing form-generated fields and can't be constructed standalone in a headless unit test without the window system. The fix mirrors the pattern validated by the Appearance test above (same `runAction` helper, same registration reordering), so I judged writing a second, weaker test not worth the added test-only scaffolding it would require.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

