### PR TITLE
#3246 Fix remaining Step 4 hygiene items left behind by PR #3255

### DIFF
--- a/modules/DesktopProject/pom.xml
+++ b/modules/DesktopProject/pom.xml
@@ -83,6 +83,13 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-util-ui</artifactId>
         </dependency>
+
+        <!-- Test only -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
+++ b/modules/DesktopProject/src/main/java/org/gephi/desktop/project/ProjectControllerUIImpl.java
@@ -111,9 +111,17 @@ public class ProjectControllerUIImpl implements ProjectListener {
     private volatile Project lastSavedProject;
 
     public ProjectControllerUIImpl() {
+        this(Lookup.getDefault().lookup(ProjectController.class),
+            Lookup.getDefault().lookup(ImportControllerUI.class));
+    }
 
-        controller = Lookup.getDefault().lookup(ProjectController.class);
-        importControllerUI = Lookup.getDefault().lookup(ImportControllerUI.class);
+    /**
+     * Package-private seam for tests to drive this class with a mocked {@link ProjectController}
+     * instead of going through {@link Lookup}.
+     */
+    ProjectControllerUIImpl(ProjectController controller, ImportControllerUI importControllerUI) {
+        this.controller = controller;
+        this.importControllerUI = importControllerUI;
 
         //Project IO executor
         longTaskExecutor = new LongTaskExecutor(true, "Project IO");
@@ -157,8 +165,9 @@ public class ProjectControllerUIImpl implements ProjectListener {
         unlockProjectActions();
         updateTitleBar(project);
 
-        //Persist projects so the last opened is refreshed
-        saveProjects();
+        //Persist projects so the last opened is refreshed, off the critical path (this callback
+        //runs while ProjectControllerImpl holds its monitor, and saveProjects() does blocking file I/O)
+        runInProjectIO(this::saveProjects);
     }
 
     @Override
@@ -194,8 +203,9 @@ public class ProjectControllerUIImpl implements ProjectListener {
         unlockProjectActions();
         updateTitleBar(project);
 
-        //Persist projects so the last opened is refreshed
-        saveProjects();
+        //Persist projects so the last opened is refreshed, off the critical path (this callback
+        //runs while ProjectControllerImpl holds its monitor, and saveProjects() does blocking file I/O)
+        runInProjectIO(this::saveProjects);
     }
 
     @Override
@@ -435,7 +445,7 @@ public class ProjectControllerUIImpl implements ProjectListener {
      * @return <code>true</code> when the project has been closed and the operation that requested
      *     the close may continue
      */
-    private boolean closeCurrentProject(CloseDecision decision) {
+    boolean closeCurrentProject(CloseDecision decision) {
         if (decision.cancelled) {
             return false;
         }
@@ -938,9 +948,9 @@ public class ProjectControllerUIImpl implements ProjectListener {
      * project has to be written to before being closed, <code>null</code> when it has to be closed
      * without being saved.
      */
-    private static final class CloseDecision {
+    static final class CloseDecision {
 
-        private static final CloseDecision CANCEL = new CloseDecision(null, true, null);
+        static final CloseDecision CANCEL = new CloseDecision(null, true, null);
 
         /**
          * Project the user answered about, <code>null</code> when there was nothing to answer for.
@@ -957,11 +967,11 @@ public class ProjectControllerUIImpl implements ProjectListener {
             this.saveFile = saveFile;
         }
 
-        private static CloseDecision close(Project project) {
+        static CloseDecision close(Project project) {
             return new CloseDecision(project, false, null);
         }
 
-        private static CloseDecision saveAndClose(Project project, File file) {
+        static CloseDecision saveAndClose(Project project, File file) {
             return new CloseDecision(project, false, file);
         }
     }

--- a/modules/DesktopProject/src/test/java/org/gephi/desktop/project/ProjectControllerUIImplTest.java
+++ b/modules/DesktopProject/src/test/java/org/gephi/desktop/project/ProjectControllerUIImplTest.java
@@ -1,0 +1,133 @@
+/*
+ Copyright 2008-2010 Gephi
+ Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s):
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.gephi.desktop.project;
+
+import java.io.File;
+import org.gephi.desktop.importer.api.ImportControllerUI;
+import org.gephi.project.api.Project;
+import org.gephi.project.api.ProjectController;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Pins {@link ProjectControllerUIImpl#closeCurrentProject(ProjectControllerUIImpl.CloseDecision)},
+ * which is where the confirm/execute split lets the close decision be driven directly, without going
+ * through the Event Dispatch Thread dialog or the Project IO executor.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectControllerUIImplTest {
+
+    @Mock
+    private ProjectController controller;
+    @Mock
+    private ImportControllerUI importControllerUI;
+    @Mock
+    private Project project;
+
+    private ProjectControllerUIImpl impl;
+
+    @Before
+    public void setUp() {
+        impl = new ProjectControllerUIImpl(controller, importControllerUI);
+    }
+
+    @Test
+    public void cancelledDecisionDoesNotCloseOrSave() {
+        Assert.assertFalse(impl.closeCurrentProject(ProjectControllerUIImpl.CloseDecision.CANCEL));
+
+        Mockito.verify(controller, Mockito.never()).getCurrentProject();
+        Mockito.verify(controller, Mockito.never()).saveProject(Mockito.any(), Mockito.any());
+        Mockito.verify(controller, Mockito.never()).closeCurrentProject();
+    }
+
+    @Test
+    public void noCurrentProjectClosesTrivially() {
+        Mockito.when(controller.getCurrentProject()).thenReturn(null);
+
+        Assert.assertTrue(impl.closeCurrentProject(ProjectControllerUIImpl.CloseDecision.close(project)));
+
+        Mockito.verify(controller, Mockito.never()).closeCurrentProject();
+    }
+
+    @Test
+    public void staleDecisionDoesNotActOnADifferentCurrentProject() {
+        Project newCurrentProject = Mockito.mock(Project.class);
+        Mockito.when(controller.getCurrentProject()).thenReturn(newCurrentProject);
+
+        //The decision was made about "project", but the current project changed to
+        //"newCurrentProject" while the user was being asked
+        Assert.assertFalse(impl.closeCurrentProject(ProjectControllerUIImpl.CloseDecision.close(project)));
+
+        Mockito.verify(controller, Mockito.never()).saveProject(Mockito.any(), Mockito.any());
+        Mockito.verify(controller, Mockito.never()).closeCurrentProject();
+    }
+
+    @Test
+    public void saveCancelledFromTheProgressBarDoesNotClose() {
+        File file = new File("test.gephi");
+        Mockito.when(controller.getCurrentProject()).thenReturn(project);
+        //controller.saveProject(...) is left unstubbed: it writes nothing and calls back
+        //neither saved() nor error(), exactly like a save cancelled from the progress bar
+
+        Assert.assertFalse(
+            impl.closeCurrentProject(ProjectControllerUIImpl.CloseDecision.saveAndClose(project, file)));
+
+        Mockito.verify(controller).saveProject(project, file);
+        Mockito.verify(controller, Mockito.never()).closeCurrentProject();
+    }
+
+    @Test
+    public void closeWithoutSavingClosesDirectly() {
+        Mockito.when(controller.getCurrentProject()).thenReturn(project);
+
+        Assert.assertTrue(impl.closeCurrentProject(ProjectControllerUIImpl.CloseDecision.close(project)));
+
+        Mockito.verify(controller, Mockito.never()).saveProject(Mockito.any(), Mockito.any());
+        Mockito.verify(controller).closeCurrentProject();
+    }
+}

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectMetaDataImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/ProjectMetaDataImpl.java
@@ -50,10 +50,10 @@ import org.gephi.project.api.ProjectMetaData;
  */
 public class ProjectMetaDataImpl implements ProjectMetaData {
 
-    private String author;
-    private String title = "";
-    private String keywords = "";
-    private String description = "";
+    private volatile String author;
+    private volatile String title = "";
+    private volatile String keywords = "";
+    private volatile String description = "";
 
     public ProjectMetaDataImpl() {
         String username = System.getProperty("user.name");
@@ -127,10 +127,6 @@ public class ProjectMetaDataImpl implements ProjectMetaData {
 
     @Override
     public int hashCode() {
-        int result = author != null ? author.hashCode() : 0;
-        result = 31 * result + (title != null ? title.hashCode() : 0);
-        result = 31 * result + (keywords != null ? keywords.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        return result;
+        return Objects.hash(author, title, keywords, description);
     }
 }

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/impl/WorkspaceMetaDataImpl.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/impl/WorkspaceMetaDataImpl.java
@@ -4,8 +4,8 @@ import org.gephi.project.api.WorkspaceMetaData;
 
 public class WorkspaceMetaDataImpl implements WorkspaceMetaData {
 
-    private String description = "";
-    private String title = "";
+    private volatile String description = "";
+    private volatile String title = "";
 
     @Override
     public String getDescription() {

--- a/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
+++ b/modules/ProjectAPI/src/main/java/org/gephi/project/io/SaveTask.java
@@ -79,7 +79,7 @@ public class SaveTask implements LongTask {
     private static final String ZIP_LEVEL_PREFERENCE = "ProjectIO_Save_ZipLevel_0_TO_9";
     private final File file;
     private final Project project;
-    private boolean cancel = false;
+    private volatile boolean cancel = false;
     private ProgressTicket progressTicket;
 
     public SaveTask(Project project, File file) {


### PR DESCRIPTION
## Description

Small, independent cleanups deliberately deferred when #3255 landed, per #3246's Step 4:

- **`SaveTask.cancel`**: now written from the EDT (the progress bar's Cancel button, which #3255 made functional for the first time) with no happens-before edge to the background thread polling it in `run()`. Made `volatile`.
- **`ProjectMetaDataImpl` / `WorkspaceMetaDataImpl`**: plain fields written on the Project IO thread, read from the EDT when a properties dialog reopens. Made `volatile`. Also switched `ProjectMetaDataImpl.hashCode()` from hand-rolled `field != null ? field.hashCode() : 0` ternaries (each one two independent reads of the same now-`volatile` field, so not atomic) to `Objects.hash(...)`, matching how `equals()` already reads each field once. An adversarial review pass raised this as a real-but-currently-unreachable defect (no caller passes `null` through these setters today); fixed anyway since it's the same pattern already being fixed everywhere else in this series.
- **`ProjectControllerUIImpl.saved()`/`opened()`**: used to call `saveProjects()` (blocking `projects.xml` write) synchronously, inside the listener callback — which means inside `ProjectControllerImpl`'s monitor. Now resubmitted via `runInProjectIO(this::saveProjects)`, so the write happens after the monitor is released instead of while other background work is blocked on it.
- **`DesktopProject` test infrastructure**: the module had no test dependencies and zero coverage of `ProjectControllerUIImpl`. Added `mockito-core`, split the constructor so tests can inject a mocked `ProjectController` instead of going through `Lookup`, and relaxed `closeCurrentProject(CloseDecision)` and `CloseDecision` to package-private so the confirm/execute split can be driven directly. Added tests pinning the cancelled, no-current-project, stale-decision, save-cancelled-from-the-progress-bar, and close-without-saving paths.

Refs #3246. This closes out all four steps from the original follow-up audit.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

5 new unit tests for `ProjectControllerUIImpl.closeCurrentProject(CloseDecision)` (`ProjectControllerUIImplTest`), using Mockito to drive the confirm/execute split without the EDT dialog or the Project IO executor. The volatile-field and `saveProjects()`-deferral changes have no independently testable business logic; verified via scoped `mvn verify -P enableCheckStyle` and an adversarial code review pass (nothing survived scrutiny except the `hashCode()` issue above, which was fixed). Not yet manually exercised in the running app.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed