### PR TITLE
#3246 Fix constructor-ordering races in Appearance/Preview controllers (Step 3)

### DIFF
--- a/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/AppearanceUIController.java
+++ b/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/AppearanceUIController.java
@@ -82,44 +82,6 @@ public class AppearanceUIController {
     public AppearanceUIController() {
         final ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
         appearanceController = Lookup.getDefault().lookup(AppearanceController.class);
-        pc.addWorkspaceListener(new WorkspaceListener() {
-            @Override
-            public void initialize(Workspace workspace) {
-            }
-
-            @Override
-            public void select(Workspace workspace) {
-                AppearanceUIModel oldModel = model;
-                model = workspace.getLookup().lookup(AppearanceUIModel.class);
-                if (model == null) {
-                    AppearanceModel appearanceModel = appearanceController.getModel(workspace);
-                    model = new AppearanceUIModel(appearanceModel);
-                    workspace.add(model);
-                }
-                model.select();
-
-                firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, model);
-            }
-
-            @Override
-            public void unselect(Workspace workspace) {
-                AppearanceUIModel m = model;
-                if (m != null) {
-                    m.unselect();
-                }
-            }
-
-            @Override
-            public void close(Workspace workspace) {
-            }
-
-            @Override
-            public void disable() {
-                AppearanceUIModel oldModel = model;
-                model = null;
-                firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, model);
-            }
-        });
 
         if (pc.getCurrentWorkspace() != null) {
             model = pc.getCurrentWorkspace().getLookup().lookup(AppearanceUIModel.class);
@@ -159,6 +121,47 @@ public class AppearanceUIController {
                 }
             }
         }
+
+        // Register only once fully constructed, since events can be delivered from a
+        // background thread as soon as this listener is registered
+        pc.addWorkspaceListener(new WorkspaceListener() {
+            @Override
+            public void initialize(Workspace workspace) {
+            }
+
+            @Override
+            public void select(Workspace workspace) {
+                AppearanceUIModel oldModel = model;
+                model = workspace.getLookup().lookup(AppearanceUIModel.class);
+                if (model == null) {
+                    AppearanceModel appearanceModel = appearanceController.getModel(workspace);
+                    model = new AppearanceUIModel(appearanceModel);
+                    workspace.add(model);
+                }
+                model.select();
+
+                firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, model);
+            }
+
+            @Override
+            public void unselect(Workspace workspace) {
+                AppearanceUIModel m = model;
+                if (m != null) {
+                    m.unselect();
+                }
+            }
+
+            @Override
+            public void close(Workspace workspace) {
+            }
+
+            @Override
+            public void disable() {
+                AppearanceUIModel oldModel = model;
+                model = null;
+                firePropertyChangeEvent(AppearanceUIModelEvent.MODEL, oldModel, model);
+            }
+        });
     }
 
     public void transform(Function function) {

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewTopComponent.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/PreviewTopComponent.java
@@ -204,8 +204,15 @@ public final class PreviewTopComponent extends TopComponent implements PropertyC
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(PreviewUIController.SELECT)) {
-            this.model = (PreviewUIModel) evt.getNewValue();
-            initTarget(model);
+            final PreviewUIModel newModel = (PreviewUIModel) evt.getNewValue();
+            SwingUtilities.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    model = newModel;
+                    initTarget(model);
+                }
+            });
         } else if (evt.getPropertyName().equals(PreviewUIController.REFRESHED)) {
             SwingUtilities.invokeLater(new Runnable() {
                 @Override

--- a/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/RendererManager.java
+++ b/modules/DesktopPreview/src/main/java/org/gephi/desktop/preview/RendererManager.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import net.miginfocom.swing.MigLayout;
 import org.gephi.desktop.preview.api.PreviewUIController;
@@ -135,7 +136,13 @@ public class RendererManager extends javax.swing.JPanel implements PropertyChang
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(PreviewUIController.SELECT) ||
             evt.getPropertyName().equals(PreviewUIController.UNSELECT)) {
-            setup();
+            SwingUtilities.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    setup();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Description

Follow-up to #3255 / #3256 / #3257. Same bug class as PR #3232 (commit `cecb363db`, "Fix NPE from listener-registration race in AttributesTopComponent"): a controller registers a `WorkspaceListener`/`PropertyChangeListener` early in its constructor, so events can be delivered on another thread while the rest of the constructor is still running.

### 3a — `AppearanceUIController` (finding 3)

`pc.addWorkspaceListener(...)` used to be registered before `listeners`/`transformers` were assigned, and before the constructor's own bootstrap block (which independently populates `model` for an already-selected workspace) had finished. Moved registration to the last statement of the constructor.

This closes both the original NPE-on-`listeners` window *and* a model-duplication race an earlier adversarial review pass found in the bootstrap block: `select()`/`unselect()`/`disable()` write `model` synchronously with no `invokeLater` deferral, so preventing the listener from firing during construction is the only way to close that race (there's no EDT-confinement trick available here since `model` isn't itself a Swing component).

### 3b — `PreviewUIControllerImpl` and its three second-layer listeners (finding 4)

The plan explicitly warned this finding predates #3255 and should be re-checked rather than trusted, so audited all three consumers instead of reapplying the pattern blindly:

- **`PreviewUIControllerImpl`** itself needed no change — `listeners` is inline-initialized at field declaration, so there's no NPE window.
- **`PreviewTopComponent`**: `propertyChange()`'s `SELECT` branch wrote the `model` field and called `initTarget()` (many raw Swing mutations — panel add/remove, several button `setEnabled`/`setSelected` calls) directly and unguarded, reachable off-EDT since #3255. Deferred both together into one `invokeLater`.
- **`RendererManager`**: `propertyChange()` called `setup()` with *no* guarding at all — a raw panel rebuild (`removeAll`/`add`/`updateUI`) on every workspace select/unselect, off the EDT. Wrapped in `invokeLater`.
- **`PreviewSettingsTopComponent`** needed no further change; its Swing work was already deferred by an earlier fix (#3256).

**"Register last" was tried for these three second-layer listeners too** (matching `AppearanceUIController`'s shape), but reverted after adversarial review: once a listener's own Swing work is deferred via `invokeLater`, the corruption risk that reordering prevents is already closed, and registering later only adds a new downside — an event landing in the gap between the constructor's bootstrap read and the (now later) registration is silently dropped rather than self-corrected by the listener's own deferred runnable once construction finishes. Unlike `AppearanceUIController`, none of these three write off-EDT synchronously, so there was no corruption bug for reordering to fix in the first place — only a new one to introduce. `PreviewSettingsTopComponent` ends up with no net change for this reason.

Refs #3246.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

Constructor-ordering / EDT-deferral fixes with no independently testable business logic change; no Swing-harness test infrastructure exists for these components. Verified via scoped `mvn verify -P enableCheckStyle` (compiles clean, checkstyle clean) and two rounds of adversarial code review — the second round caught that "register last" was actively wrong for three of the four files and led to reverting it there. Not yet manually exercised in the running app.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed