### PR TITLE
#3246 Fix field-visibility races on the Project IO thread (Step 2)

### DIFF
--- a/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/AppearanceUIController.java
+++ b/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/AppearanceUIController.java
@@ -77,7 +77,7 @@ public class AppearanceUIController {
     protected final AppearanceController appearanceController;
     private final CopyOnWriteArraySet<AppearanceUIModelListener> listeners;
     //Model
-    private AppearanceUIModel model;
+    private volatile AppearanceUIModel model;
 
     public AppearanceUIController() {
         final ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
@@ -103,8 +103,9 @@ public class AppearanceUIController {
 
             @Override
             public void unselect(Workspace workspace) {
-                if (model != null) {
-                    model.unselect();
+                AppearanceUIModel m = model;
+                if (m != null) {
+                    m.unselect();
                 }
             }
 
@@ -161,10 +162,11 @@ public class AppearanceUIController {
     }
 
     public void transform(Function function) {
-        if (model != null && function != null) {
-            model.saveTransformerProperties();
+        AppearanceUIModel m = model;
+        if (m != null && function != null) {
+            m.saveTransformerProperties();
             appearanceController.transform(function);
-            TransformerUI selectedUI = model.getSelectedTransformerUI();
+            TransformerUI selectedUI = m.getSelectedTransformerUI();
             if (selectedUI != null) {
                 selectedUI.onApply(function);
             }
@@ -198,10 +200,11 @@ public class AppearanceUIController {
         if (!elementClass.equals(NODE_ELEMENT) && !elementClass.equals(EDGE_ELEMENT)) {
             throw new RuntimeException("Element class has to be " + NODE_ELEMENT + " or " + EDGE_ELEMENT);
         }
-        if (model != null) {
-            String oldValue = model.getSelectedElementClass();
+        AppearanceUIModel m = model;
+        if (m != null) {
+            String oldValue = m.getSelectedElementClass();
             if (!oldValue.equals(elementClass)) {
-                model.setSelectedElementClass(elementClass);
+                m.setSelectedElementClass(elementClass);
 
                 firePropertyChangeEvent(AppearanceUIModelEvent.SELECTED_ELEMENT_CLASS, oldValue, elementClass);
             }
@@ -209,21 +212,23 @@ public class AppearanceUIController {
     }
 
     public void setSelectedCategory(TransformerCategory category) {
-        if (model != null) {
-            TransformerCategory oldValue = model.getSelectedCategory();
+        AppearanceUIModel m = model;
+        if (m != null) {
+            TransformerCategory oldValue = m.getSelectedCategory();
             if (!oldValue.equals(category)) {
-                model.setSelectedCategory(category);
+                m.setSelectedCategory(category);
                 firePropertyChangeEvent(AppearanceUIModelEvent.SELECTED_CATEGORY, oldValue, category);
             }
         }
     }
 
     public void setSelectedTransformerUI(TransformerUI ui) {
-        if (model != null) {
-            TransformerUI oldValue = model.getSelectedTransformerUI();
+        AppearanceUIModel m = model;
+        if (m != null) {
+            TransformerUI oldValue = m.getSelectedTransformerUI();
             if (!oldValue.equals(ui)) {
-                model.setAutoApply(false);
-                model.setSelectedTransformerUI(ui);
+                m.setAutoApply(false);
+                m.setSelectedTransformerUI(ui);
 
                 firePropertyChangeEvent(AppearanceUIModelEvent.SELECTED_TRANSFORMER_UI, oldValue, ui);
             }
@@ -231,27 +236,30 @@ public class AppearanceUIController {
     }
 
     public void setSelectedFunction(Function function) {
-        if (model != null) {
-            Function oldValue = model.getSelectedFunction();
+        AppearanceUIModel m = model;
+        if (m != null) {
+            Function oldValue = m.getSelectedFunction();
             if ((oldValue == null && function != null) || (oldValue != null && function == null) ||
                 (function != null && oldValue != null && !oldValue.equals(function))) {
-                model.setAutoApply(false);
-                model.setSelectedFunction(function);
+                m.setAutoApply(false);
+                m.setSelectedFunction(function);
                 firePropertyChangeEvent(AppearanceUIModelEvent.SELECTED_FUNCTION, oldValue, function);
             }
         }
     }
 
     public void setAutoApply(boolean autoApply) {
-        if (model != null) {
-            model.setAutoApply(autoApply);
+        AppearanceUIModel m = model;
+        if (m != null) {
+            m.setAutoApply(autoApply);
             firePropertyChangeEvent(AppearanceUIModelEvent.SET_AUTO_APPLY, !autoApply, autoApply);
         }
     }
 
     public void startAutoApply() {
-        if (model != null) {
-            AutoAppyTransformer aat = model.getAutoApplyTransformer();
+        AppearanceUIModel m = model;
+        if (m != null) {
+            AutoAppyTransformer aat = m.getAutoApplyTransformer();
             if (aat != null) {
                 aat.start();
                 firePropertyChangeEvent(AppearanceUIModelEvent.START_STOP_AUTO_APPLY, false, true);
@@ -260,8 +268,9 @@ public class AppearanceUIController {
     }
 
     public void stopAutoApply() {
-        if (model != null) {
-            AutoAppyTransformer aat = model.getAutoApplyTransformer();
+        AppearanceUIModel m = model;
+        if (m != null) {
+            AutoAppyTransformer aat = m.getAutoApplyTransformer();
             if (aat != null) {
                 aat.stop();
                 firePropertyChangeEvent(AppearanceUIModelEvent.START_STOP_AUTO_APPLY, true, false);
@@ -270,8 +279,9 @@ public class AppearanceUIController {
     }
 
     public void refreshColumnsList() {
-        if (model != null) {
-            Function function = model.getSelectedFunction();
+        AppearanceUIModel m = model;
+        if (m != null) {
+            Function function = m.getSelectedFunction();
             if (function != null && !function.isValid()) {
                 setSelectedFunction(null);
             }

--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
@@ -155,7 +155,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     private volatile AvailableColumnsModel edgeAvailableColumnsModel;
     //Observers for auto-refreshing:
     private volatile boolean autoRefreshEnabled = false;
-    private DataTablesObservers dataTablesObservers;
+    private volatile DataTablesObservers dataTablesObservers;
     //Timer for the observers:
     private java.util.Timer observersTimer;
     //Table
@@ -170,7 +170,7 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     private final Map<DisplayTable, String> filterTextByDisplayTable = new EnumMap<>(DisplayTable.class);
     private final Map<DisplayTable, Integer> filterColumnIndexByDisplayTable = new EnumMap<>(DisplayTable.class);
     //Refresh executor
-    private RefreshOnceHelperThread refreshOnceHelperThread;
+    private volatile RefreshOnceHelperThread refreshOnceHelperThread;
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JScrollPane attributeColumnsScrollPane;
     private javax.swing.JButton availableColumnsButton;
@@ -276,8 +276,9 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     }
 
     private void deactivateAll() {
-        if (dataTablesObservers != null) {
-            dataTablesObservers.destroy();
+        DataTablesObservers observers = dataTablesObservers;
+        if (observers != null) {
+            observers.destroy();
         }
 
         graphModel = null;
@@ -341,8 +342,9 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
                                         if (!autoRefreshEnabled) {
                                             return;
                                         }
-                                        if (dataTablesObservers != null) {
-                                            if (dataTablesObservers.hasChanges()) {
+                                        DataTablesObservers observers = dataTablesObservers;
+                                        if (observers != null) {
+                                            if (observers.hasChanges()) {
                                                 graphChanged();//Execute refresh
                                             }
                                         }
@@ -480,13 +482,15 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
      * @param refreshTableOnly True to refresh only table values, false to
      *                         refresh all UI including manipulators
      */
-    private void refreshOnce(boolean refreshTableOnly) {
-        if (refreshOnceHelperThread == null || !refreshOnceHelperThread.isAlive() ||
-            (refreshOnceHelperThread.refreshTableOnly && !refreshTableOnly)) {
-            refreshOnceHelperThread = new RefreshOnceHelperThread(refreshTableOnly);
-            refreshOnceHelperThread.start();
+    private synchronized void refreshOnce(boolean refreshTableOnly) {
+        RefreshOnceHelperThread helperThread = refreshOnceHelperThread;
+        if (helperThread == null || !helperThread.isAlive() ||
+            (helperThread.refreshTableOnly && !refreshTableOnly)) {
+            helperThread = new RefreshOnceHelperThread(refreshTableOnly);
+            refreshOnceHelperThread = helperThread;
+            helperThread.start();
         } else {
-            refreshOnceHelperThread.eventAttended();
+            helperThread.eventAttended();
         }
     }
 

--- a/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/FiltersTopComponent.java
+++ b/modules/DesktopFilters/src/main/java/org/gephi/desktop/filters/FiltersTopComponent.java
@@ -73,9 +73,9 @@ public final class FiltersTopComponent extends TopComponent {
     //Panel
     private final FiltersPanel panel;
     //Models
-    private FilterModel filterModel;
-    private WorkspaceColumnsObservers observers;
-    private FilterUIModel uiModel;
+    private volatile FilterModel filterModel;
+    private volatile WorkspaceColumnsObservers observers;
+    private volatile FilterUIModel uiModel;
     private java.util.Timer observersTimer;
 
     public FiltersTopComponent() {
@@ -103,8 +103,9 @@ public final class FiltersTopComponent extends TopComponent {
 
             @Override
             public void unselect(Workspace workspace) {
-                if (observers != null) {
-                    observers.destroy();
+                WorkspaceColumnsObservers o = observers;
+                if (o != null) {
+                    o.destroy();
                 }
             }
 
@@ -159,9 +160,10 @@ public final class FiltersTopComponent extends TopComponent {
 
                                     @Override
                                     public void run() {
-                                        if (observers != null) {
-                                            if (observers.hasChanges()) {
-                                                refreshModel();
+                                        WorkspaceColumnsObservers o = observers;
+                                        if (o != null) {
+                                            if (o.hasChanges()) {
+                                                SwingUtilities.invokeLater(() -> refreshModel());
                                             }
                                         }
                                     }

--- a/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutTopComponent.java
+++ b/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutTopComponent.java
@@ -71,7 +71,7 @@ public final class LayoutTopComponent extends TopComponent {
 
     private final LayoutPanel layoutPanel;
     private final TransformationPanel transformationPanel;
-    private LayoutModel model;
+    private volatile LayoutModel model;
 
     public LayoutTopComponent() {
         initComponents();
@@ -100,8 +100,9 @@ public final class LayoutTopComponent extends TopComponent {
 
             @Override
             public void unselect(Workspace workspace) {
-                if (model != null) {
-                    model.removePropertyChangeListener(layoutPanel);
+                LayoutModel m = model;
+                if (m != null) {
+                    m.removePropertyChangeListener(layoutPanel);
                 }
             }
 

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/GraphObserverThread.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/GraphObserverThread.java
@@ -16,7 +16,7 @@ public class GraphObserverThread extends Thread {
 
     private final TimelineControllerImpl timelineController;
     private final TimelineModelImpl timelineModel;
-    private boolean stop;
+    private volatile boolean stop;
     private Interval interval;
 
     public GraphObserverThread(TimelineControllerImpl controller, TimelineModelImpl model) {

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/TimelineControllerImpl.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/TimelineControllerImpl.java
@@ -83,7 +83,7 @@ import org.openide.util.lookup.ServiceProviders;
 public class TimelineControllerImpl implements TimelineController, Controller<TimelineModelImpl> {
 
     private final List<TimelineModelListener> listeners;
-    private GraphObserverThread observerThread;
+    private volatile GraphObserverThread observerThread;
     private ScheduledExecutorService playExecutor;
 
     public TimelineControllerImpl() {
@@ -108,8 +108,9 @@ public class TimelineControllerImpl implements TimelineController, Controller<Ti
             @Override
             public void unselect(Workspace workspace) {
                 stopPlay();
-                if (observerThread != null) {
-                    observerThread.stopThread();
+                GraphObserverThread thread = observerThread;
+                if (thread != null) {
+                    thread.stopThread();
                     observerThread = null;
                 }
             }
@@ -121,8 +122,9 @@ public class TimelineControllerImpl implements TimelineController, Controller<Ti
             @Override
             public void disable() {
                 stopPlay();
-                if (observerThread != null) {
-                    observerThread.stopThread();
+                GraphObserverThread thread = observerThread;
+                if (thread != null) {
+                    thread.stopThread();
                     observerThread = null;
                 }
                 fireTimelineModelEvent(new TimelineModelEvent(TimelineModelEvent.EventType.MODEL, null, null));


### PR DESCRIPTION
## Description

Follow-up to #3255 / #3256. PR #3255 made `WorkspaceListener`/`ProjectListener` delivery deterministically off the EDT, on a dedicated Project IO thread. That turned plain (non-`volatile`) fields — written from those listener callbacks and read from the EDT or a timer thread — from intermittently racy into routinely racy. This fixes the fields tracked by #3246's Step 2:

- **`DataTableTopComponent`**: `dataTablesObservers` and `refreshOnceHelperThread` made `volatile`; `deactivateAll()`, the auto-refresh timer task, and `refreshOnce()` now snapshot into a local before use. `refreshOnce()` is also now `synchronized` (matching the existing `synchronized refreshAll()` in the same class) and starts the freshly-created helper thread from a local instead of re-reading the field — closing a write-then-start race an adversarial review pass caught: without it, two threads (EDT vs. Project IO) racing into `refreshOnce()` could silently drop one helper thread and throw `IllegalThreadStateException` starting the other's, which in turn aborted the rest of `WorkspaceListener.select()` and left auto-refresh disabled until the next select/unselect cycle.
- **`AppearanceUIController`**: `model` made `volatile`; every consumer (`transform`, `setSelected*`, `setAutoApply`, `start/stopAutoApply`, `refreshColumnsList`, `unselect`) snapshots it into a local. `select()`'s lazy create-and-publish sequence is left as-is, leaning on `ProjectControllerImpl`'s existing per-listener serialization rather than adding field-level guarding — an explicit call rather than an oversight.
- **`FiltersTopComponent`**: `filterModel`/`observers`/`uiModel` made `volatile`; `unselect()` and the auto-refresh timer snapshot `observers`. Also fixed an adjacent EDT violation found in that same timer task: it called `refreshModel()` (touches Swing components) directly from the raw `Timer` thread — now deferred via `invokeLater`, same class of bug as #3256.
- **`LayoutTopComponent`**: `model` made `volatile`; `unselect()` snapshots it.
- **`TimelineControllerImpl`**: `observerThread` made `volatile`; `unselect()`/`disable()` snapshot it. `GraphObserverThread.stop` (a separate, adjacent field of the same bug class, missed by the original 7-field audit) made `volatile` too.

Refs #3246.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

Field-visibility/synchronization fixes with no independently testable business logic change; no Swing-harness test infrastructure exists for these components. Verified via scoped `mvn verify -P enableCheckStyle` (compiles clean, checkstyle clean) and an adversarial code review pass that caught and led to fixing the `refreshOnce()` race described above. Not yet manually exercised in the running app.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed