### PR TITLE
#3246 Fix remaining EDT violations in Timeline/DataLab/Preview panels

### DIFF
--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
@@ -498,23 +498,29 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
      * **************Table related methods:****************
      */
     private void refreshAppliedFilter() {
-        int index = columnComboBox.getSelectedIndex();
-        if (index < 0) {
-            return;
-        }
-        if (isShowingNodesTable()) {
-            if (nodeTable.setFilterPattern(filterTextField.getText(), index)) {
-                filterTextField.setBackground(UIManager.getColor("TextField.background"));
-            } else {
-                filterTextField.setBackground(INVALID_FILTER_COLOR);
+        SwingUtilities.invokeLater(new Runnable() {
+
+            @Override
+            public void run() {
+                int index = columnComboBox.getSelectedIndex();
+                if (index < 0) {
+                    return;
+                }
+                if (isShowingNodesTable()) {
+                    if (nodeTable.setFilterPattern(filterTextField.getText(), index)) {
+                        filterTextField.setBackground(UIManager.getColor("TextField.background"));
+                    } else {
+                        filterTextField.setBackground(INVALID_FILTER_COLOR);
+                    }
+                } else if (isShowingEdgesTable()) {
+                    if (edgeTable.setFilterPattern(filterTextField.getText(), index)) {
+                        filterTextField.setBackground(UIManager.getColor("TextField.background"));
+                    } else {
+                        filterTextField.setBackground(INVALID_FILTER_COLOR);
+                    }
+                }
             }
-        } else if (isShowingEdgesTable()) {
-            if (edgeTable.setFilterPattern(filterTextField.getText(), index)) {
-                filterTextField.setBackground(UIManager.getColor("TextField.background"));
-            } else {
-                filterTextField.setBackground(INVALID_FILTER_COLOR);
-            }
-        }
+        });
     }
 
     private void refreshAvailableColumnsButton(AvailableColumnsModel availableColumnsModel, Table table) {
@@ -727,12 +733,30 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     }
 
     private void refreshTable() {
-        bannerPanel.setVisible(false);
+        SwingUtilities.invokeLater(new Runnable() {
+
+            @Override
+            public void run() {
+                bannerPanel.setVisible(false);
+            }
+        });
         if (isShowingNodesTable()) {
-            nodesButton.setSelected(true);
+            SwingUtilities.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    nodesButton.setSelected(true);
+                }
+            });
             initNodesView();
         } else if (isShowingEdgesTable()) {
-            edgesButton.setSelected(true);
+            SwingUtilities.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    edgesButton.setSelected(true);
+                }
+            });
             initEdgesView();
         }
 

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewSettingsTopComponent.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewSettingsTopComponent.java
@@ -59,13 +59,13 @@ import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.JTabbedPane;
 import javax.swing.ListCellRenderer;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.gephi.desktop.preview.api.PreviewUIController;
 import org.gephi.desktop.preview.api.PreviewUIModel;
-import org.gephi.preview.api.PreviewController;
 import org.gephi.preview.api.PreviewModel;
 import org.gephi.preview.api.PreviewPreset;
 import org.gephi.preview.spi.PreviewUI;
@@ -235,65 +235,70 @@ public final class PreviewSettingsTopComponent extends TopComponent implements P
     }
 
     public void setup(PreviewUIModel previewModel) {
-        propertySheet.setNodes(new Node[] {new PreviewNode(propertySheet)});
-        PreviewUIController previewUIController = Lookup.getDefault().lookup(PreviewUIController.class);
-        if (previewModel != null) {
-            ratioSlider.setValue((int) (previewModel.getVisibilityRatio() * 100));
-        }
+        SwingUtilities.invokeLater(new Runnable() {
 
-        //Presets
-        if (previewModel == null) {
-            saveButton.setEnabled(false);
-            removeButton.setEnabled(false);
-            labelPreset.setEnabled(false);
-            presetComboBox.setEnabled(false);
-            presetComboBox.setModel(new javax.swing.DefaultComboBoxModel(new String[] {NO_SELECTION}));
-        } else {
-            saveButton.setEnabled(true);
-            labelPreset.setEnabled(true);
-            presetComboBox.setEnabled(true);
-            DefaultComboBoxModel comboBoxModel = new DefaultComboBoxModel();
-            defaultPresetLimit = 0;
-            for (PreviewPreset preset : previewUIController.getDefaultPresets()) {
-                comboBoxModel.addElement(preset);
-                defaultPresetLimit++;
-            }
-            PreviewPreset[] userPresets = previewUIController.getUserPresets();
-            if (userPresets.length > 0) {
-                comboBoxModel.addElement(NO_SELECTION);
-                for (PreviewPreset preset : userPresets) {
-                    comboBoxModel.addElement(preset);
+            @Override
+            public void run() {
+                propertySheet.setNodes(new Node[] {new PreviewNode(propertySheet)});
+                PreviewUIController previewUIController = Lookup.getDefault().lookup(PreviewUIController.class);
+                if (previewModel != null) {
+                    ratioSlider.setValue((int) (previewModel.getVisibilityRatio() * 100));
                 }
-            }
-            comboBoxModel.setSelectedItem(previewModel.getCurrentPreset());
-            presetComboBox.setModel(comboBoxModel);
-        }
 
-        //Refresh tabs
-        int tabCount = tabbedPane.getTabCount();
-        for (int i = 2; i < tabCount; i++) {//Start at 2, not removing settings and renderer manager tabs
-            tabbedPane.removeTabAt(i);
-        }
-        for (PreviewUI pui : Lookup.getDefault().lookupAll(PreviewUI.class)) {
-            pui.unsetup();
-        }
-        if (previewModel != null) {
-            PreviewController previewController = Lookup.getDefault().lookup(PreviewController.class);
-            PreviewModel pModel = previewController.getModel();
-            //Add new tabs
-            for (PreviewUI pui : Lookup.getDefault().lookupAll(PreviewUI.class)) {
-                pui.setup(pModel);
-                JPanel pluginPanel = pui.getPanel();
-                if (UIUtils.isAquaLookAndFeel()) {
-                    pluginPanel.setBackground(UIManager.getColor("NbExplorerView.background"));
-                }
-                if (pui.getIcon() != null) {
-                    tabbedPane.addTab(pui.getPanelTitle(), pui.getIcon(), pluginPanel);
+                //Presets
+                if (previewModel == null) {
+                    saveButton.setEnabled(false);
+                    removeButton.setEnabled(false);
+                    labelPreset.setEnabled(false);
+                    presetComboBox.setEnabled(false);
+                    presetComboBox.setModel(new javax.swing.DefaultComboBoxModel(new String[] {NO_SELECTION}));
                 } else {
-                    tabbedPane.addTab(pui.getPanelTitle(), pluginPanel);
+                    saveButton.setEnabled(true);
+                    labelPreset.setEnabled(true);
+                    presetComboBox.setEnabled(true);
+                    DefaultComboBoxModel comboBoxModel = new DefaultComboBoxModel();
+                    defaultPresetLimit = 0;
+                    for (PreviewPreset preset : previewUIController.getDefaultPresets()) {
+                        comboBoxModel.addElement(preset);
+                        defaultPresetLimit++;
+                    }
+                    PreviewPreset[] userPresets = previewUIController.getUserPresets();
+                    if (userPresets.length > 0) {
+                        comboBoxModel.addElement(NO_SELECTION);
+                        for (PreviewPreset preset : userPresets) {
+                            comboBoxModel.addElement(preset);
+                        }
+                    }
+                    comboBoxModel.setSelectedItem(previewModel.getCurrentPreset());
+                    presetComboBox.setModel(comboBoxModel);
+                }
+
+                //Refresh tabs
+                int tabCount = tabbedPane.getTabCount();
+                for (int i = 2; i < tabCount; i++) {//Start at 2, not removing settings and renderer manager tabs
+                    tabbedPane.removeTabAt(i);
+                }
+                for (PreviewUI pui : Lookup.getDefault().lookupAll(PreviewUI.class)) {
+                    pui.unsetup();
+                }
+                if (previewModel != null) {
+                    PreviewModel pModel = previewModel.getPreviewModel();
+                    //Add new tabs
+                    for (PreviewUI pui : Lookup.getDefault().lookupAll(PreviewUI.class)) {
+                        pui.setup(pModel);
+                        JPanel pluginPanel = pui.getPanel();
+                        if (UIUtils.isAquaLookAndFeel()) {
+                            pluginPanel.setBackground(UIManager.getColor("NbExplorerView.background"));
+                        }
+                        if (pui.getIcon() != null) {
+                            tabbedPane.addTab(pui.getPanelTitle(), pui.getIcon(), pluginPanel);
+                        } else {
+                            tabbedPane.addTab(pui.getPanelTitle(), pluginPanel);
+                        }
+                    }
                 }
             }
-        }
+        });
     }
 
     public void unsetup() {
@@ -320,12 +325,18 @@ public final class PreviewSettingsTopComponent extends TopComponent implements P
      * Enables the refresh button.
      */
     public void enableRefreshButton() {
-        refreshButton.setEnabled(true);
-        labelRatio.setEnabled(true);
-        ratioLabel.setEnabled(true);
-        ratioSlider.setEnabled(true);
-        labelExport.setEnabled(true);
-        svgExportButton.setEnabled(true);
+        SwingUtilities.invokeLater(new Runnable() {
+
+            @Override
+            public void run() {
+                refreshButton.setEnabled(true);
+                labelRatio.setEnabled(true);
+                ratioLabel.setEnabled(true);
+                ratioSlider.setEnabled(true);
+                labelExport.setEnabled(true);
+                svgExportButton.setEnabled(true);
+            }
+        });
     }
 
     public void enableRemoveButtonIfNeeded() {
@@ -342,12 +353,18 @@ public final class PreviewSettingsTopComponent extends TopComponent implements P
      * Disables the refresh button.
      */
     public void disableRefreshButton() {
-        refreshButton.setEnabled(false);
-        labelRatio.setEnabled(false);
-        ratioLabel.setEnabled(false);
-        ratioSlider.setEnabled(false);
-        labelExport.setEnabled(false);
-        svgExportButton.setEnabled(false);
+        SwingUtilities.invokeLater(new Runnable() {
+
+            @Override
+            public void run() {
+                refreshButton.setEnabled(false);
+                labelRatio.setEnabled(false);
+                ratioLabel.setEnabled(false);
+                ratioSlider.setEnabled(false);
+                labelExport.setEnabled(false);
+                svgExportButton.setEnabled(false);
+            }
+        });
     }
 
     private boolean isDefaultPreset(PreviewPreset preset) {

--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineTopComponent.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/TimelineTopComponent.java
@@ -327,15 +327,15 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
     }
 
     private void setup(TimelineModel model) {
-        if (drawer != null) {
-            innerPanel.remove(drawer);
-            drawer = null;
-        }
-        if (model != null) {
-            SwingUtilities.invokeLater(new Runnable() {
+        SwingUtilities.invokeLater(new Runnable() {
 
-                @Override
-                public void run() {
+            @Override
+            public void run() {
+                if (drawer != null) {
+                    innerPanel.remove(drawer);
+                    drawer = null;
+                }
+                if (model != null) {
                     // Add Drawer
                     drawer = new TimelineDrawer(controller, model);
                     GridBagConstraints gridBagConstraints = new java.awt.GridBagConstraints();
@@ -348,21 +348,11 @@ public final class TimelineTopComponent extends JPanel implements TimelineModelL
                     innerPanel.add(drawer, gridBagConstraints);
 
                     enableTimeline(model);
-                }
-            });
-        } else {
-            SwingUtilities.invokeLater(new Runnable() {
-
-                @Override
-                public void run() {
-                    if (drawer != null) {
-                        innerPanel.remove(drawer);
-                    }
-                    drawer = null;
+                } else {
                     enableTimeline(null);
                 }
-            });
-        }
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
## Description

PR #3255 made `WorkspaceListener`/`ProjectListener` delivery deterministically off the EDT (never the calling thread is the EDT anymore). That turned three previously-incidental EDT violations into systematic ones, tracked as part of #3246's audit. This PR fixes those three:

- **`TimelineTopComponent.setup()`** — `innerPanel.remove(drawer)` used to run synchronously on the calling (now guaranteed off-EDT) thread before the add was deferred via `invokeLater`. The whole remove-then-add sequence now happens inside a single `invokeLater`, preserving ordering and keeping `drawer` EDT-confined.
- **`DataTableTopComponent.refreshTable()`** — `bannerPanel.setVisible(...)` and `nodesButton`/`edgesButton.setSelected(...)` were raw Swing calls reached off-EDT via `RefreshOnceHelperThread`. Wrapped just those three touches in `invokeLater`, matching the existing self-deferring style of sibling methods in this class. (An earlier version of this fix wrapped the whole method, which reordered it after `refreshColumnManipulators()`/`refreshGeneralActionsButtons()` on the EDT queue and made the column-manipulator buttons build from a stale column model — caught in review, reverted to the narrower fix.) Also fixed `refreshAppliedFilter()`, reached from the same call chain, which had the identical bug (raw `filterTextField`/`columnComboBox` mutations) but wasn't in the original audit.
- **`PreviewSettingsTopComponent`** — `enableRefreshButton()`/`disableRefreshButton()` bodies are now deferred via `invokeLater`. `setup()` had the same gap (a dozen more raw mutations: combo box models, tab add/remove, `setEnabled`), reached the same way via `propertyChange()`'s `SELECT` branch off the Project IO thread; its body is now deferred too. While fixing that, `setup()` was also switched from the ambient `PreviewController.getModel()` (reads whatever workspace is *current* at the time the deferred runnable executes) to the workspace-scoped `previewModel.getPreviewModel()` (bound to the model instance the call was actually made for) — otherwise rapid workspace switching could pair a stale `PreviewUIModel` with a different workspace's `PreviewModel`.

Refs #3246.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

These are Swing thread-confinement fixes with no independently testable business logic; this codebase has no Swing-harness test infrastructure for these UI components. Verified via scoped `mvn verify -P enableCheckStyle` (compiles clean, checkstyle clean) and two rounds of independent adversarial code review. **Not yet manually exercised in the running desktop app** (switching workspaces with a timeline open, Data Lab auto-refresh while switching workspaces, repeated Preview refresh clicks, per the existing test plan) — flagging that as still open before merge.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed