### PR TITLE
Fix stale timeline bounds write from a superseded GraphObserverThread

### DIFF
--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/GraphObserverThread.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/GraphObserverThread.java
@@ -32,7 +32,7 @@ public class GraphObserverThread extends Thread {
             Interval bounds = graphModel.getTimeBounds();
             if (!bounds.equals(interval)) {
                 interval = bounds;
-                timelineController.setMinMax(interval.getLow(), interval.getHigh());
+                timelineController.setMinMax(this, interval.getLow(), interval.getHigh());
             }
             try {
                 Thread.sleep(1000);
@@ -44,6 +44,11 @@ public class GraphObserverThread extends Thread {
 
     public void stopThread() {
         stop = true;
+        interrupt();
+    }
+
+    TimelineModelImpl getTimelineModel() {
+        return timelineModel;
     }
 
 }

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/TimelineControllerImpl.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/TimelineControllerImpl.java
@@ -83,6 +83,7 @@ import org.openide.util.lookup.ServiceProviders;
 public class TimelineControllerImpl implements TimelineController, Controller<TimelineModelImpl> {
 
     private final List<TimelineModelListener> listeners;
+    private final Object observerLock = new Object();
     private volatile GraphObserverThread observerThread;
     private ScheduledExecutorService playExecutor;
 
@@ -160,34 +161,36 @@ public class TimelineControllerImpl implements TimelineController, Controller<Ti
         }
     }
 
-    protected boolean setMinMax(double min, double max) {
-        TimelineModelImpl currentModel = getModel();
-        if (currentModel == null) {
-            return false;
-        }
-        double[] prevCustomBounds = new double[2];
-        if (!currentModel.updateMinMax(min, max, prevCustomBounds)) {
-            return false;
-        }
-        if (currentModel.hasValidBounds()) {
-            fireTimelineModelEvent(
-                new TimelineModelEvent(TimelineModelEvent.EventType.MIN_MAX, currentModel, new double[] {min, max}));
-
-            if (currentModel.getCustomMax() != max || currentModel.getCustomMin() != min) {
-                fireTimelineModelEvent(new TimelineModelEvent(TimelineModelEvent.EventType.CUSTOM_BOUNDS, currentModel,
-                    new double[] {min, max}));
+    protected boolean setMinMax(GraphObserverThread caller, double min, double max) {
+        synchronized (observerLock) {
+            if (caller != observerThread) {
+                return false;
             }
+            TimelineModelImpl currentModel = caller.getTimelineModel();
+            double[] prevCustomBounds = new double[2];
+            if (!currentModel.updateMinMax(min, max, prevCustomBounds)) {
+                return false;
+            }
+            if (currentModel.hasValidBounds()) {
+                fireTimelineModelEvent(
+                    new TimelineModelEvent(TimelineModelEvent.EventType.MIN_MAX, currentModel, new double[] {min, max}));
+
+                if (currentModel.getCustomMax() != max || currentModel.getCustomMin() != min) {
+                    fireTimelineModelEvent(new TimelineModelEvent(TimelineModelEvent.EventType.CUSTOM_BOUNDS, currentModel,
+                        new double[] {min, max}));
+                }
+            }
+            if ((Double.isInfinite(prevCustomBounds[1]) || Double.isInfinite(prevCustomBounds[0])) &&
+                currentModel.hasValidBounds()) {
+                fireTimelineModelEvent(
+                    new TimelineModelEvent(TimelineModelEvent.EventType.VALID_BOUNDS, currentModel, true));
+            } else if (!Double.isInfinite(prevCustomBounds[1]) && !Double.isInfinite(prevCustomBounds[0]) &&
+                !currentModel.hasValidBounds()) {
+                fireTimelineModelEvent(
+                    new TimelineModelEvent(TimelineModelEvent.EventType.VALID_BOUNDS, currentModel, false));
+            }
+            return true;
         }
-        if ((Double.isInfinite(prevCustomBounds[1]) || Double.isInfinite(prevCustomBounds[0])) &&
-            currentModel.hasValidBounds()) {
-            fireTimelineModelEvent(
-                new TimelineModelEvent(TimelineModelEvent.EventType.VALID_BOUNDS, currentModel, true));
-        } else if (!Double.isInfinite(prevCustomBounds[1]) && !Double.isInfinite(prevCustomBounds[0]) &&
-            !currentModel.hasValidBounds()) {
-            fireTimelineModelEvent(
-                new TimelineModelEvent(TimelineModelEvent.EventType.VALID_BOUNDS, currentModel, false));
-        }
-        return true;
     }
 
     @Override


### PR DESCRIPTION
## Description

Follow-up to #3255 / #3256 / #3257 / #3258 / #3260. Closes item 2a from the `LISTENER-THREADING-FOLLOWUPS.md` handover (folded into the audit tracked by #3246, now closed): `GraphObserverThread` polls a workspace's graph bounds once per second and reports changes via `TimelineControllerImpl.setMinMax()`, but `stopThread()` only set a flag with no join, and `setMinMax()` resolved its write target *dynamically* via `getModel()` -> `ProjectController.getCurrentWorkspace()` rather than the workspace the thread was actually built for. A thread already past its bounds-changed check when its workspace was unselected could deliver stale bounds to whichever workspace was current by the time the call landed, silently overwriting that workspace's `customMin`/`customMax` and firing a bogus event for the wrong workspace.

### The fix

`setMinMax(GraphObserverThread caller, ...)` now:
- Writes to `caller.getTimelineModel()` — the model captured once at construction, immune to any dynamic "current workspace" lookup, so it can never target the wrong workspace's model regardless of timing.
- Rejects the call if `caller` is no longer `TimelineControllerImpl`'s current `observerThread`, with the check and the write happening atomically under a dedicated lock (`observerLock`) rather than sharing a monitor with anything else in the class.

`stopThread()` also calls `interrupt()` so a stopped thread exits promptly instead of after up to 1s.

### Why the design ended up here (five rejected intermediate versions)

This went through six iterations under adversarial review, each round catching a real gap:
1. Comparing the calling thread's captured model against `getModel()`'s current-workspace model — rejected because workspace models are created once and cached forever (`WorkspaceImpl.initModels()`), so a same-workspace reselect produces a new thread bound to the *same* model reference as the one it superseded; the guard couldn't tell the two generations apart.
2. Guarding with `caller != observerThread` then separately calling `getModel()` — rejected because those are two independently-mutated pieces of state (the field vs. `ProjectController`'s current-workspace pointer); a full workspace switch could complete between the two reads.
3. `caller != observerThread` + writing to `caller.getTimelineModel()` (closes cross-workspace corruption unconditionally) — review found a superseded thread already past the check could still finish its write on the same permanently-cached model a fresh same-workspace thread was also writing to.
4. Added `thread.join()` in `unselect()`/`disable()` to guarantee the old thread is dead first — rejected: `GraphObserverThread` calls `getTimeBounds()` every iteration, which acquires GraphStore's *non-interruptible* read lock; if a filter pass holds that graph's write lock (e.g. during timeline playback), `join()` could stall for the entire filter pass, and since `unselect()`/`disable()` can run on the EDT, that's a multi-second UI freeze.
5. Made `setMinMax` a `synchronized` method instead (no waiting on the old thread at all, just a fresh re-check under a lock) — rejected because it shared its monitor (`this`) with the existing public `addListener`/`removeListener` API, reopening the same EDT-freeze risk through a different door.
6. Final: dedicated `observerLock`, used nowhere else in the class, so only two `GraphObserverThread` generations can ever contend for it — never the EDT, never any public API caller.

### Related, pre-existing issues found along the way (deliberately not fixed here)

Adversarial review also surfaced three latent issues in the surrounding code, none caused by or specific to this fix, all out of scope for this change:
- `TimelineModelImpl.customMin`/`customMax`/`previousMin`/`previousMax` are plain, non-volatile fields with no synchronization at all, independently written by the EDT (`CustomBoundsDialog` -> `setCustomBounds()`) and by a separate "Timeline animator" executor thread (`startPlay()`'s lambda) — a real, pre-existing field-level race, much broader in scope than this fix.
- A new `GraphObserverThread` generation's own change-detection baseline is captured from the graph's *current* bounds at construction time, not from the model's stored bounds — so if a superseded thread's (valid-when-written) bounds are later invalidated by the graph changing again, the new generation may never notice a discrepancy to correct, since its own baseline already matches the new reality.
- `fireTimelineModelEvent()`'s `listeners.toArray()` call has no synchronization against `addListener()`/`removeListener()`'s `synchronized` mutations of the same list — confirmed pre-existing on master today, identical across all 8+ existing call sites, not introduced or worsened by this diff.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

`TimelineAPI` has zero test infrastructure today, and the classes here lean on static NetBeans `Lookup` singletons that aren't easily mockable without disproportionate new scaffolding. Verified via scoped `mvn -P enableCheckStyle` (compiles clean, checkstyle clean) and six rounds of adversarial code review (summarized above). Not yet manually exercised in the running app.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed