### PR TITLE
Clean up ForceAtlas2 implementation

### DIFF
--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
@@ -45,6 +45,7 @@ package org.gephi.layout.plugin.forceAtlas2;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -69,6 +70,12 @@ import org.openide.util.NbBundle;
  */
 public class ForceAtlas2 implements Layout {
 
+    private static final int TASKS_PER_THREAD = 8;
+    private static final double JITTER_TOLERANCE_COEFFICIENT = 0.05;
+    private static final double MAX_JITTER_TOLERANCE = 10d;
+    private static final double MIN_SPEED_EFFICIENCY = 0.05;
+    private static final double MAX_SPEED = 1_000d;
+    private static final double MAX_SPEED_RISE = 0.5;
     private final ForceAtlas2Builder layoutBuilder;
     double outboundAttCompensation = 1;
     private GraphModel graphModel;
@@ -111,19 +118,7 @@ public class ForceAtlas2 implements Layout {
         try {
             Node[] nodes = graph.getNodes().toArray();
 
-            // Initialise layout data
-            for (Node n : nodes) {
-                if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceAtlas2LayoutData)) {
-                    ForceAtlas2LayoutData nLayout = new ForceAtlas2LayoutData();
-                    n.setLayoutData(nLayout);
-                }
-                ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                nLayout.mass = 1 + graph.getDegree(n);
-                nLayout.old_dx = 0;
-                nLayout.old_dy = 0;
-                nLayout.dx = 0;
-                nLayout.dy = 0;
-            }
+            initializeLayoutData(nodes, true);
 
             pool = Executors.newFixedThreadPool(threadCount);
             currentThreadCount = threadCount;
@@ -143,6 +138,23 @@ public class ForceAtlas2 implements Layout {
         return w;
     }
 
+    private void initializeLayoutData(Node[] nodes, boolean resetDisplacements) {
+        for (Node node : nodes) {
+            ForceAtlas2LayoutData nodeLayout;
+            if (node.getLayoutData() instanceof ForceAtlas2LayoutData existingLayout) {
+                nodeLayout = existingLayout;
+            } else {
+                nodeLayout = new ForceAtlas2LayoutData();
+                node.setLayoutData(nodeLayout);
+            }
+            nodeLayout.mass = 1 + graph.getDegree(node);
+            nodeLayout.oldDx = resetDisplacements ? 0d : nodeLayout.dx;
+            nodeLayout.oldDy = resetDisplacements ? 0d : nodeLayout.dy;
+            nodeLayout.dx = 0d;
+            nodeLayout.dy = 0d;
+        }
+    }
+
 
     @Override
     public void goAlgo() {
@@ -159,19 +171,7 @@ public class ForceAtlas2 implements Layout {
             Node[] nodes = graph.getNodes().toArray();
             Edge[] edges = graph.getEdges().toArray();
 
-            // Initialise layout data
-            for (Node n : nodes) {
-                if (n.getLayoutData() == null || !(n.getLayoutData() instanceof ForceAtlas2LayoutData)) {
-                    ForceAtlas2LayoutData nLayout = new ForceAtlas2LayoutData();
-                    n.setLayoutData(nLayout);
-                }
-                ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                nLayout.mass = 1 + graph.getDegree(n);
-                nLayout.old_dx = nLayout.dx;
-                nLayout.old_dy = nLayout.dy;
-                nLayout.dx = 0;
-                nLayout.dy = 0;
-            }
+            initializeLayoutData(nodes, false);
 
             // If Barnes Hut active, initialize root region
             if (isBarnesHutOptimize()) {
@@ -190,89 +190,94 @@ public class ForceAtlas2 implements Layout {
             }
 
             // Repulsion (and gravity)
-            // NB: Muti-threaded
-            RepulsionForce Repulsion = ForceFactory.builder.buildRepulsion(isAdjustSizes(), getScalingRatio());
+            // NB: Multi-threaded
+            RepulsionForce repulsionForce = ForceFactory.INSTANCE.buildRepulsion(isAdjustSizes(), getScalingRatio());
 
-            int taskCount = 8 *
+            int taskCount = TASKS_PER_THREAD *
                 currentThreadCount;  // The threadPool Executor Service will manage the fetching of tasks and threads.
             // We make more tasks than threads because some tasks may need more time to compute.
-            ArrayList<Future> threads = new ArrayList();
+            List<Future<?>> tasks = new ArrayList<>();
             for (int t = taskCount; t > 0; t--) {
                 int from = (int) Math.floor(nodes.length * (t - 1) / taskCount);
                 int to = (int) Math.floor(nodes.length * t / taskCount);
-                Future future = pool.submit(
+                Future<?> task = pool.submit(
                     new NodesThread(nodes, from, to, isBarnesHutOptimize(), getBarnesHutTheta(), getGravity(),
-                        (isStrongGravityMode()) ? (ForceFactory.builder.getStrongGravity(getScalingRatio())) :
-                            (Repulsion), getScalingRatio(), rootRegion, Repulsion));
-                threads.add(future);
+                        isStrongGravityMode() ? ForceFactory.INSTANCE.getStrongGravity(getScalingRatio())
+                            : repulsionForce,
+                        getScalingRatio(), rootRegion, repulsionForce));
+                tasks.add(task);
             }
-            for (Future future : threads) {
+            for (Future<?> task : tasks) {
                 try {
-                    future.get();
-                } catch (Exception e) {
+                    task.get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Unable to layout " + getClass().getSimpleName() + ".", e);
+                } catch (ExecutionException e) {
                     throw new RuntimeException("Unable to layout " + this.getClass().getSimpleName() + ".", e);
                 }
             }
 
             // Attraction
-            AttractionForce Attraction = ForceFactory.builder
+            AttractionForce attractionForce = ForceFactory.INSTANCE
                 .buildAttraction(isLinLogMode(), isOutboundAttractionDistribution(), isAdjustSizes(),
-                    1 * ((isOutboundAttractionDistribution()) ? (outboundAttCompensation) : (1)));
+                    isOutboundAttractionDistribution() ? outboundAttCompensation : 1d);
             if (getEdgeWeightInfluence() == 0) {
                 for (Edge e : edges) {
-                    Attraction.apply(e.getSource(), e.getTarget(), 1);
+                    attractionForce.apply(e.getSource(), e.getTarget(), 1d);
                 }
             } else if (getEdgeWeightInfluence() == 1) {
                 if (isNormalizeEdgeWeights()) {
-                    Double w;
-                    Double edgeWeightMin = Double.MAX_VALUE;
-                    Double edgeWeightMax = Double.MIN_VALUE;
+                    double weight;
+                    double edgeWeightMin = Double.POSITIVE_INFINITY;
+                    double edgeWeightMax = Double.NEGATIVE_INFINITY;
                     for (Edge e : edges) {
-                        w = getEdgeWeight(e, isDynamicWeight, interval);
-                        edgeWeightMin = Math.min(w, edgeWeightMin);
-                        edgeWeightMax = Math.max(w, edgeWeightMax);
+                        weight = getEdgeWeight(e, isDynamicWeight, interval);
+                        edgeWeightMin = Math.min(weight, edgeWeightMin);
+                        edgeWeightMax = Math.max(weight, edgeWeightMax);
                     }
                     if (edgeWeightMin < edgeWeightMax) {
                         for (Edge e : edges) {
-                            w = (getEdgeWeight(e, isDynamicWeight, interval) - edgeWeightMin) /
+                            weight = (getEdgeWeight(e, isDynamicWeight, interval) - edgeWeightMin) /
                                 (edgeWeightMax - edgeWeightMin);
-                            Attraction.apply(e.getSource(), e.getTarget(), w);
+                            attractionForce.apply(e.getSource(), e.getTarget(), weight);
                         }
                     } else {
                         for (Edge e : edges) {
-                            Attraction.apply(e.getSource(), e.getTarget(), 1.);
+                            attractionForce.apply(e.getSource(), e.getTarget(), 1d);
                         }
                     }
                 } else {
                     for (Edge e : edges) {
-                        Attraction.apply(e.getSource(), e.getTarget(), getEdgeWeight(e, isDynamicWeight, interval));
+                        attractionForce.apply(e.getSource(), e.getTarget(),
+                            getEdgeWeight(e, isDynamicWeight, interval));
                     }
                 }
             } else {
                 if (isNormalizeEdgeWeights()) {
-                    Double w;
-                    Double edgeWeightMin = Double.MAX_VALUE;
-                    Double edgeWeightMax = Double.MIN_VALUE;
+                    double weight;
+                    double edgeWeightMin = Double.POSITIVE_INFINITY;
+                    double edgeWeightMax = Double.NEGATIVE_INFINITY;
                     for (Edge e : edges) {
-                        w = getEdgeWeight(e, isDynamicWeight, interval);
-                        edgeWeightMin = Math.min(w, edgeWeightMin);
-                        edgeWeightMax = Math.max(w, edgeWeightMax);
+                        weight = getEdgeWeight(e, isDynamicWeight, interval);
+                        edgeWeightMin = Math.min(weight, edgeWeightMin);
+                        edgeWeightMax = Math.max(weight, edgeWeightMax);
                     }
                     if (edgeWeightMin < edgeWeightMax) {
                         for (Edge e : edges) {
-                            w = (getEdgeWeight(e, isDynamicWeight, interval) - edgeWeightMin) /
+                            weight = (getEdgeWeight(e, isDynamicWeight, interval) - edgeWeightMin) /
                                 (edgeWeightMax - edgeWeightMin);
-                            Attraction.apply(e.getSource(), e.getTarget(),
-                                Math.pow(w, getEdgeWeightInfluence()));
+                            attractionForce.apply(e.getSource(), e.getTarget(),
+                                Math.pow(weight, getEdgeWeightInfluence()));
                         }
                     } else {
                         for (Edge e : edges) {
-                            Attraction.apply(e.getSource(), e.getTarget(), 1.);
+                            attractionForce.apply(e.getSource(), e.getTarget(), 1d);
                         }
                     }
                 } else {
                     for (Edge e : edges) {
-                        Attraction.apply(e.getSource(), e.getTarget(),
+                        attractionForce.apply(e.getSource(), e.getTarget(),
                             Math.pow(getEdgeWeight(e, isDynamicWeight, interval), getEdgeWeightInfluence()));
                     }
                 }
@@ -281,32 +286,31 @@ public class ForceAtlas2 implements Layout {
             // Auto adjust speed
             double totalSwinging = 0d;  // How much irregular movement
             double totalEffectiveTraction = 0d;  // Hom much useful movement
-            for (Node n : nodes) {
-                ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                if (!n.isFixed()) {
+            for (Node node : nodes) {
+                ForceAtlas2LayoutData nodeLayout = node.getLayoutData();
+                if (!node.isFixed()) {
                     double swinging =
-                        Math.sqrt(Math.pow(nLayout.old_dx - nLayout.dx, 2) + Math.pow(nLayout.old_dy - nLayout.dy, 2));
-                    totalSwinging += nLayout.mass *
+                        Math.hypot(nodeLayout.oldDx - nodeLayout.dx, nodeLayout.oldDy - nodeLayout.dy);
+                    totalSwinging += nodeLayout.mass *
                         swinging;   // If the node has a burst change of direction, then it's not converging.
-                    totalEffectiveTraction += nLayout.mass * 0.5 *
-                        Math.sqrt(Math.pow(nLayout.old_dx + nLayout.dx, 2) + Math.pow(nLayout.old_dy + nLayout.dy, 2));
+                    totalEffectiveTraction += nodeLayout.mass * 0.5 *
+                        Math.hypot(nodeLayout.oldDx + nodeLayout.dx, nodeLayout.oldDy + nodeLayout.dy);
                 }
             }
             // We want that swingingMovement < tolerance * convergenceMovement
 
             // Optimize jitter tolerance
             // The 'right' jitter tolerance for this network. Bigger networks need more tolerance. Denser networks need less tolerance. Totally empiric.
-            double estimatedOptimalJitterTolerance = 0.05 * Math.sqrt(nodes.length);
+            double estimatedOptimalJitterTolerance = JITTER_TOLERANCE_COEFFICIENT * Math.sqrt(nodes.length);
             double minJT = Math.sqrt(estimatedOptimalJitterTolerance);
-            double maxJT = 10;
+            double maxJT = MAX_JITTER_TOLERANCE;
             double jt = jitterTolerance * Math.max(minJT,
-                Math.min(maxJT, estimatedOptimalJitterTolerance * totalEffectiveTraction / Math.pow(nodes.length, 2)));
-
-            double minSpeedEfficiency = 0.05;
+                Math.min(maxJT, estimatedOptimalJitterTolerance * totalEffectiveTraction /
+                    ((double) nodes.length * nodes.length)));
 
             // Protection against erratic behavior
             if (totalSwinging / totalEffectiveTraction > 2.0) {
-                if (speedEfficiency > minSpeedEfficiency) {
+                if (speedEfficiency > MIN_SPEED_EFFICIENCY) {
                     speedEfficiency *= 0.5;
                 }
                 jt = Math.max(jt, jitterTolerance);
@@ -317,59 +321,55 @@ public class ForceAtlas2 implements Layout {
             // Speed efficiency is how the speed really corresponds to the swinging vs. convergence tradeoff
             // We adjust it slowly and carefully
             if (totalSwinging > jt * totalEffectiveTraction) {
-                if (speedEfficiency > minSpeedEfficiency) {
+                if (speedEfficiency > MIN_SPEED_EFFICIENCY) {
                     speedEfficiency *= 0.7;
                 }
-            } else if (speed < 1000) {
+            } else if (speed < MAX_SPEED) {
                 speedEfficiency *= 1.3;
             }
 
             // But the speed shoudn't rise too much too quickly, since it would make the convergence drop dramatically.
-            double maxRise = 0.5;   // Max rise: 50%
-            speed = speed + Math.min(targetSpeed - speed, maxRise * speed);
+            speed += Math.min(targetSpeed - speed, MAX_SPEED_RISE * speed);
 
             // Apply forces
             if (isAdjustSizes()) {
                 // If nodes overlap prevention is active, it's not possible to trust the swinging mesure.
-                for (Node n : nodes) {
-                    ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                    if (!n.isFixed()) {
+                for (Node node : nodes) {
+                    ForceAtlas2LayoutData nodeLayout = node.getLayoutData();
+                    if (!node.isFixed()) {
 
                         // Adaptive auto-speed: the speed of each node is lowered
                         // when the node swings.
-                        double swinging = nLayout.mass * Math.sqrt(
-                            (nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) +
-                                (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy));
+                        double swinging = nodeLayout.mass * Math.hypot(
+                            nodeLayout.oldDx - nodeLayout.dx, nodeLayout.oldDy - nodeLayout.dy);
                         double factor = 0.1 * speed / (1f + Math.sqrt(speed * swinging));
 
-                        double df = Math.sqrt(Math.pow(nLayout.dx, 2) + Math.pow(nLayout.dy, 2));
+                        double df = Math.hypot(nodeLayout.dx, nodeLayout.dy);
                         factor = df == 0 ? 0 : Math.min(factor * df, 10.) / df;
 
-                        double x = n.x() + nLayout.dx * factor;
-                        double y = n.y() + nLayout.dy * factor;
+                        double x = node.x() + nodeLayout.dx * factor;
+                        double y = node.y() + nodeLayout.dy * factor;
 
-                        n.setX((float) x);
-                        n.setY((float) y);
+                        node.setX((float) x);
+                        node.setY((float) y);
                     }
                 }
             } else {
-                for (Node n : nodes) {
-                    ForceAtlas2LayoutData nLayout = n.getLayoutData();
-                    if (!n.isFixed()) {
+                for (Node node : nodes) {
+                    ForceAtlas2LayoutData nodeLayout = node.getLayoutData();
+                    if (!node.isFixed()) {
 
                         // Adaptive auto-speed: the speed of each node is lowered
                         // when the node swings.
-                        double swinging = nLayout.mass * Math.sqrt(
-                            (nLayout.old_dx - nLayout.dx) * (nLayout.old_dx - nLayout.dx) +
-                                (nLayout.old_dy - nLayout.dy) * (nLayout.old_dy - nLayout.dy));
-                        //double factor = speed / (1f + Math.sqrt(speed * swinging));
+                        double swinging = nodeLayout.mass * Math.hypot(
+                            nodeLayout.oldDx - nodeLayout.dx, nodeLayout.oldDy - nodeLayout.dy);
                         double factor = speed / (1f + Math.sqrt(speed * swinging));
 
-                        double x = n.x() + nLayout.dx * factor;
-                        double y = n.y() + nLayout.dy * factor;
+                        double x = node.x() + nodeLayout.dx * factor;
+                        double y = node.y() + nodeLayout.dy * factor;
 
-                        n.setX((float) x);
-                        n.setY((float) y);
+                        node.setX((float) x);
+                        node.setY((float) y);
                     }
                 }
             }

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2Builder.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2Builder.java
@@ -72,8 +72,7 @@ public class ForceAtlas2Builder implements LayoutBuilder {
 
     @Override
     public ForceAtlas2 buildLayout() {
-        ForceAtlas2 layout = new ForceAtlas2(this);
-        return layout;
+        return new ForceAtlas2(this);
     }
 
     private class ForceAtlas2UI implements LayoutUI {

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2LayoutData.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2LayoutData.java
@@ -52,9 +52,9 @@ import org.gephi.graph.spi.LayoutData;
 public class ForceAtlas2LayoutData implements LayoutData {
     //Data
 
-    public double dx = 0;
-    public double dy = 0;
-    public double old_dx = 0;
-    public double old_dy = 0;
-    public double mass = 1;
+    public double dx;
+    public double dy;
+    public double oldDx;
+    public double oldDy;
+    public double mass = 1d;
 }

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceFactory.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceFactory.java
@@ -50,23 +50,23 @@ import org.gephi.graph.api.Node;
  *
  * @author Mathieu Jacomy
  */
-public class ForceFactory {
+public final class ForceFactory {
 
-    public static ForceFactory builder = new ForceFactory();
+    static final ForceFactory INSTANCE = new ForceFactory();
 
     private ForceFactory() {
     }
 
     public RepulsionForce buildRepulsion(boolean adjustBySize, double coefficient) {
         if (adjustBySize) {
-            return new linRepulsion_antiCollision(coefficient);
+            return new LinearRepulsionAntiCollision(coefficient);
         } else {
-            return new linRepulsion(coefficient);
+            return new LinearRepulsion(coefficient);
         }
     }
 
     public RepulsionForce getStrongGravity(double coefficient) {
-        return new strongGravity(coefficient);
+        return new StrongGravity(coefficient);
     }
 
     public AttractionForce buildAttraction(boolean logAttraction, boolean distributedAttraction, boolean adjustBySize,
@@ -74,41 +74,41 @@ public class ForceFactory {
         if (adjustBySize) {
             if (logAttraction) {
                 if (distributedAttraction) {
-                    return new logAttraction_degreeDistributed_antiCollision(coefficient);
+                    return new LogAttractionDegreeDistributedAntiCollision(coefficient);
                 } else {
-                    return new logAttraction_antiCollision(coefficient);
+                    return new LogAttractionAntiCollision(coefficient);
                 }
             } else {
                 if (distributedAttraction) {
-                    return new linAttraction_degreeDistributed_antiCollision(coefficient);
+                    return new LinearAttractionDegreeDistributedAntiCollision(coefficient);
                 } else {
-                    return new linAttraction_antiCollision(coefficient);
+                    return new LinearAttractionAntiCollision(coefficient);
                 }
             }
         } else {
             if (logAttraction) {
                 if (distributedAttraction) {
-                    return new logAttraction_degreeDistributed(coefficient);
+                    return new LogAttractionDegreeDistributed(coefficient);
                 } else {
-                    return new logAttraction(coefficient);
+                    return new LogAttraction(coefficient);
                 }
             } else {
                 if (distributedAttraction) {
-                    return new linAttraction_massDistributed(coefficient);
+                    return new LinearAttractionMassDistributed(coefficient);
                 } else {
-                    return new linAttraction(coefficient);
+                    return new LinearAttraction(coefficient);
                 }
             }
         }
     }
 
-    public abstract class AttractionForce {
+    public static abstract class AttractionForce {
 
         public abstract void apply(Node n1, Node n2,
                                    double e); // Model for node-node attraction (e is for edge weight if needed)
     }
 
-    public abstract class RepulsionForce {
+    public static abstract class RepulsionForce {
 
         public abstract void apply(Node n1, Node n2);           // Model for node-node repulsion
 
@@ -120,11 +120,11 @@ public class ForceFactory {
     /*
      * Repulsion force: Linear
      */
-    private class linRepulsion extends RepulsionForce {
+    private static class LinearRepulsion extends RepulsionForce {
 
         private final double coefficient;
 
-        public linRepulsion(double c) {
+        private LinearRepulsion(double c) {
             coefficient = c;
         }
 
@@ -136,7 +136,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n1.x() - n2.x();
             double yDist = n1.y() - n2.y();
-            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+            double distance = Math.hypot(xDist, yDist);
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -157,7 +157,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n.x() - r.getMassCenterX();
             double yDist = n.y() - r.getMassCenterY();
-            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+            double distance = Math.hypot(xDist, yDist);
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -175,7 +175,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n.x();
             double yDist = n.y();
-            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+            double distance = Math.hypot(xDist, yDist);
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -190,11 +190,11 @@ public class ForceFactory {
     /*
      * Repulsion force: Strong Gravity (as a Repulsion Force because it is easier)
      */
-    private class linRepulsion_antiCollision extends RepulsionForce {
+    private static class LinearRepulsionAntiCollision extends RepulsionForce {
 
         private final double coefficient;
 
-        public linRepulsion_antiCollision(double c) {
+        private LinearRepulsionAntiCollision(double c) {
             coefficient = c;
         }
 
@@ -206,7 +206,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n1.x() - n2.x();
             double yDist = n1.y() - n2.y();
-            double distance = Math.sqrt(xDist * xDist + yDist * yDist) - n1.size() - n2.size();
+            double distance = Math.hypot(xDist, yDist) - n1.size() - n2.size();
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -236,7 +236,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n.x() - r.getMassCenterX();
             double yDist = n.y() - r.getMassCenterY();
-            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+            double distance = Math.hypot(xDist, yDist);
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -259,7 +259,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n.x();
             double yDist = n.y();
-            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+            double distance = Math.hypot(xDist, yDist);
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -271,11 +271,11 @@ public class ForceFactory {
         }
     }
 
-    private class strongGravity extends RepulsionForce {
+    private static class StrongGravity extends RepulsionForce {
 
         private final double coefficient;
 
-        public strongGravity(double c) {
+        private StrongGravity(double c) {
             coefficient = c;
         }
 
@@ -296,7 +296,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n.x();
             double yDist = n.y();
-            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+            double distance = Math.hypot(xDist, yDist);
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -311,11 +311,11 @@ public class ForceFactory {
     /*
      * Attraction force: Linear
      */
-    private class linAttraction extends AttractionForce {
+    private static class LinearAttraction extends AttractionForce {
 
         private final double coefficient;
 
-        public linAttraction(double c) {
+        private LinearAttraction(double c) {
             coefficient = c;
         }
 
@@ -342,11 +342,11 @@ public class ForceFactory {
     /*
      * Attraction force: Linear, distributed by mass (typically, degree)
      */
-    private class linAttraction_massDistributed extends AttractionForce {
+    private static class LinearAttractionMassDistributed extends AttractionForce {
 
         private final double coefficient;
 
-        public linAttraction_massDistributed(double c) {
+        private LinearAttractionMassDistributed(double c) {
             coefficient = c;
         }
 
@@ -373,11 +373,11 @@ public class ForceFactory {
     /*
      * Attraction force: Logarithmic
      */
-    private class logAttraction extends AttractionForce {
+    private static class LogAttraction extends AttractionForce {
 
         private final double coefficient;
 
-        public logAttraction(double c) {
+        private LogAttraction(double c) {
             coefficient = c;
         }
 
@@ -389,7 +389,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n1.x() - n2.x();
             double yDist = n1.y() - n2.y();
-            double distance = (float) Math.sqrt(xDist * xDist + yDist * yDist);
+            double distance = Math.hypot(xDist, yDist);
 
             if (distance > 0) {
 
@@ -408,11 +408,11 @@ public class ForceFactory {
     /*
      * Attraction force: Linear, distributed by Degree
      */
-    private class logAttraction_degreeDistributed extends AttractionForce {
+    private static class LogAttractionDegreeDistributed extends AttractionForce {
 
         private final double coefficient;
 
-        public logAttraction_degreeDistributed(double c) {
+        private LogAttractionDegreeDistributed(double c) {
             coefficient = c;
         }
 
@@ -443,11 +443,11 @@ public class ForceFactory {
     /*
      * Attraction force: Linear, with Anti-Collision
      */
-    private class linAttraction_antiCollision extends AttractionForce {
+    private static class LinearAttractionAntiCollision extends AttractionForce {
 
         private final double coefficient;
 
-        public linAttraction_antiCollision(double c) {
+        private LinearAttractionAntiCollision(double c) {
             coefficient = c;
         }
 
@@ -459,7 +459,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n1.x() - n2.x();
             double yDist = n1.y() - n2.y();
-            double distance = Math.sqrt(xDist * xDist + yDist * yDist) - n1.size() - n2.size();
+            double distance = Math.hypot(xDist, yDist) - n1.size() - n2.size();
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -477,11 +477,11 @@ public class ForceFactory {
     /*
      * Attraction force: Linear, distributed by Degree, with Anti-Collision
      */
-    private class linAttraction_degreeDistributed_antiCollision extends AttractionForce {
+    private static class LinearAttractionDegreeDistributedAntiCollision extends AttractionForce {
 
         private final double coefficient;
 
-        public linAttraction_degreeDistributed_antiCollision(double c) {
+        private LinearAttractionDegreeDistributedAntiCollision(double c) {
             coefficient = c;
         }
 
@@ -493,7 +493,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n1.x() - n2.x();
             double yDist = n1.y() - n2.y();
-            double distance = Math.sqrt(xDist * xDist + yDist * yDist) - n1.size() - n2.size();
+            double distance = Math.hypot(xDist, yDist) - n1.size() - n2.size();
 
             if (distance > 0) {
                 // NB: factor = force / distance
@@ -511,11 +511,11 @@ public class ForceFactory {
     /*
      * Attraction force: Logarithmic, with Anti-Collision
      */
-    private class logAttraction_antiCollision extends AttractionForce {
+    private static class LogAttractionAntiCollision extends AttractionForce {
 
         private final double coefficient;
 
-        public logAttraction_antiCollision(double c) {
+        private LogAttractionAntiCollision(double c) {
             coefficient = c;
         }
 
@@ -527,7 +527,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n1.x() - n2.x();
             double yDist = n1.y() - n2.y();
-            double distance = Math.sqrt(xDist * xDist + yDist * yDist) - n1.size() - n2.size();
+            double distance = Math.hypot(xDist, yDist) - n1.size() - n2.size();
 
             if (distance > 0) {
 
@@ -546,11 +546,11 @@ public class ForceFactory {
     /*
      * Attraction force: Linear, distributed by Degree, with Anti-Collision
      */
-    private class logAttraction_degreeDistributed_antiCollision extends AttractionForce {
+    private static class LogAttractionDegreeDistributedAntiCollision extends AttractionForce {
 
         private final double coefficient;
 
-        public logAttraction_degreeDistributed_antiCollision(double c) {
+        private LogAttractionDegreeDistributedAntiCollision(double c) {
             coefficient = c;
         }
 
@@ -562,7 +562,7 @@ public class ForceFactory {
             // Get the distance
             double xDist = n1.x() - n2.x();
             double yDist = n1.y() - n2.y();
-            double distance = Math.sqrt(xDist * xDist + yDist * yDist) - n1.size() - n2.size();
+            double distance = Math.hypot(xDist, yDist) - n1.size() - n2.size();
 
             if (distance > 0) {
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/NodesThread.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/NodesThread.java
@@ -55,23 +55,23 @@ public class NodesThread implements Runnable {
     private final int to;
     private final Region rootRegion;
     private final boolean barnesHutOptimize;
-    private final RepulsionForce Repulsion;
+    private final RepulsionForce repulsionForce;
     private final double barnesHutTheta;
     private final double gravity;
-    private final RepulsionForce GravityForce;
+    private final RepulsionForce gravityForce;
     private final double scaling;
 
     public NodesThread(Node[] nodes, int from, int to, boolean barnesHutOptimize, double barnesHutTheta, double gravity,
-                       RepulsionForce GravityForce, double scaling, Region rootRegion, RepulsionForce Repulsion) {
+                       RepulsionForce gravityForce, double scaling, Region rootRegion, RepulsionForce repulsionForce) {
         this.nodes = nodes;
         this.from = from;
         this.to = to;
         this.rootRegion = rootRegion;
         this.barnesHutOptimize = barnesHutOptimize;
-        this.Repulsion = Repulsion;
+        this.repulsionForce = repulsionForce;
         this.barnesHutTheta = barnesHutTheta;
         this.gravity = gravity;
-        this.GravityForce = GravityForce;
+        this.gravityForce = gravityForce;
         this.scaling = scaling;
     }
 
@@ -80,23 +80,23 @@ public class NodesThread implements Runnable {
         // Repulsion
         if (barnesHutOptimize) {
             for (int nIndex = from; nIndex < to; nIndex++) {
-                Node n = nodes[nIndex];
-                rootRegion.applyForce(n, Repulsion, barnesHutTheta);
+                Node node = nodes[nIndex];
+                rootRegion.applyForce(node, repulsionForce, barnesHutTheta);
             }
         } else {
             for (int n1Index = from; n1Index < to; n1Index++) {
                 Node n1 = nodes[n1Index];
                 for (int n2Index = 0; n2Index < n1Index; n2Index++) {
                     Node n2 = nodes[n2Index];
-                    Repulsion.apply(n1, n2);
+                    repulsionForce.apply(n1, n2);
                 }
             }
         }
 
         // Gravity
         for (int nIndex = from; nIndex < to; nIndex++) {
-            Node n = nodes[nIndex];
-            GravityForce.apply(n, gravity / scaling);
+            Node node = nodes[nIndex];
+            gravityForce.apply(node, gravity / scaling);
         }
     }
 }

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/Region.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/Region.java
@@ -63,12 +63,11 @@ public class Region {
     private double size;
 
     public Region(Node[] nodes) {
-        this.nodes = new ArrayList<>();
-        this.nodes.addAll(Arrays.asList(nodes));
+        this.nodes = new ArrayList<>(Arrays.asList(nodes));
         updateMassAndGeometry();
     }
 
-    public Region(ArrayList<Node> nodes) {
+    public Region(List<Node> nodes) {
         this.nodes = new ArrayList<>(nodes);
         updateMassAndGeometry();
     }
@@ -89,10 +88,9 @@ public class Region {
             massCenterY = massSumY / mass;
 
             // Compute size
-            size = Double.MIN_VALUE;
+            size = 0d;
             for (Node n : nodes) {
-                double distance = Math.sqrt(
-                    (n.x() - massCenterX) * (n.x() - massCenterX) + (n.y() - massCenterY) * (n.y() - massCenterY));
+                double distance = Math.hypot(n.x() - massCenterX, n.y() - massCenterY);
                 size = Math.max(size, 2 * distance);
             }
         }
@@ -100,73 +98,73 @@ public class Region {
 
     public synchronized void buildSubRegions() {
         if (nodes.size() > 1) {
-            ArrayList<Node> leftNodes = new ArrayList<>();
-            ArrayList<Node> rightNodes = new ArrayList<>();
+            List<Node> leftNodes = new ArrayList<>();
+            List<Node> rightNodes = new ArrayList<>();
             for (Node n : nodes) {
-                ArrayList<Node> nodesColumn = (n.x() < massCenterX) ? (leftNodes) : (rightNodes);
+                List<Node> nodesColumn = n.x() < massCenterX ? leftNodes : rightNodes;
                 nodesColumn.add(n);
             }
 
-            ArrayList<Node> topleftNodes = new ArrayList<>();
-            ArrayList<Node> bottomleftNodes = new ArrayList<>();
+            List<Node> topLeftNodes = new ArrayList<>();
+            List<Node> bottomLeftNodes = new ArrayList<>();
             for (Node n : leftNodes) {
-                ArrayList<Node> nodesLine = (n.y() < massCenterY) ? (topleftNodes) : (bottomleftNodes);
+                List<Node> nodesLine = n.y() < massCenterY ? topLeftNodes : bottomLeftNodes;
                 nodesLine.add(n);
             }
 
-            ArrayList<Node> bottomrightNodes = new ArrayList<>();
-            ArrayList<Node> toprightNodes = new ArrayList<>();
+            List<Node> bottomRightNodes = new ArrayList<>();
+            List<Node> topRightNodes = new ArrayList<>();
             for (Node n : rightNodes) {
-                ArrayList<Node> nodesLine = (n.y() < massCenterY) ? (toprightNodes) : (bottomrightNodes);
+                List<Node> nodesLine = n.y() < massCenterY ? topRightNodes : bottomRightNodes;
                 nodesLine.add(n);
             }
 
-            if (topleftNodes.size() > 0) {
-                if (topleftNodes.size() < nodes.size()) {
-                    Region subregion = new Region(topleftNodes);
+            if (!topLeftNodes.isEmpty()) {
+                if (topLeftNodes.size() < nodes.size()) {
+                    Region subregion = new Region(topLeftNodes);
                     subregions.add(subregion);
                 } else {
-                    for (Node n : topleftNodes) {
-                        ArrayList<Node> oneNodeList = new ArrayList<>();
+                    for (Node n : topLeftNodes) {
+                        List<Node> oneNodeList = new ArrayList<>();
                         oneNodeList.add(n);
                         Region subregion = new Region(oneNodeList);
                         subregions.add(subregion);
                     }
                 }
             }
-            if (bottomleftNodes.size() > 0) {
-                if (bottomleftNodes.size() < nodes.size()) {
-                    Region subregion = new Region(bottomleftNodes);
+            if (!bottomLeftNodes.isEmpty()) {
+                if (bottomLeftNodes.size() < nodes.size()) {
+                    Region subregion = new Region(bottomLeftNodes);
                     subregions.add(subregion);
                 } else {
-                    for (Node n : bottomleftNodes) {
-                        ArrayList<Node> oneNodeList = new ArrayList<>();
+                    for (Node n : bottomLeftNodes) {
+                        List<Node> oneNodeList = new ArrayList<>();
                         oneNodeList.add(n);
                         Region subregion = new Region(oneNodeList);
                         subregions.add(subregion);
                     }
                 }
             }
-            if (bottomrightNodes.size() > 0) {
-                if (bottomrightNodes.size() < nodes.size()) {
-                    Region subregion = new Region(bottomrightNodes);
+            if (!bottomRightNodes.isEmpty()) {
+                if (bottomRightNodes.size() < nodes.size()) {
+                    Region subregion = new Region(bottomRightNodes);
                     subregions.add(subregion);
                 } else {
-                    for (Node n : bottomrightNodes) {
-                        ArrayList<Node> oneNodeList = new ArrayList<>();
+                    for (Node n : bottomRightNodes) {
+                        List<Node> oneNodeList = new ArrayList<>();
                         oneNodeList.add(n);
                         Region subregion = new Region(oneNodeList);
                         subregions.add(subregion);
                     }
                 }
             }
-            if (toprightNodes.size() > 0) {
-                if (toprightNodes.size() < nodes.size()) {
-                    Region subregion = new Region(toprightNodes);
+            if (!topRightNodes.isEmpty()) {
+                if (topRightNodes.size() < nodes.size()) {
+                    Region subregion = new Region(topRightNodes);
                     subregions.add(subregion);
                 } else {
-                    for (Node n : toprightNodes) {
-                        ArrayList<Node> oneNodeList = new ArrayList<>();
+                    for (Node n : topRightNodes) {
+                        List<Node> oneNodeList = new ArrayList<>();
                         oneNodeList.add(n);
                         Region subregion = new Region(oneNodeList);
                         subregions.add(subregion);
@@ -180,18 +178,17 @@ public class Region {
         }
     }
 
-    public void applyForce(Node n, RepulsionForce Force, double theta) {
+    public void applyForce(Node node, RepulsionForce repulsionForce, double theta) {
         if (nodes.size() < 2) {
             Node regionNode = nodes.get(0);
-            Force.apply(n, regionNode);
+            repulsionForce.apply(node, regionNode);
         } else {
-            double distance = Math.sqrt(
-                (n.x() - massCenterX) * (n.x() - massCenterX) + (n.y() - massCenterY) * (n.y() - massCenterY));
+            double distance = Math.hypot(node.x() - massCenterX, node.y() - massCenterY);
             if (distance * theta > size) {
-                Force.apply(n, this);
+                repulsionForce.apply(node, this);
             } else {
                 for (Region subregion : subregions) {
-                    subregion.applyForce(n, Force, theta);
+                    subregion.applyForce(node, repulsionForce, theta);
                 }
             }
         }


### PR DESCRIPTION
## Description

Cleans up the ForceAtlas2 implementation without intentionally changing its behavior.

- Modernizes naming, generics, numeric literals, and nested helper classes.
- Extracts duplicated layout-data initialization.
- Uses `Math.hypot` for distance calculations.
- Preserves the thread interruption status when a worker task is interrupted.
- Replaces the incorrect `Double.MIN_VALUE` maximum-initialization sentinel with `0d`.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 🙅 no, because this is a behavior-preserving cleanup; existing focused tests were run.

## Added to documentation?

- [x] 🙅 no, because no public API or user-facing behavior changed.

## Validation

- `mvn -pl modules/LayoutPlugin compile`
- `ForceAtlas2Test` — 1 test passed
- `NoverlapTest` — 2 tests passed when run with reactor dependencies