### PR TITLE
Never deliver project and workspace events on the EDT

### DIFF
--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/Installer.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/Installer.java
@@ -1,12 +1,10 @@
 package org.gephi.desktop.project;
 
-import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 import org.gephi.project.api.ProjectController;
-import org.openide.awt.Actions;
+import org.openide.LifecycleManager;
 import org.openide.modules.ModuleInstall;
 import org.openide.util.Lookup;
-import org.openide.util.NbBundle;
-import org.openide.windows.WindowManager;
 
 public class Installer extends ModuleInstall {
 
@@ -20,15 +18,24 @@ public class Installer extends ModuleInstall {
     public boolean closing() {
         ProjectControllerUIImpl projectControllerUI = Lookup.getDefault().lookup(ProjectControllerUIImpl.class);
 
-        if (Lookup.getDefault().lookup(ProjectController.class).getCurrentProject() == null) {
-            //Close directly if no project open
+        if (!Lookup.getDefault().lookup(ProjectController.class).hasCurrentProject()) {
+            //Close directly if no project open. This is also the second pass of the sequence below,
+            //the project having been closed in the meantime.
             projectControllerUI.saveProjects();
             return true;
         }
-        boolean res = projectControllerUI.closeCurrentProject();
-        if (res) {
+
+        //The user is asked here, on the Event Dispatch Thread, but the save and close run on the
+        //Project IO thread and this thread must not wait for them. This shutdown pass is therefore
+        //vetoed and exit() is triggered again once the project is effectively closed, which then
+        //takes the branch above. When the user cancels, or when the save fails, nothing more happens
+        //and the application stays open.
+        projectControllerUI.confirmAndCloseCurrentProject(() -> {
+            //Persisted here too, and not only on the second pass, so the project list survives a
+            //shutdown that another module ends up vetoing
             projectControllerUI.saveProjects();
-        }
-        return res;
+            SwingUtilities.invokeLater(() -> LifecycleManager.getDefault().exit());
+        });
+        return false;
     }
 }

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -44,12 +44,11 @@ package org.gephi.desktop.project;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
@@ -57,6 +56,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileFilter;
 import org.gephi.desktop.importer.api.ImportControllerUI;
+import org.gephi.graph.api.Configuration;
 import org.gephi.io.importer.api.FileType;
 import org.gephi.io.importer.spi.FileImporterBuilder;
 import org.gephi.lib.validation.DialogDescriptorWithValidation;
@@ -66,7 +66,9 @@ import org.gephi.project.api.LegacyGephiFormatException;
 import org.gephi.project.api.Project;
 import org.gephi.project.api.ProjectController;
 import org.gephi.project.api.ProjectListener;
+import org.gephi.project.api.ProjectMetaData;
 import org.gephi.project.api.Workspace;
+import org.gephi.project.api.WorkspaceMetaData;
 import org.gephi.ui.project.NewWorkspace;
 import org.gephi.ui.project.ProjectList;
 import org.gephi.ui.project.ProjectPropertiesEditor;
@@ -103,17 +105,10 @@ public class ProjectControllerUIImpl implements ProjectListener {
     //Utilities
     private final LongTaskExecutor longTaskExecutor;
     //Actions
-    private boolean openProject = true;
-    private boolean newProject = true;
-    private boolean openFile = true;
-    private boolean saveProject = false;
-    private boolean saveAsProject = false;
-    private boolean projectProperties = false;
-    private boolean closeProject = false;
-    private boolean newWorkspace = false;
-    private boolean deleteWorkspace = false;
-    private boolean duplicateWorkspace = false;
-    private boolean renameWorkspace = false;
+    private volatile ActionsState actionsState = ActionsState.forProject(null);
+    //Last project the controller reported as saved. A save cancelled from the progress bar writes
+    //nothing and reports no failure, so this is the only way to tell it from a successful one.
+    private volatile Project lastSavedProject;
 
     public ProjectControllerUIImpl() {
 
@@ -135,6 +130,8 @@ public class ProjectControllerUIImpl implements ProjectListener {
                 Exceptions.printStackTrace(t);
             }
         });
+        //Safety net: a task may return early, or lock the actions without reaching the matching
+        //unlock, and the actions would stay disabled. Recomputing the state is idempotent.
         longTaskExecutor.setLongTaskListener(task -> unlockProjectActions());
     }
 
@@ -150,6 +147,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
 
     @Override
     public void saved(Project project) {
+        lastSavedProject = project;
         SwingUtilities.invokeLater(() -> {
             //Status line
             StatusDisplayer.getDefault().setStatusText(
@@ -228,18 +226,39 @@ public class ProjectControllerUIImpl implements ProjectListener {
         });
     }
 
+    /**
+     * Runs <code>runnable</code> on the Project IO thread, so the project controller never mutates
+     * the model nor invokes its listeners on the Event Dispatch Thread. Returns as soon as the task
+     * is submitted.
+     * <p>
+     * All the callers are on the Event Dispatch Thread. The operations that continue on the Project
+     * IO thread, such as confirming and closing the current project, deliberately call their steps
+     * directly rather than coming back through here: the executor runs a single task at a time, so
+     * submitting from within a task would enqueue it behind the task it is part of.
+     *
+     * @param runnable the operation to perform on the Project IO thread
+     */
+    private void runInProjectIO(Runnable runnable) {
+        longTaskExecutor.execute(null, runnable);
+    }
+
     private Future<Void> saveProject(Project project, File file) {
-
-
-        return longTaskExecutor.execute(null,   new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                controller.saveProject(project, file);
-                return null;
-            }
+        return longTaskExecutor.execute(null, () -> {
+            controller.saveProject(project, file);
+            return null;
         });
     }
 
+    /**
+     * Saves the current project, asking for a destination when it has none yet.
+     * <p>
+     * The returned future completes on the Project IO thread. Never wait on it from the Event
+     * Dispatch Thread: the save notifies the project listeners synchronously, and one of them
+     * marshalling to the interface would deadlock. Use it only from a background thread, or ignore
+     * it and react to {@link #saved(org.gephi.project.api.Project)} instead.
+     *
+     * @return a future that completes once the save is done
+     */
     public Future<Void> saveProject() {
         Project project = controller.getCurrentProject();
         if (project.hasFile()) {
@@ -249,7 +268,30 @@ public class ProjectControllerUIImpl implements ProjectListener {
         }
     }
 
+    /**
+     * Asks for a destination and saves the current project to it.
+     * <p>
+     * Same caveat as {@link #saveProject()}: the returned future must not be waited on from the
+     * Event Dispatch Thread.
+     *
+     * @return a future that completes once the save is done, already completed when the user gave up
+     *     the destination
+     */
     public Future<Void> saveAsProject() {
+        File file = selectSaveAsFile();
+        if (file != null) {
+            return saveProject(controller.getCurrentProject(), file);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Asks the user where the current project should be written. Runs on the calling thread, which
+     * has to be the Event Dispatch Thread.
+     *
+     * @return the destination file, or <code>null</code> if the user cancelled
+     */
+    private File selectSaveAsFile() {
         final String LAST_PATH = "SaveAsProject_Last_Path";
         final String LAST_PATH_DEFAULT = "SaveAsProject_Last_Path_Default";
 
@@ -292,10 +334,9 @@ public class ProjectControllerUIImpl implements ProjectListener {
             // Save last path
             NbPreferences.forModule(ProjectControllerUIImpl.class).put(LAST_PATH, file.getAbsolutePath());
 
-            // Save file
-            return saveProject(controller.getCurrentProject(), file);
+            return file;
         }
-        return CompletableFuture.completedFuture(null);
+        return null;
     }
 
     private boolean canExport(JFileChooser chooser) {
@@ -322,36 +363,143 @@ public class ProjectControllerUIImpl implements ProjectListener {
         return true;
     }
 
-    public boolean closeCurrentProject() {
-        if (controller.getCurrentProject() != null) {
-            //Save ?
-            String messageBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_message");
-            String titleBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_title");
-            String saveBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_save");
-            String doNotSaveBundle =
-                NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_doNotSave");
-            String cancelBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_cancel");
-            NotifyDescriptor msg = new NotifyDescriptor(messageBundle, titleBundle,
-                NotifyDescriptor.YES_NO_CANCEL_OPTION,
-                NotifyDescriptor.INFORMATION_MESSAGE,
-                new Object[] {saveBundle, doNotSaveBundle, cancelBundle}, saveBundle);
-            Object result = DialogDisplayer.getDefault().notify(msg);
-            if (result == saveBundle) {
-                Future<Void> saveTask = saveProject();
-                if(saveTask !=null){
-                    try {
-                        saveTask.get();
-                    } catch (InterruptedException | ExecutionException ex) {
-                        Exceptions.printStackTrace(ex);
-                    }
-                }
-            } else if (result == cancelBundle) {
+    /**
+     * Asks the user what to do with the current project before it gets closed, without touching the
+     * model. All the dialogs happen here, so the caller can perform the decision on the Project IO
+     * thread.
+     * <p>
+     * Blocks until the user answered. This is the only place where blocking is correct: a background
+     * thread waits for the user, never the interface for a background thread.
+     *
+     * @return the user's decision, never <code>null</code>
+     */
+    private CloseDecision confirmCloseCurrentProject() {
+        if (SwingUtilities.isEventDispatchThread()) {
+            return askCloseCurrentProject();
+        }
+        final CloseDecision[] decision = new CloseDecision[1];
+        try {
+            SwingUtilities.invokeAndWait(() -> decision[0] = askCloseCurrentProject());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return CloseDecision.CANCEL;
+        } catch (InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex.getCause() != null ? ex.getCause() : ex);
+            return CloseDecision.CANCEL;
+        }
+        return decision[0];
+    }
+
+    /**
+     * Shows the close confirmation. Runs on the Event Dispatch Thread only.
+     */
+    private CloseDecision askCloseCurrentProject() {
+        Project project = controller.getCurrentProject();
+        if (project == null) {
+            return CloseDecision.close(null);
+        }
+
+        //Save ?
+        String messageBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_message");
+        String titleBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_title");
+        String saveBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_save");
+        String doNotSaveBundle =
+            NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_doNotSave");
+        String cancelBundle = NbBundle.getMessage(ProjectControllerUIImpl.class, "CloseProject_confirm_cancel");
+        NotifyDescriptor msg = new NotifyDescriptor(messageBundle, titleBundle,
+            NotifyDescriptor.YES_NO_CANCEL_OPTION,
+            NotifyDescriptor.INFORMATION_MESSAGE,
+            new Object[] {saveBundle, doNotSaveBundle, cancelBundle}, saveBundle);
+        Object result = DialogDisplayer.getDefault().notify(msg);
+        if (result == saveBundle) {
+            //The destination is asked for now, so the close itself needs no dialog
+            File file = project.hasFile() ? project.getFile() : selectSaveAsFile();
+            if (file == null) {
+                //Giving up the destination gives up the close, otherwise the project would be
+                //closed without being saved
+                return CloseDecision.CANCEL;
+            }
+            return CloseDecision.saveAndClose(project, file);
+        } else if (result == cancelBundle) {
+            return CloseDecision.CANCEL;
+        }
+        return CloseDecision.close(project);
+    }
+
+    /**
+     * Performs a decision taken by {@link #confirmCloseCurrentProject()}. Shows no dialog: when the
+     * project has to be saved, the save runs before the close on the calling thread, which has to be
+     * the Project IO thread.
+     *
+     * @param decision the user's decision
+     * @return <code>true</code> when the project has been closed and the operation that requested
+     *     the close may continue
+     */
+    private boolean closeCurrentProject(CloseDecision decision) {
+        if (decision.cancelled) {
+            return false;
+        }
+        Project project = controller.getCurrentProject();
+        if (project == null) {
+            return true;
+        }
+        if (decision.project != null && decision.project != project) {
+            //The current project changed while the user was being asked, so neither the answer nor
+            //the destination it carries applies to what is open now
+            return false;
+        }
+        if (decision.saveFile != null) {
+            lastSavedProject = null;
+            try {
+                controller.saveProject(project, decision.saveFile);
+            } catch (RuntimeException ex) {
+                //The failure has already been reported to the user by the error() callback and
+                //closing now would throw away what couldn't be written
                 return false;
             }
-
-            controller.closeCurrentProject();
+            if (lastSavedProject != project) {
+                //The save was cancelled from the progress bar, which writes nothing and reports no
+                //failure. Closing now would throw the work away.
+                return false;
+            }
         }
+        controller.closeCurrentProject();
         return true;
+    }
+
+    /**
+     * Confirms and closes the current project, if any. Runs on the Project IO thread, the
+     * confirmation being marshalled to the Event Dispatch Thread.
+     *
+     * @return <code>true</code> when the operation that requested the close may continue
+     */
+    private boolean confirmAndCloseCurrentProject() {
+        if (!controller.hasCurrentProject()) {
+            return true;
+        }
+        return closeCurrentProject(confirmCloseCurrentProject());
+    }
+
+    /**
+     * Confirms closing the current project with the user and then closes it on the Project IO
+     * thread. Made for the shutdown sequence, which needs the user's answer before it can decide
+     * whether to proceed, while the close itself must not run on the Event Dispatch Thread.
+     * <p>
+     * Nothing happens when the user cancels.
+     *
+     * @param whenClosed executed on the Project IO thread once the project has been closed, not
+     *                   called if the user cancelled or if the close failed
+     */
+    public void confirmAndCloseCurrentProject(Runnable whenClosed) {
+        CloseDecision decision = confirmCloseCurrentProject();
+        if (decision.cancelled) {
+            return;
+        }
+        runInProjectIO(() -> {
+            if (closeCurrentProject(decision) && whenClosed != null) {
+                whenClosed.run();
+            }
+        });
     }
 
     public void openProject(Project project) {
@@ -363,108 +511,78 @@ public class ProjectControllerUIImpl implements ProjectListener {
             DialogDisplayer.getDefault().notify(msg);
             return;
         }
-        longTaskExecutor.execute(null, () -> {
-            if (controller.getCurrentProject() != null) {
-                if (!closeCurrentProject()) {
-                    return;
-                }
+        runInProjectIO(() -> {
+            if (!confirmAndCloseCurrentProject()) {
+                return;
             }
             controller.openProject(project);
         });
     }
 
     public void openProject(File file) {
-        longTaskExecutor.execute(null, () -> {
-            if (controller.getCurrentProject() != null) {
-                if (!closeCurrentProject()) {
-                    return;
-                }
+        runInProjectIO(() -> {
+            if (!confirmAndCloseCurrentProject()) {
+                return;
             }
             controller.openProject(file);
         });
     }
 
     public void removeProject(Project project) {
-        longTaskExecutor.execute(null, () -> {
-            if (controller.getCurrentProject() == project) {
-                if (!closeCurrentProject()) {
-                    return;
-                }
+        runInProjectIO(() -> {
+            if (controller.getCurrentProject() == project && !confirmAndCloseCurrentProject()) {
+                return;
             }
             controller.removeProject(project);
         });
     }
 
     public boolean canCloseProject() {
-        return closeProject;
+        return actionsState.closeProject;
     }
 
     public boolean canDeleteWorkspace() {
-        return deleteWorkspace;
+        return actionsState.deleteWorkspace;
     }
 
     public boolean canNewProject() {
-        return newProject;
+        return actionsState.newProject;
     }
 
     public boolean canNewWorkspace() {
-        return newWorkspace;
+        return actionsState.newWorkspace;
     }
 
     public boolean canDuplicateWorkspace() {
-        return duplicateWorkspace;
+        return actionsState.duplicateWorkspace;
     }
 
     public boolean canRenameWorkspace() {
-        return renameWorkspace;
+        return actionsState.renameWorkspace;
     }
 
     public boolean canOpenFile() {
-        return openFile;
+        return actionsState.openFile;
     }
 
     public boolean canSave() {
-        return saveProject;
+        return actionsState.saveProject;
     }
 
     public boolean canSaveAs() {
-        return saveAsProject;
+        return actionsState.saveAsProject;
     }
 
     public boolean canProjectProperties() {
-        return projectProperties;
+        return actionsState.projectProperties;
     }
 
     private void lockProjectActions() {
-        saveProject = false;
-        saveAsProject = false;
-        openProject = false;
-        closeProject = false;
-        newProject = false;
-        openFile = false;
-        newWorkspace = false;
-        deleteWorkspace = false;
-        duplicateWorkspace = false;
-        renameWorkspace = false;
-        projectProperties = false;
+        actionsState = ActionsState.LOCKED;
     }
 
     private void unlockProjectActions() {
-        if (controller.getCurrentProject() != null) {
-            saveProject = true;
-            saveAsProject = true;
-            closeProject = true;
-            newWorkspace = true;
-            projectProperties = true;
-            if (controller.getCurrentProject().hasCurrentWorkspace()) {
-                deleteWorkspace = true;
-                duplicateWorkspace = true;
-                renameWorkspace = true;
-            }
-        }
-        openProject = true;
-        newProject = true;
-        openFile = true;
+        actionsState = ActionsState.forProject(controller.getCurrentProject());
     }
 
     public void projectProperties() {
@@ -476,7 +594,23 @@ public class ProjectControllerUIImpl implements ProjectListener {
             NbBundle.getMessage(ProjectControllerUIImpl.class, "ProjectProperties_dialog_title")) ;
         Object result = DialogDisplayer.getDefault().notify(dd);
         if (result == NotifyDescriptor.OK_OPTION) {
-            panel.save(project);
+            String name = panel.getProjectName();
+            String title = panel.getProjectTitle();
+            String author = panel.getProjectAuthor();
+            String keywords = panel.getProjectKeywords();
+            String description = panel.getProjectDescription();
+            runInProjectIO(() -> {
+                if (!name.isEmpty() && !name.equals(project.getName())) {
+                    controller.renameProject(project, name);
+                }
+                ProjectMetaData metaData = project.getLookup().lookup(ProjectMetaData.class);
+                if (metaData != null) {
+                    metaData.setTitle(title);
+                    metaData.setAuthor(author);
+                    metaData.setKeywords(keywords);
+                    metaData.setDescription(description);
+                }
+            });
         }
     }
 
@@ -490,7 +624,21 @@ public class ProjectControllerUIImpl implements ProjectListener {
             NbBundle.getMessage(ProjectControllerUIImpl.class, "WorkspaceProperties_dialog_title"));
         Object result = DialogDisplayer.getDefault().notify(dd);
         if (result == NotifyDescriptor.OK_OPTION) {
-            panel.unsetup(workspace);
+            String name = panel.getWorkspaceName();
+            String title = panel.getWorkspaceTitle();
+            String description = panel.getWorkspaceDescription();
+            runInProjectIO(() -> {
+                WorkspaceMetaData metaData = workspace.getWorkspaceMetadata();
+                if (!description.isEmpty() && !description.equals(metaData.getDescription())) {
+                    metaData.setDescription(description);
+                }
+                if (!name.isEmpty() && !name.equals(workspace.getName())) {
+                    controller.renameWorkspace(workspace, name);
+                }
+                if (!title.isEmpty() && !title.equals(metaData.getTitle())) {
+                    metaData.setTitle(title);
+                }
+            });
         }
     }
 
@@ -608,15 +756,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
 
             if (gephiFile != null) {
                 //Project
-                File finalGephiFile = gephiFile;
-                longTaskExecutor.execute(null, () -> {
-                    if (controller.getCurrentProject() != null) {
-                        if (!closeCurrentProject()) {
-                            return;
-                        }
-                    }
-                    controller.openProject(finalGephiFile);
-                });
+                openProject(gephiFile);
             } else {
                 //Import
                 importControllerUI.importFiles(fileObjects.toArray(new FileObject[0]));
@@ -628,19 +768,20 @@ public class ProjectControllerUIImpl implements ProjectListener {
         return controller.getCurrentProject();
     }
 
-    public Project newProject() {
-        if (closeCurrentProject()) {
-            return controller.newProject();
-        }
-        return null;
+    public void newProject() {
+        runInProjectIO(() -> {
+            if (confirmAndCloseCurrentProject()) {
+                controller.newProject();
+            }
+        });
     }
 
     public void closeProject() {
-        closeCurrentProject();
+        runInProjectIO(() -> confirmAndCloseCurrentProject());
     }
 
-    public Workspace newWorkspace() {
-        return controller.newWorkspace(controller.getCurrentProject());
+    public void newWorkspace() {
+        runInProjectIO(() -> controller.newWorkspace(controller.getCurrentProject()));
     }
 
     public void newWorkspaceWithSettings() {
@@ -652,8 +793,23 @@ public class ProjectControllerUIImpl implements ProjectListener {
                 NbBundle.getMessage(ProjectControllerUIImpl.class, "NewWorkspace_dialog_title"));
         Object result = DialogDisplayer.getDefault().notify(dd);
         if (result == NotifyDescriptor.OK_OPTION) {
-            panel.unsetup();
+            Configuration configuration = panel.unsetup();
+            String name = panel.getWorkspaceName();
+            runInProjectIO(() -> {
+                Workspace workspace = controller.newWorkspace(controller.getCurrentProject(), configuration);
+                controller.renameWorkspace(workspace, name);
+            });
         }
+    }
+
+    /**
+     * Makes the given workspace the current one. Returns immediately when called from the Event
+     * Dispatch Thread, the workspace being opened on the Project IO thread.
+     *
+     * @param workspace the workspace to open
+     */
+    public void openWorkspace(Workspace workspace) {
+        runInProjectIO(() -> controller.openWorkspace(workspace));
     }
 
     public void deleteWorkspace() {
@@ -669,7 +825,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
             NotifyDescriptor.QUESTION_MESSAGE, null, null);
         Object retType = DialogDisplayer.getDefault().notify(dd);
         if (retType == NotifyDescriptor.YES_OPTION) {
-            controller.deleteWorkspace(workspace);
+            runInProjectIO(() -> controller.deleteWorkspace(workspace));
         }
     }
 
@@ -682,20 +838,22 @@ public class ProjectControllerUIImpl implements ProjectListener {
             NotifyDescriptor.QUESTION_MESSAGE, null, null);
         Object retType = DialogDisplayer.getDefault().notify(dd);
         if (retType == NotifyDescriptor.YES_OPTION) {
-            for (Workspace workspace : workspaces) {
-                controller.deleteWorkspace(workspace);
-            }
+            List<Workspace> toDelete = new ArrayList<>(workspaces);
+            runInProjectIO(() -> {
+                for (Workspace workspace : toDelete) {
+                    controller.deleteWorkspace(workspace);
+                }
+            });
         }
     }
 
     public void renameWorkspace(String name) {
-        controller.renameWorkspace(controller.getCurrentWorkspace(), name);
+        Workspace workspace = controller.getCurrentWorkspace();
+        runInProjectIO(() -> controller.renameWorkspace(workspace, name));
     }
 
     public void duplicateWorkspace() {
-        longTaskExecutor.execute(null, () -> {
-            controller.duplicateWorkspace(controller.getCurrentWorkspace());
-        });
+        runInProjectIO(() -> controller.duplicateWorkspace(controller.getCurrentWorkspace()));
     }
 
     private String getCurrentVersion() {
@@ -734,6 +892,77 @@ public class ProjectControllerUIImpl implements ProjectListener {
             } catch (IOException e) {
                 Exceptions.printStackTrace(e);
             }
+        }
+    }
+
+    /**
+     * Immutable snapshot of the actions currently enabled. The Project IO thread replaces the whole
+     * snapshot at once while the Event Dispatch Thread reads it from <code>Action.isEnabled()</code>,
+     * so the interface can't observe a half-applied enablement.
+     */
+    private static final class ActionsState {
+
+        private static final ActionsState LOCKED = new ActionsState(false, false, false);
+
+        private final boolean newProject;
+        private final boolean openFile;
+        private final boolean saveProject;
+        private final boolean saveAsProject;
+        private final boolean projectProperties;
+        private final boolean closeProject;
+        private final boolean newWorkspace;
+        private final boolean deleteWorkspace;
+        private final boolean duplicateWorkspace;
+        private final boolean renameWorkspace;
+
+        private ActionsState(boolean fileActions, boolean projectActions, boolean workspaceActions) {
+            this.newProject = fileActions;
+            this.openFile = fileActions;
+            this.saveProject = projectActions;
+            this.saveAsProject = projectActions;
+            this.projectProperties = projectActions;
+            this.closeProject = projectActions;
+            this.newWorkspace = projectActions;
+            this.deleteWorkspace = workspaceActions;
+            this.duplicateWorkspace = workspaceActions;
+            this.renameWorkspace = workspaceActions;
+        }
+
+        private static ActionsState forProject(Project project) {
+            return new ActionsState(true, project != null, project != null && project.hasCurrentWorkspace());
+        }
+    }
+
+    /**
+     * The user's answer to the close confirmation. <code>saveFile</code> is the destination the
+     * project has to be written to before being closed, <code>null</code> when it has to be closed
+     * without being saved.
+     */
+    private static final class CloseDecision {
+
+        private static final CloseDecision CANCEL = new CloseDecision(null, true, null);
+
+        /**
+         * Project the user answered about, <code>null</code> when there was nothing to answer for.
+         * The answer is acted upon later, on the Project IO thread, by which time another project
+         * may have become the current one.
+         */
+        private final Project project;
+        private final boolean cancelled;
+        private final File saveFile;
+
+        private CloseDecision(Project project, boolean cancelled, File saveFile) {
+            this.project = project;
+            this.cancelled = cancelled;
+            this.saveFile = saveFile;
+        }
+
+        private static CloseDecision close(Project project) {
+            return new CloseDecision(project, false, null);
+        }
+
+        private static CloseDecision saveAndClose(Project project, File file) {
+            return new CloseDecision(project, false, file);
         }
     }
 }

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/actions/OpenWorkspace.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/actions/OpenWorkspace.java
@@ -1,0 +1,76 @@
+/*
+Copyright 2008-2010 Gephi
+Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+Website : http://www.gephi.org
+
+This file is part of Gephi.
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2011 Gephi Consortium. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 3 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://gephi.org/about/legal/license-notice/
+or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License files at
+/cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 3, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 3] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 3 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 3 code and therefore, elected the GPL
+Version 3 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+
+Contributor(s):
+
+Portions Copyrighted 2011 Gephi Consortium.
+*/
+
+package org.gephi.desktop.project.actions;
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import org.gephi.desktop.project.ProjectControllerUIImpl;
+import org.gephi.project.api.Workspace;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+
+/**
+ * Selects a workspace off the Event Dispatch Thread.
+ * <p>
+ * This action exists so modules outside DesktopProject can trigger a workspace selection without
+ * reaching into <code>org.gephi.desktop.project</code>, which is not one of this module's public
+ * packages. It is invoked programmatically with the target workspace as the event source and is
+ * deliberately not registered in any menu.
+ */
+@ActionID(id = "org.gephi.desktop.project.actions.OpenWorkspace", category = "Workspace")
+@ActionRegistration(displayName = "#CTL_OpenWorkspace", lazy = false)
+public final class OpenWorkspace extends AbstractAction {
+
+    OpenWorkspace() {
+        super(NbBundle.getMessage(OpenWorkspace.class, "CTL_OpenWorkspace"));
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent ev) {
+        if (ev.getSource() instanceof Workspace) {
+            Lookup.getDefault().lookup(ProjectControllerUIImpl.class).openWorkspace((Workspace) ev.getSource());
+        }
+    }
+}

--- a/modules/DesktopProject/src/main/java/org/gephi/ui/project/NewWorkspace.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/ui/project/NewWorkspace.java
@@ -47,7 +47,6 @@ import org.gephi.graph.api.GraphController;
 import org.gephi.graph.api.TimeRepresentation;
 import org.gephi.project.api.Project;
 import org.gephi.project.api.ProjectController;
-import org.gephi.project.api.Workspace;
 import org.gephi.project.api.WorkspaceProvider;
 import org.gephi.ui.utils.TimeRepresentationWrapper;
 import org.netbeans.validation.api.builtin.stringvalidation.StringValidators;
@@ -96,20 +95,26 @@ public class NewWorkspace extends javax.swing.JPanel {
         nameTextField.setText(prefix+" "+workspaceProvider.getNextWorkspaceId());
     }
 
-    public void unsetup() {
+    /**
+     * Returns the configuration the user selected and remembers it as the default for the next
+     * workspace. The workspace itself is created by the caller, off the Event Dispatch Thread.
+     *
+     * @return the configuration for the workspace to create
+     */
+    public Configuration unsetup() {
         GraphController graphController = Lookup.getDefault().lookup(GraphController.class);
         Configuration.Builder defaultConfig = graphController.getDefaultConfigurationBuilder();
         TimeRepresentation selected = ((TimeRepresentationWrapper)timeRepresentationComboBox.getSelectedItem()).getTimeRepresentation();
 
-        Configuration configuration = defaultConfig.timeRepresentation(selected).build();
-
-        ProjectController controller = Lookup.getDefault().lookup(ProjectController.class);
-        Workspace workspace = controller.newWorkspace(controller.getCurrentProject(), configuration);
-        controller.renameWorkspace(workspace, nameTextField.getText());
-
         // Save preference
         NbPreferences.forModule(NewWorkspace.class)
             .putInt(TIME_REPRESENTATION_SAVED_PREFERENCES, timeRepresentationComboBox.getSelectedIndex());
+
+        return defaultConfig.timeRepresentation(selected).build();
+    }
+
+    public String getWorkspaceName() {
+        return nameTextField.getText();
     }
 
     public static ValidationPanel createValidationPanel(NewWorkspace innerPanel) {

--- a/modules/DesktopProject/src/main/java/org/gephi/ui/project/ProjectPropertiesEditor.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/ui/project/ProjectPropertiesEditor.java
@@ -43,13 +43,11 @@ Portions Copyrighted 2011 Gephi Consortium.
 package org.gephi.ui.project;
 
 import org.gephi.project.api.Project;
-import org.gephi.project.api.ProjectController;
 import org.gephi.project.api.ProjectInformation;
 import org.gephi.project.api.ProjectMetaData;
 import org.netbeans.validation.api.builtin.stringvalidation.StringValidators;
 import org.netbeans.validation.api.ui.ValidationGroup;
 import org.netbeans.validation.api.ui.swing.ValidationPanel;
-import org.openide.util.Lookup;
 
 /**
  * @author Mathieu Bastian
@@ -111,22 +109,24 @@ public class ProjectPropertiesEditor extends javax.swing.JPanel {
         }
     }
 
-    public void save(Project project) {
-        ProjectInformation info = project.getLookup().lookup(ProjectInformation.class);
-        if (info != null) {
-            if (!nameTextField.getText().isEmpty() && !nameTextField.getText().equals(info.getName())) {
-                ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-                pc.renameProject(project, nameTextField.getText());
-            }
-        }
-        ProjectMetaData metaData = project.getLookup().lookup(ProjectMetaData.class);
-        if (metaData != null) {
-            metaData.setTitle(titleTextField.getText());
+    public String getProjectName() {
+        return nameTextField.getText();
+    }
 
-            metaData.setAuthor(authorTextField.getText());
-            metaData.setKeywords(keywordsTextField.getText());
-            metaData.setDescription(descriptionTextArea.getText());
-        }
+    public String getProjectTitle() {
+        return titleTextField.getText();
+    }
+
+    public String getProjectAuthor() {
+        return authorTextField.getText();
+    }
+
+    public String getProjectKeywords() {
+        return keywordsTextField.getText();
+    }
+
+    public String getProjectDescription() {
+        return descriptionTextArea.getText();
     }
 
     /**

--- a/modules/DesktopProject/src/main/java/org/gephi/ui/project/WorkspacePropertiesEditor.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/ui/project/WorkspacePropertiesEditor.java
@@ -1,12 +1,10 @@
 package org.gephi.ui.project;
 
-import org.gephi.desktop.project.ProjectControllerUIImpl;
 import org.gephi.project.api.Workspace;
 import org.gephi.project.api.WorkspaceMetaData;
 import org.netbeans.validation.api.builtin.stringvalidation.StringValidators;
 import org.netbeans.validation.api.ui.ValidationGroup;
 import org.netbeans.validation.api.ui.swing.ValidationPanel;
-import org.openide.util.Lookup;
 
 public class WorkspacePropertiesEditor extends javax.swing.JPanel {
 
@@ -37,19 +35,16 @@ public class WorkspacePropertiesEditor extends javax.swing.JPanel {
         nameTextField.setText(workspace.getName());
     }
 
-    public void unsetup(Workspace workspace) {
-        WorkspaceMetaData info = workspace.getWorkspaceMetadata();
-        if (!descriptionTextArea.getText().isEmpty() && !descriptionTextArea.getText().equals(info.getDescription())) {
-            info.setDescription(descriptionTextArea.getText());
-        }
+    public String getWorkspaceName() {
+        return nameTextField.getText();
+    }
 
-        if (!nameTextField.getText().isEmpty() && !nameTextField.getText().equals(workspace.getName())) {
-            Lookup.getDefault().lookup(ProjectControllerUIImpl.class).renameWorkspace(nameTextField.getText());
-        }
+    public String getWorkspaceTitle() {
+        return titleTextField.getText();
+    }
 
-        if (!titleTextField.getText().isEmpty() && !titleTextField.getText().equals(info.getTitle())) {
-            info.setTitle(titleTextField.getText());
-        }
+    public String getWorkspaceDescription() {
+        return descriptionTextArea.getText();
     }
 
     /**

--- a/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/actions/Bundle.properties
+++ b/modules/DesktopProject/src/main/resources/org/gephi/desktop/project/actions/Bundle.properties
@@ -18,3 +18,4 @@ RenameWorkspace.dialog.title = Rename Workspace
 CTL_OpenRecentFiles=Open Recent...
 OpenFile.fileNotSupported=The file format is not supported
 OpenFile.fileNotAccessible=The file "{0}" cannot be accessed. It may have been moved, deleted, or is on an unavailable drive.
+CTL_OpenWorkspace=Open

--- a/modules/DesktopWindow/src/main/java/org/gephi/desktop/banner/workspace/WorkspacePanel.java
+++ b/modules/DesktopWindow/src/main/java/org/gephi/desktop/banner/workspace/WorkspacePanel.java
@@ -49,6 +49,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import javax.swing.Action;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
@@ -69,10 +70,17 @@ import org.openide.awt.Actions;
 import org.openide.util.Lookup;
 import org.openide.windows.WindowManager;
 
-public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListener, PropertyChangeListener {
+public class WorkspacePanel extends javax.swing.JPanel implements PropertyChangeListener {
 
     private transient final DefaultTabDataModel tabDataModel;
     private transient final TabDisplayer tabbedContainer;
+
+    /**
+     * True while the panel is pushing the controller's state into the tab selection. Workspace
+     * opening is asynchronous, so the current workspace can't be used to tell a user-initiated
+     * selection from an echo of a model-driven one. EDT-confined.
+     */
+    private transient boolean applyingModelSelection;
 
     /**
      * Creates new form WorkspacePanel
@@ -113,13 +121,16 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
 
             @Override
             public void stateChanged(ChangeEvent e) {
+                if (applyingModelSelection) {
+                    return;
+                }
                 if (tabbedContainer.getSelectionModel().getSelectedIndex() != -1) {
                     TabData tabData = tabDataModel.getTab(tabbedContainer.getSelectionModel().getSelectedIndex());
-                    Workspace workspace = (Workspace) tabData.getUserObject();
-                    ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-                    if (pc.getCurrentWorkspace() != null && pc.getCurrentWorkspace() != workspace) {
-                        pc.openWorkspace(workspace);
-                    }
+                    // Deliberately not filtered on the controller's current workspace: opening is
+                    // asynchronous, so that read is stale and would drop a selection made while a
+                    // previous one is still in flight. applyingModelSelection above is what keeps
+                    // the model-driven changes from coming back here.
+                    openWorkspace((Workspace) tabData.getUserObject());
                 }
             }
         });
@@ -147,8 +158,7 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
                     tabActionEvent.consume();
                 } else if (TabbedContainer.COMMAND_SELECT.equals(tabActionEvent.getActionCommand())) {
                     TabData tabData = tabDataModel.getTab(tabActionEvent.getTabIndex());
-                    ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-                    pc.openWorkspace((Workspace) tabData.getUserObject());
+                    openWorkspace((Workspace) tabData.getUserObject());
                     tabActionEvent.consume();
                 }
             }
@@ -160,13 +170,28 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
             @Override
             public void run() {
                 ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-                pc.addWorkspaceListener(WorkspacePanel.this);
+                pc.addWorkspaceListener(createWorkspaceListener());
                 refreshModel();
             }
         });
     }
 
-    private synchronized void refreshModel() {
+    /**
+     * Requests that <code>workspace</code> becomes the selected one, off the Event Dispatch Thread.
+     * <p>
+     * Routed through the action system rather than calling ProjectControllerUIImpl directly:
+     * <code>org.gephi.desktop.project</code> is not one of the DesktopProject module's public
+     * packages, so the NetBeans module classloader would refuse the access at runtime. The tab bar
+     * already reaches its sibling workspace actions the same way.
+     */
+    private static void openWorkspace(Workspace workspace) {
+        Action action = Actions.forID("Workspace", "org.gephi.desktop.project.actions.OpenWorkspace");
+        if (action != null) {
+            action.actionPerformed(new ActionEvent(workspace, 0, null));
+        }
+    }
+
+    private void refreshModel() {
         ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
         if (pc.getCurrentProject() != null) {
             WorkspaceProvider workspaceProvider = pc.getCurrentProject().getLookup().lookup(WorkspaceProvider.class);
@@ -180,7 +205,12 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
                         new TabData(workspace, null, workspaceInformation.getName(),
                             workspaceInformation.getSource()));
                     if (workspaceProvider.getCurrentWorkspace() == workspace) {
-                        tabbedContainer.getSelectionModel().setSelectedIndex(index);
+                        applyingModelSelection = true;
+                        try {
+                            tabbedContainer.getSelectionModel().setSelectedIndex(index);
+                        } finally {
+                            applyingModelSelection = false;
+                        }
                         workspace.getLookup().lookup(WorkspaceInformation.class).addChangeListener(this);
                     }
                 }
@@ -191,10 +221,28 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
             }
         }
 
-        // Clear
-        tabbedContainer.getSelectionModel().clearSelection();
-        if (tabDataModel.size() > 0) {
-            tabDataModel.removeTabs(0, tabDataModel.size() - 1);
+        clearTabs();
+    }
+
+    /**
+     * Empties the tab bar and detaches it. Must run on the EDT.
+     */
+    private void clearTabs() {
+        applyingModelSelection = true;
+        try {
+            tabbedContainer.getSelectionModel().clearSelection();
+            if (tabDataModel.size() > 0) {
+                // removeTabs(int, int) treats its end index as exclusive, unless both bounds are
+                // equal, in which case it removes the single tab at that index. Hence size() and
+                // not size() - 1, and hence the guard, as removeTabs(0, 0) would be out of bounds
+                tabDataModel.removeTabs(0, tabDataModel.size());
+            }
+        } finally {
+            applyingModelSelection = false;
+        }
+        if (tabbedContainer.getParent() == this) {
+            remove(tabbedContainer);
+            getParent().revalidate();
         }
     }
 
@@ -213,8 +261,49 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     // End of variables declaration//GEN-END:variables
-    @Override
-    public void initialize(final Workspace workspace) {
+    /**
+     * Adapts the workspace events onto this panel.
+     * <p>
+     * The panel deliberately does not implement {@link WorkspaceListener} itself: it extends
+     * <code>JPanel</code>, and <code>WorkspaceListener.disable()</code> would collide with the
+     * inherited deprecated <code>java.awt.Component.disable()</code>. Before this indirection the
+     * interface method silently bound to the inherited one, so closing a project greyed the tab bar
+     * out instead of clearing it; overriding it instead would make every
+     * <code>setEnabled(false)</code> on this panel clear the tabs. Keeping the two apart avoids both.
+     *
+     * @return a listener forwarding to this panel's own callbacks
+     */
+    private WorkspaceListener createWorkspaceListener() {
+        return new WorkspaceListener() {
+
+            @Override
+            public void initialize(Workspace workspace) {
+                workspaceInitialized(workspace);
+            }
+
+            @Override
+            public void select(Workspace workspace) {
+                workspaceSelected(workspace);
+            }
+
+            @Override
+            public void unselect(Workspace workspace) {
+                workspaceUnselected(workspace);
+            }
+
+            @Override
+            public void close(Workspace workspace) {
+                workspaceClosed(workspace);
+            }
+
+            @Override
+            public void disable() {
+                workspacesDisabled();
+            }
+        };
+    }
+
+    private void workspaceInitialized(final Workspace workspace) {
         final WorkspaceInformation workspaceInformation = workspace.getLookup().lookup(WorkspaceInformation.class);
         SwingUtilities.invokeLater(new Runnable() {
 
@@ -231,8 +320,7 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
         });
     }
 
-    @Override
-    public void select(final Workspace workspace) {
+    private void workspaceSelected(final Workspace workspace) {
         SwingUtilities.invokeLater(new Runnable() {
 
             @Override
@@ -241,7 +329,12 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
                     TabData tabData = tabDataModel.getTab(i);
                     if (tabData.getUserObject() == workspace) {
                         if (tabbedContainer.getSelectionModel().getSelectedIndex() != i) {
-                            tabbedContainer.getSelectionModel().setSelectedIndex(i);
+                            applyingModelSelection = true;
+                            try {
+                                tabbedContainer.getSelectionModel().setSelectedIndex(i);
+                            } finally {
+                                applyingModelSelection = false;
+                            }
                         }
                         tabDataModel.setText(i, workspace.getName());
                         workspace.getLookup().lookup(WorkspaceInformation.class).addChangeListener(WorkspacePanel.this);
@@ -252,30 +345,49 @@ public class WorkspacePanel extends javax.swing.JPanel implements WorkspaceListe
         });
     }
 
-    @Override
-    public void unselect(Workspace workspace) {
+    private void workspaceUnselected(Workspace workspace) {
         workspace.getLookup().lookup(WorkspaceInformation.class).removeChangeListener(this);
     }
 
-    @Override
-    public void close(final Workspace workspace) {
+    private void workspaceClosed(final Workspace workspace) {
         SwingUtilities.invokeLater(new Runnable() {
 
             @Override
             public void run() {
-                for (int i = 0; i < tabDataModel.size(); i++) {
-                    TabData tabData = tabDataModel.getTab(i);
-                    if (tabData.getUserObject() == workspace) {
-                        tabDataModel.removeTab(i);
-                        break;
+                // Removing a tab can move the selection onto a neighbour, which would ask the
+                // controller to select that workspace in the middle of tearing this one down
+                applyingModelSelection = true;
+                try {
+                    for (int i = 0; i < tabDataModel.size(); i++) {
+                        TabData tabData = tabDataModel.getTab(i);
+                        if (tabData.getUserObject() == workspace) {
+                            tabDataModel.removeTab(i);
+                            break;
+                        }
                     }
+                    if (tabDataModel.size() == 0) {
+                        tabbedContainer.getSelectionModel().clearSelection();
+                    }
+                } finally {
+                    applyingModelSelection = false;
                 }
-                if (tabDataModel.size() == 0) {
-                    tabbedContainer.getSelectionModel().clearSelection();
-
+                if (tabDataModel.size() == 0 && tabbedContainer.getParent() == WorkspacePanel.this) {
                     remove(tabbedContainer);
                     getParent().revalidate();
                 }
+            }
+        });
+    }
+
+    private void workspacesDisabled() {
+        // Clear unconditionally instead of re-reading the controller: when a project replaces
+        // another one, the replacement is already current by the time this reaches the EDT, and
+        // its own initialize() callbacks are queued behind us to fill the tab bar again.
+        SwingUtilities.invokeLater(new Runnable() {
+
+            @Override
+            public void run() {
+                clearTabs();
             }
         });
     }

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
@@ -134,8 +134,8 @@ public final class LongTaskExecutor {
      *                               <code>taskName</code> is null
      * @throws IllegalStateException if a task is still executing at this time
      */
-    public synchronized void execute(LongTask task, final Runnable runnable, String taskName,
-                                     LongTaskErrorHandler errorHandler) {
+    public void execute(LongTask task, final Runnable runnable, String taskName,
+                        LongTaskErrorHandler errorHandler) {
         if (runnable == null || taskName == null) {
             throw new NullPointerException();
         }
@@ -158,8 +158,8 @@ public final class LongTaskExecutor {
      *                               <code>taskName</code> is null
      * @throws IllegalStateException if a task is still executing at this time
      */
-    public synchronized <V> Future<V> execute(LongTask task, final Callable<V> callable, String taskName,
-                                     LongTaskErrorHandler errorHandler) {
+    public <V> Future<V> execute(LongTask task, final Callable<V> callable, String taskName,
+                                 LongTaskErrorHandler errorHandler) {
         if (callable == null || taskName == null) {
             throw new NullPointerException();
         }
@@ -168,18 +168,16 @@ public final class LongTaskExecutor {
 
     private <V> Future<V> execute(RunningLongTask<V> runningLongtask) {
         if (inBackground) {
-            if (executor == null) {
-                this.executor = new ThreadPoolExecutor(0, 1, 15, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
-                    new NamedThreadFactory());
-            }
-            Future<V> result = executor.submit(runningLongtask);
-            runningLongtask.future = result;
-            return result;
-        } else {
-            currentTask = runningLongtask;
-            runningLongtask.call();
-            return runningLongtask.future;
+            return submit(runningLongtask);
         }
+        // The synchronous path runs the whole task body on the calling thread and must
+        // do so without holding this executor's monitor. cancel() is synchronized and
+        // is typically called from the EDT (the progress bar's Cancel button), so a
+        // monitor held here would block the EDT until the task completes and the cancel
+        // request would always arrive too late to be of any use.
+        currentTask = runningLongtask;
+        runningLongtask.call();
+        return runningLongtask.future;
     }
 
     /**
@@ -192,7 +190,7 @@ public final class LongTaskExecutor {
      * @throws NullPointerException  if <code>runnable</code> is null
      * @throws IllegalStateException if a task is still executing at this time
      */
-    public synchronized void execute(LongTask task, Runnable runnable) {
+    public void execute(LongTask task, Runnable runnable) {
         execute(task, runnable, "", null);
     }
 
@@ -206,8 +204,22 @@ public final class LongTaskExecutor {
      * @throws NullPointerException  if <code>callable</code> is null
      * @throws IllegalStateException if a task is still executing at this time
      */
-    public synchronized <V> Future<V> execute(LongTask task, Callable<V> callable) {
+    public <V> Future<V> execute(LongTask task, Callable<V> callable) {
         return execute(task, callable, "", null);
+    }
+
+    /**
+     * Submits the task to the background executor, creating it on first use.
+     * Synchronized so the lazy creation and the submission stay atomic.
+     */
+    private synchronized <V> Future<V> submit(RunningLongTask<V> runningLongtask) {
+        if (executor == null) {
+            this.executor = new ThreadPoolExecutor(0, 1, 15, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
+                new NamedThreadFactory());
+        }
+        Future<V> result = executor.submit(runningLongtask);
+        runningLongtask.future = result;
+        return result;
     }
 
     /**

--- a/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/SynchronousTest.java
+++ b/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/SynchronousTest.java
@@ -1,8 +1,11 @@
 package org.gephi.utils.longtask.api;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.awaitility.Awaitility;
 import org.gephi.utils.longtask.api.LongTaskErrorHandler;
 import org.gephi.utils.longtask.api.LongTaskExecutor;
@@ -110,6 +113,40 @@ public class SynchronousTest {
         expectedException.expect(ExecutionException.class);
         expectedException.expectCause(Is.isA(RuntimeException.class));
         res.get();
+    }
+
+    @Test(timeout = 30000)
+    public void testCancelNotBlockedByRunningTask() throws Exception {
+        final CountDownLatch taskStarted = new CountDownLatch(1);
+        final CountDownLatch cancelReturned = new CountDownLatch(1);
+        final AtomicBoolean cancelledWhileRunning = new AtomicBoolean();
+
+        // The task body only completes once cancel() has returned on the other thread,
+        // so the executor's monitor can't be held while the task is running.
+        Mockito.doAnswer(invocation -> {
+            taskStarted.countDown();
+            cancelledWhileRunning.set(cancelReturned.await(5, TimeUnit.SECONDS));
+            return null;
+        }).when(runnable).run();
+
+        Thread canceller = new Thread(() -> {
+            try {
+                if (taskStarted.await(10, TimeUnit.SECONDS)) {
+                    executor.cancel();
+                    cancelReturned.countDown();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }, "cancel-caller");
+        canceller.start();
+
+        executor.execute(longTask, runnable);
+        canceller.join();
+
+        Assert.assertTrue("cancel() must not wait for the running synchronous task",
+            cancelledWhileRunning.get());
+        Mockito.verify(longTask).cancel();
     }
 
     public static class MockProgressTicketProvider implements ProgressTicketProvider {

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectController.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectController.java
@@ -56,6 +56,11 @@ import java.util.Collection;
  * At startup, no project is opened. To open a project, use {@link #openProject(java.io.File)} or create a new one with {@link #newProject()}.
  * <p>
  * A project contains one or more workspaces. A project can have only one workspace selected at a time. By default, a project starts with one workspace.
+ * <p>
+ * <b>Threading:</b> every method that mutates a project or a workspace blocks until the operation completes, and
+ * notifies the {@link ProjectListener} and {@link WorkspaceListener} instances synchronously, on the thread performing
+ * that operation. Such methods must therefore not be called from the Event Dispatch Thread.
+ * The read-only methods, such as {@link #getCurrentWorkspace()}, can be called from anywhere.
  *
  * @author Mathieu Bastian
  * @see Project

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectListener.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/ProjectListener.java
@@ -4,11 +4,29 @@ import java.util.EventListener;
 
 /**
  * Project listener.
+ * <p>
+ * <b>Threading:</b> all the methods below are invoked synchronously, on the thread that is performing
+ * the project operation. That thread is never the Event Dispatch Thread, and two callbacks may well
+ * arrive on two different threads, so any state shared with other threads must be volatile, atomic or
+ * otherwise guarded.
+ * <p>
+ * Implementations must post any user interface work with <code>SwingUtilities.invokeLater</code> and
+ * return promptly: they run inside the operation and delay it. In particular they must never call
+ * <code>SwingUtilities.invokeAndWait</code>, or wait on the Event Dispatch Thread in any other way,
+ * as that deadlocks whenever the EDT is itself waiting for the operation.
  */
 public interface ProjectListener extends EventListener {
 
+    /**
+     * Called when a long project operation starts, so clients can disable what must not be used while
+     * it runs. Toggling Swing components has to be deferred to the Event Dispatch Thread.
+     */
     void lock();
 
+    /**
+     * Called when an operation ends without any other outcome being reported, for instance because the
+     * user cancelled it.
+     */
     void unlock();
 
     /**

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceInformation.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceInformation.java
@@ -114,6 +114,13 @@ public interface WorkspaceInformation {
 
     /**
      * Add change listener.
+     * <p>
+     * These events come from the same {@link ProjectController} operations as the
+     * {@link WorkspaceListener} callbacks and share their threading rules: the listener is invoked
+     * synchronously on the thread performing the operation, which is never the Event Dispatch Thread
+     * and isn't necessarily the same thread from one event to the next. Post user interface work with
+     * <code>SwingUtilities.invokeLater</code>, never with <code>invokeAndWait</code>, and don't block
+     * the calling thread.
      *
      * @param listener change listener
      */

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceListener.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/api/WorkspaceListener.java
@@ -44,6 +44,16 @@ package org.gephi.project.api;
 
 /**
  * Workspace event listener.
+ * <p>
+ * <b>Threading:</b> all the methods below are invoked synchronously, on the thread that is performing
+ * the project operation. That thread is never the Event Dispatch Thread, and two callbacks may well
+ * arrive on two different threads, so any state shared with other threads must be volatile, atomic or
+ * otherwise guarded.
+ * <p>
+ * Implementations must post any user interface work with <code>SwingUtilities.invokeLater</code> and
+ * return promptly: they run inside the operation and delay it. In particular they must never call
+ * <code>SwingUtilities.invokeAndWait</code>, or wait on the Event Dispatch Thread in any other way,
+ * as that deadlocks whenever the EDT is itself waiting for the operation.
  *
  * @author Mathieu Bastian
  */
@@ -51,6 +61,9 @@ public interface WorkspaceListener {
 
     /**
      * Notify a workspace has been created.
+     * <p>
+     * This is where a module typically creates its model for the workspace, so it is called before
+     * any other callback for that workspace and must complete before the workspace is usable.
      *
      * @param workspace the workspace that was created
      */
@@ -58,6 +71,9 @@ public interface WorkspaceListener {
 
     /**
      * Notify a workspace has become the selected workspace.
+     * <p>
+     * Refreshing the interface to match the new selection has to be deferred to the Event Dispatch
+     * Thread.
      *
      * @param workspace the workspace that was made current workspace
      */

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectControllerImpl.java
@@ -44,6 +44,8 @@ package org.gephi.project.impl;
 
 import java.beans.PropertyEditorManager;
 import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,6 +54,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.gephi.project.api.GephiFormatException;
 import org.gephi.project.api.LegacyGephiFormatException;
 import org.gephi.project.api.Project;
@@ -73,6 +77,8 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service = ProjectController.class)
 public class ProjectControllerImpl implements ProjectController {
+
+    private static final Logger LOGGER = Logger.getLogger(ProjectControllerImpl.class.getName());
 
     //Data
     private final ProjectsImpl projects = new ProjectsImpl();
@@ -99,8 +105,34 @@ public class ProjectControllerImpl implements ProjectController {
         }
     }
 
+    /**
+     * Reports a mutating operation started from the Event Dispatch Thread. Such an operation blocks
+     * its caller until completion and notifies the listeners synchronously, so on the EDT it freezes
+     * the interface and hands the listeners a thread they are told never to expect.
+     * <p>
+     * The EDT is detected by thread name deliberately: <code>EventQueue.isDispatchThread()</code> and
+     * <code>SwingUtilities.isEventDispatchThread()</code> both go through
+     * <code>Toolkit.getDefaultToolkit()</code> and would initialize the AWT toolkit as a side effect.
+     * This module is AWT-free so that gephi-toolkit can use it headless, so please don't replace this
+     * check with the Swing one.
+     */
+    private void warnIfEventDispatchThread(String method) {
+        if (Thread.currentThread().getName().startsWith("AWT-EventQueue")) {
+            StringWriter callSite = new StringWriter();
+            PrintWriter writer = new PrintWriter(callSite);
+            new Throwable("call site").printStackTrace(writer);
+            writer.flush();
+            LOGGER.log(Level.WARNING, "ProjectController." + method
+                + "() was called from the Event Dispatch Thread. It blocks its caller until the operation completes"
+                + " and notifies the project and workspace listeners synchronously, so it freezes the interface."
+                + " Run it on a background thread instead; the desktop application has ProjectControllerUIImpl"
+                + " for that. This will become an error in a future release.\n" + callSite);
+        }
+    }
+
     @Override
     public ProjectImpl newProject() {
+        warnIfEventDispatchThread("newProject");
         return this.newProjectInternal();
     }
 
@@ -137,6 +169,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public Project openProject(File file) {
+        warnIfEventDispatchThread("openProject");
         synchronized (this) {
             fireProjectEvent(ProjectListener::lock);
             LoadTask loadTask = new LoadTask(file);
@@ -161,6 +194,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void openProject(Project project) {
+        warnIfEventDispatchThread("openProject");
         if (!projects.containsProject(project)) {
             throw new IllegalArgumentException(
                 "Project " + project.getUniqueIdentifier() + " does not belong to the list of active projects");
@@ -174,6 +208,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void saveProject(Project project) {
+        warnIfEventDispatchThread("saveProject");
         synchronized (this) {
             if (project.getLookup().lookup(ProjectInformationImpl.class).hasFile()) {
                 File file = project.getLookup().lookup(ProjectInformationImpl.class).getFile();
@@ -186,6 +221,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void saveProject(Project project, File file) {
+        warnIfEventDispatchThread("saveProject");
         synchronized (this) {
             fireProjectEvent(ProjectListener::lock);
             SaveTask saveTask = new SaveTask(project, file);
@@ -204,6 +240,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void closeCurrentProject() {
+        warnIfEventDispatchThread("closeCurrentProject");
         synchronized (this) {
             if (projects.hasCurrentProject()) {
                 fireProjectEvent(ProjectListener::lock);
@@ -233,6 +270,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void removeProject(Project project) {
+        warnIfEventDispatchThread("removeProject");
         synchronized (this) {
             if (projects.getCurrentProject() == project) {
                 closeCurrentProject();
@@ -258,11 +296,13 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public Workspace newWorkspace(Project project) {
+        warnIfEventDispatchThread("newWorkspace");
         return newWorkspaceInternal(project);
     }
 
     @Override
     public Workspace newWorkspace(Project project, Object... objectsForLookup) {
+        warnIfEventDispatchThread("newWorkspace");
         return newWorkspaceInternal(project, objectsForLookup);
     }
 
@@ -279,6 +319,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void deleteWorkspace(Workspace workspace) {
+        warnIfEventDispatchThread("deleteWorkspace");
         synchronized (this) {
             Project project = workspace.getProject();
             WorkspaceProviderImpl workspaceProvider = project.getLookup().lookup(WorkspaceProviderImpl.class);
@@ -344,6 +385,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void closeCurrentWorkspace() {
+        warnIfEventDispatchThread("closeCurrentWorkspace");
         synchronized (this) {
             WorkspaceImpl workspace = getCurrentWorkspace();
             if (workspace != null) {
@@ -357,6 +399,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void openWorkspace(Workspace workspace) {
+        warnIfEventDispatchThread("openWorkspace");
         synchronized (this) {
             closeCurrentWorkspace();
             getCurrentProject().setCurrentWorkspace(workspace);
@@ -368,11 +411,13 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public Workspace openNewWorkspace() {
+        warnIfEventDispatchThread("openNewWorkspace");
         return openNewWorkspaceInternal();
     }
 
     @Override
     public Workspace openNewWorkspace(Object... objectsForLookup) {
+        warnIfEventDispatchThread("openNewWorkspace");
         return openNewWorkspaceInternal(objectsForLookup);
     }
 
@@ -394,6 +439,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public Workspace duplicateWorkspace(Workspace workspace) {
+        warnIfEventDispatchThread("duplicateWorkspace");
         synchronized (this) {
             DuplicateTask duplicateTask = new DuplicateTask(workspace);
             Future<WorkspaceImpl> res = longTaskExecutor.execute(duplicateTask, () -> {
@@ -419,6 +465,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void renameProject(Project project, final String name) {
+        warnIfEventDispatchThread("renameProject");
         synchronized (this) {
             project.getLookup().lookup(ProjectInformationImpl.class).setName(name);
             fireProjectEvent((pl) -> pl.changed(project));
@@ -427,6 +474,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void renameWorkspace(Workspace workspace, String name) {
+        warnIfEventDispatchThread("renameWorkspace");
         synchronized (this) {
             workspace.getLookup().lookup(WorkspaceInformationImpl.class).setName(name);
         }
@@ -434,6 +482,7 @@ public class ProjectControllerImpl implements ProjectController {
 
     @Override
     public void setSource(Workspace workspace, String source) {
+        warnIfEventDispatchThread("setSource");
         synchronized (this) {
             workspace.getLookup().lookup(WorkspaceInformationImpl.class).setSource(source);
         }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/WorkspaceInformationImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/WorkspaceInformationImpl.java
@@ -44,8 +44,8 @@ package org.gephi.project.impl;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.gephi.project.api.WorkspaceInformation;
 
 /**
@@ -54,7 +54,9 @@ import org.gephi.project.api.WorkspaceInformation;
 public class WorkspaceInformationImpl implements WorkspaceInformation {
 
     //Lookup
-    private final transient List<PropertyChangeListener> listeners = new ArrayList<>();
+    //Copy-on-write: the events are fired from the thread performing the project operation while the
+    //listeners are typically registered from the Event Dispatch Thread
+    private final transient List<PropertyChangeListener> listeners = new CopyOnWriteArrayList<>();
     private String name;
     private Status status = Status.CLOSED;
     private String source;

--- a/modules/ProjectAPI/src/test/java/org/gephi/project/impl/ProjectControllerImplTest.java
+++ b/modules/ProjectAPI/src/test/java/org/gephi/project/impl/ProjectControllerImplTest.java
@@ -3,6 +3,14 @@ package org.gephi.project.impl;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import javax.swing.SwingUtilities;
 import org.gephi.project.api.GephiFormatException;
 import org.gephi.project.api.Project;
 import org.gephi.project.api.ProjectListener;
@@ -11,8 +19,11 @@ import org.gephi.project.api.WorkspaceListener;
 import org.gephi.project.io.utils.MockBytesPersistenceProviderFailWrite;
 import org.gephi.project.spi.Controller;
 import org.gephi.project.spi.Model;
+import org.gephi.utils.progress.ProgressTicket;
+import org.gephi.utils.progress.ProgressTicketProvider;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -22,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.netbeans.junit.MockServices;
+import org.openide.util.Cancellable;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectControllerImplTest {
@@ -378,6 +390,96 @@ public class ProjectControllerImplTest {
         Assert.assertEquals(foo, workspace.getLookup().lookup(String.class));
     }
 
+    /**
+     * Mutating methods notify their listeners synchronously, so they must never run on the Event Dispatch Thread. The
+     * controller warns when they do, and stays silent otherwise.
+     */
+    @Test
+    public void testWarnsWhenMutatingFromEventDispatchThread() throws Exception {
+        String eventQueueThreadName = eventQueueThreadName();
+
+        // The controller detects the EDT by thread name so that it doesn't have to touch AWT, hence there is nothing
+        // to verify in an environment that names its event queue thread differently
+        Assume.assumeTrue("Unexpected event queue thread name: " + eventQueueThreadName,
+            eventQueueThreadName != null && eventQueueThreadName.startsWith("AWT-EventQueue"));
+
+        ProjectControllerImpl pc = new ProjectControllerImpl();
+        Project project = pc.newProject();
+
+        List<LogRecord> records = Collections.synchronizedList(new ArrayList<>());
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        Logger logger = Logger.getLogger(ProjectControllerImpl.class.getName());
+        boolean useParentHandlers = logger.getUseParentHandlers();
+        logger.addHandler(handler);
+        // The expected warning would otherwise be printed with its stack trace and read as a build failure
+        logger.setUseParentHandlers(false);
+        try {
+            pc.renameProject(project, "background");
+            Assert.assertTrue("A call from outside the event queue must not warn", records.isEmpty());
+
+            SwingUtilities.invokeAndWait(() -> pc.renameProject(project, "edt"));
+            Assert.assertEquals("A call from the event queue must warn once", 1, records.size());
+            LogRecord record = records.get(0);
+            Assert.assertEquals(Level.WARNING, record.getLevel());
+            Assert.assertTrue("The warning must name the offending method: " + record.getMessage(),
+                record.getMessage().contains("renameProject"));
+            Assert.assertTrue("The warning must include the call site", record.getMessage().contains("\tat "));
+            // A logged throwable would be turned into a crash report by the desktop application
+            Assert.assertNull("The warning must not carry a throwable", record.getThrown());
+        } finally {
+            logger.setUseParentHandlers(useParentHandlers);
+            logger.removeHandler(handler);
+        }
+    }
+
+    /**
+     * Returns the name of the event queue thread, or skips the test if this environment has no usable event queue.
+     */
+    private String eventQueueThreadName() {
+        String[] name = new String[1];
+        try {
+            SwingUtilities.invokeAndWait(() -> name[0] = Thread.currentThread().getName());
+        } catch (Throwable t) {
+            Assume.assumeNoException("No usable event queue in this environment", t);
+        }
+        return name[0];
+    }
+
+    /**
+     * Regression test for the save-then-close flow in the desktop UI: it saves the project and only
+     * then closes it, so it has to be able to tell a cancelled save from a successful one. A cancel
+     * writes nothing and reports no failure, so the absence of <code>saved()</code> is the only
+     * signal available. Should this contract change, the UI would close the project and throw away
+     * whatever wasn't written.
+     */
+    @Test
+    public void testCancelledSaveWritesNothingAndDoesNotReportSaved() {
+        MockServices.setServices(CancellingProgressTicketProvider.class);
+
+        ProjectControllerImpl pc = new ProjectControllerImpl();
+        pc.addProjectListener(projectListener);
+        Project project = pc.newProject();
+
+        File file = new File(tempFolder.getRoot(), "cancelled.gephi");
+        pc.saveProject(project, file);
+
+        Assert.assertFalse("A cancelled save must not leave a file behind", file.exists());
+        Mockito.verify(projectListener, Mockito.never()).saved(project);
+    }
+
     public static class MockModel implements Model {
 
         private final Workspace workspace;
@@ -403,6 +505,88 @@ public class ProjectControllerImplTest {
         @Override
         public Class getModelClass() {
             return MockModel.class;
+        }
+    }
+
+    /**
+     * Hands out a ticket that cancels the running task the first time it reports progress, which is
+     * what the progress bar's Cancel button does.
+     */
+    public static class CancellingProgressTicketProvider implements ProgressTicketProvider {
+
+        @Override
+        public ProgressTicket createTicket(String taskName, Cancellable cancellable) {
+            return new CancellingProgressTicket(cancellable);
+        }
+    }
+
+    private static class CancellingProgressTicket implements ProgressTicket {
+
+        private final Cancellable cancellable;
+        private boolean cancelled;
+
+        CancellingProgressTicket(Cancellable cancellable) {
+            this.cancellable = cancellable;
+        }
+
+        private void cancelOnce() {
+            if (!cancelled && cancellable != null) {
+                cancelled = true;
+                cancellable.cancel();
+            }
+        }
+
+        @Override
+        public void finish() {
+        }
+
+        @Override
+        public void finish(String finishMessage) {
+        }
+
+        @Override
+        public void progress() {
+            cancelOnce();
+        }
+
+        @Override
+        public void progress(int workunit) {
+            cancelOnce();
+        }
+
+        @Override
+        public void progress(String message) {
+            cancelOnce();
+        }
+
+        @Override
+        public void progress(String message, int workunit) {
+            cancelOnce();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "";
+        }
+
+        @Override
+        public void setDisplayName(String newDisplayName) {
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public void start(int workunits) {
+        }
+
+        @Override
+        public void switchToDeterminate(int workunits) {
+        }
+
+        @Override
+        public void switchToIndeterminate() {
         }
     }
 }

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -19,6 +19,7 @@
         <h4>ProjectAPI</h4>
         <ul>
             <li>Addition of <code>newWorkspace()</code> and <code>openNewWorkspace()</code> methods in <code>ProjectController</code> with the option to pass objects that will be added to the <code>Workspace</code>'s lookup at creation time.</li>
+            <li>The threading contract of <code>WorkspaceListener</code> and <code>ProjectListener</code> is now specified: callbacks are invoked synchronously on the thread that performed the operation, and that thread is never the Event Dispatch Thread. Implementations must therefore defer any Swing work with <code>SwingUtilities.invokeLater()</code> and must never block - in particular never <code>invokeAndWait()</code>. Consequently, <code>ProjectController</code>'s mutating methods shouldn't be called from the Event Dispatch Thread and now log a warning when they are.</li>
         </ul>
         <h4>Graph API</h4>
         <ul>


### PR DESCRIPTION
## Problem

`ProjectController`'s mutating methods fire `WorkspaceListener` and `ProjectListener` callbacks **synchronously on whatever thread called them** — sometimes the EDT, sometimes a background thread, with no documented contract. A listener cannot know which thread it is on. That ambiguity is the root cause of the 11 bugs audited in #3246 (NPE windows during listener registration, unguarded Swing calls off the EDT, teardown-ordering hazards).

This change is narrow and foundational: **make the delivery thread deterministic — never the EDT — and document the contract**, so those findings can then be fixed against a rule instead of against an accident of the call path.

## Approach

`ProjectController` stays synchronous and blocking; no signature changed. It is a library API used headless by gephi-toolkit, and `ProjectControllerImplTest` pins that contract. The guarantee is achieved entirely in the desktop layer, which already owns a background thread — the non-EDT call paths (importer, filters, context menus) were already off the EDT.

This supersedes PR #3102's Critical Issue 1, which proposed flipping `ProjectControllerImpl`'s executor to async mode; that executor is *synchronous* and exists only for the progress ticket and cancel hook. Its Critical Issue 2 is independent and can land on its own.

## Three hazards fixed along the way

1. **The EDT blocked on the Project IO thread.** `closeCurrentProject()` ran on the EDT and called `saveTask.get()`, waiting on a thread that held the controller monitor and fired listeners. Any listener doing `invokeAndWait` deadlocked.
2. **Cancel froze the UI.** `LongTaskExecutor.execute(...)` was `synchronized` and, in synchronous mode, ran the task **inline inside the monitor**. `cancel()` is `synchronized` too and the progress bar calls it from the EDT, so cancelling a project load froze the interface until the load finished — and the cancel landed too late to matter.
3. **`WorkspacePanel.disable()` silently bound to the inherited `Component.disable()`**, so closing a project greyed the tab bar out instead of clearing it. The panel now uses an adapter, which is what every other `WorkspaceListener` implementer in the repo already does.

## Two bugs found by review, and fixed

- **Cancelling the save in "save then close" destroyed the work.** Making cancel work for the first time exposed that `SaveTask.run()` signals cancellation by returning `false`, not by throwing — so the close fell through and closed the project with nothing written, and on the shutdown path then quit. The close now refuses to proceed unless the controller reported the project as saved. Regression test: `ProjectControllerImplTest.testCancelledSaveWritesNothingAndDoesNotReportSaved`.
- **A stale close decision could overwrite an unrelated file.** The decision now carries the project it was taken for and is discarded if that project is no longer current.

## Notes

- `synchronized (this)` in `ProjectControllerImpl` is deliberately untouched. It provides mutual exclusion between concurrent operations, not publication; moving dispatch out of it and adopting single-thread delivery are a package deal and belong in a follow-up.
- EDT misuse logs a warning and proceeds inline — a deprecation path, not an exception. The record deliberately carries no `Throwable`, as `ReporterHandler` turns any logged throwable into a crash report.

## Testing

`mvn -T 4 --batch-mode -Djava.awt.headless=true verify -P enableCheckStyle` → BUILD SUCCESS, 585 tests, 0 failures. All pre-existing `ProjectControllerImplTest` tests pass unchanged, which is the proof the blocking API contract survived.

Manual in-app verification still to do: the shutdown answers (Save / Don't save / Cancel), cancelling a large open and a large save, the workspace tab bar, menu enablement after a cancelled operation, and one pass over every entry point watching the Output window's Log tab for `was called from the Event Dispatch Thread`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)