### PR TITLE
Lower default ZIP compression level for .gephi save files

### DIFF
--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
@@ -127,7 +127,7 @@ public class SaveTask implements LongTask {
             DataOutputStream dos = null;
             try {
                 //Stream
-                int zipLevel = NbPreferences.forModule(SaveTask.class).getInt(ZIP_LEVEL_PREFERENCE, 9);
+                int zipLevel = NbPreferences.forModule(SaveTask.class).getInt(ZIP_LEVEL_PREFERENCE, 1);
                 outputStream = new FileOutputStream(writeFile);
                 zipOut = new ZipOutputStream(outputStream);
                 zipOut.setLevel(zipLevel);

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
@@ -127,7 +127,7 @@ public class SaveTask implements LongTask {
             DataOutputStream dos = null;
             try {
                 //Stream
-                int zipLevel = NbPreferences.forModule(SaveTask.class).getInt(ZIP_LEVEL_PREFERENCE, 1);
+                int zipLevel = NbPreferences.forModule(SaveTask.class).getInt(ZIP_LEVEL_PREFERENCE, 3);
                 outputStream = new FileOutputStream(writeFile);
                 zipOut = new ZipOutputStream(outputStream);
                 zipOut.setLevel(zipLevel);


### PR DESCRIPTION
## Summary
- Change the default DEFLATE level used when writing `.gephi` files from `9` to `3`. Level 9 gives negligible extra size reduction over lower levels for typical project data but is noticeably slower to write.
- The level remains overridable via the existing hidden `ProjectIO_Save_ZipLevel_0_TO_9` NbPreferences key, so no new setting is introduced.
- Read compatibility is unaffected: DEFLATE decompression does not depend on the compression level used to write the stream, so both old (level 9) and new (level 3) `.gephi` files open identically.

## Test plan
- [x] Save a project and confirm the resulting `.gephi` file opens correctly in Gephi
- [x] Confirm save time improves on a larger project/graph
- [x] Confirm files saved under the old level 9 default still load without issue