### PR TITLE
Add a fatalError hook to LongTaskListener

### DIFF
--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskErrorHandler.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskErrorHandler.java
@@ -47,7 +47,13 @@ package org.gephi.utils.longtask.api;
  * asynchronous task execution.
  *
  * @author Mathieu Bastian
+ * @deprecated prefer {@link LongTaskListener#fatalError(Throwable)}, so a
+ * single listener registered on the executor receives both the successful and
+ * the failed outcome of a task. This interface remains fully functional, is
+ * still accepted by the <code>LongTaskExecutor.execute()</code> methods for
+ * per-task error handling, and is still invoked.
  */
+@Deprecated
 public interface LongTaskErrorHandler {
 
     void fatalError(Throwable t);

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
@@ -265,7 +265,11 @@ public final class LongTaskExecutor {
 
     /**
      * Set the listener to this executor. Only a unique listener can be set to
-     * this executor. The listener is called when the task terminates normally.
+     * this executor. The listener's
+     * {@link LongTaskListener#taskFinished(LongTask)} is called when the task
+     * terminates normally and its
+     * {@link LongTaskListener#fatalError(Throwable)} when it terminates with an
+     * uncaught exception.
      *
      * @param listener a listener for this executor
      */
@@ -278,7 +282,13 @@ public final class LongTaskExecutor {
      * exceptions thrown during tasks execution.
      *
      * @param errorHandler the default error handler
+     * @deprecated implement {@link LongTaskListener#fatalError(Throwable)} and
+     * register the listener with {@link #setLongTaskListener(LongTaskListener)}
+     * instead, so a single listener receives both the successful and the failed
+     * outcome of a task. Default error handlers remain fully supported and are
+     * still invoked.
      */
+    @Deprecated
     public void setDefaultErrorHandler(LongTaskErrorHandler errorHandler) {
         if (errorHandler != null) {
             this.defaultErrorHandler = errorHandler;
@@ -288,11 +298,13 @@ public final class LongTaskExecutor {
     /**
      * Completes the given task. Only the first caller which successfully
      * claimed the completion (see <code>RunningLongTask.claimFinish()</code>)
-     * should call this method, so the listener is notified exactly once per task.
+     * should call this method, so a task is completed exactly once and the
+     * listener is notified exactly once for it.
      *
      * @param runningLongTask the task which completed
-     * @param notifyListener  whether the listener should be notified, errors are
-     *                        reported to the error handler instead
+     * @param notifyListener  whether <code>taskFinished()</code> should be called on
+     *                        the listener, failures are reported to the error handler
+     *                        and to the listener's <code>fatalError()</code> instead
      */
     private synchronized void finished(RunningLongTask runningLongTask, boolean notifyListener) {
         if (cancelTimer != null) {
@@ -387,12 +399,21 @@ public final class LongTaskExecutor {
                         Logger.getLogger("").log(Level.SEVERE, "", e);
                     }
                 } finally {
-                    // Failures are reported to the error handler, not to the listener, but
-                    // the task still has to be completed so the executor doesn't stay
-                    // 'running'. When the task has been interrupted by the cancel timer the
-                    // completion is already claimed by it and this is a no-op.
+                    // Failures are reported through the error handler and the listener's
+                    // fatalError(), not through the listener's taskFinished(), but the task
+                    // still has to be completed so the executor doesn't stay 'running'. When
+                    // the task has been interrupted by the cancel timer the completion is
+                    // already claimed by it and this whole block is a no-op: the timer has
+                    // then already notified the listener itself.
                     if (claimFinish()) {
                         finished(this, false);
+                        LongTaskListener lst = listener;
+                        if (lst != null) {
+                            // In addition to, and not instead of, the error handler above.
+                            // Called after finished() so a failing handler or listener can't
+                            // leave the executor 'running' forever
+                            lst.fatalError(e);
+                        }
                     }
                 }
                 if (!inBackground) {

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskListener.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskListener.java
@@ -51,5 +51,28 @@ import org.gephi.utils.longtask.spi.LongTask;
  */
 public interface LongTaskListener {
 
+    /**
+     * Called when the task terminated normally, that is without throwing any
+     * uncaught exception. A task which failed is reported to
+     * {@link #fatalError(Throwable)} instead.
+     *
+     * @param task the task which terminated, can be <code>null</code> when the
+     *             task was executed without cancel and progress support
+     */
     void taskFinished(LongTask task);
+
+    /**
+     * Called when the task terminated with an uncaught exception, in place of
+     * {@link #taskFinished(LongTask)}. Exactly one of the two methods is called
+     * per task: a task which is completed by the executor's cancel timer is
+     * reported to {@link #taskFinished(LongTask)} even if it subsequently
+     * fails. The default implementation does nothing.
+     * <p>
+     * This complements, and doesn't replace, any {@link LongTaskErrorHandler}
+     * registered on the executor: when both are set, both are invoked.
+     *
+     * @param t the exception which terminated the task
+     */
+    default void fatalError(Throwable t) {
+    }
 }

--- a/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/AsynchronousTest.java
+++ b/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/AsynchronousTest.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.awaitility.Awaitility;
 import org.gephi.utils.longtask.spi.LongTask;
 import org.hamcrest.core.Is;
@@ -68,6 +69,34 @@ public class AsynchronousTest {
     }
 
     @Test
+    public void testExecuteCallableExceptionListenerFatalError() throws Exception {
+        RuntimeException exception = new RuntimeException();
+        executor.setLongTaskListener(listener);
+        Mockito.doThrow(exception).when(callable).call();
+        executor.execute(longTask, callable, "", errorHandler);
+        // The callbacks are awaited directly: isRunning() is already false between the
+        // submission and the moment the pool thread picks the task up
+        Mockito.verify(errorHandler, Mockito.timeout(30000)).fatalError(exception);
+        // The listener's fatalError() complements the error handler, it doesn't replace it
+        Mockito.verify(listener, Mockito.timeout(30000)).fatalError(exception);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executor::isRunning, t -> !t);
+        Mockito.verify(listener, Mockito.never()).taskFinished(Mockito.any());
+    }
+
+    @Test
+    public void testExecuteCallableExceptionListenerWithoutFatalError() throws Exception {
+        RuntimeException exception = new RuntimeException();
+        AtomicBoolean taskFinished = new AtomicBoolean();
+        // A listener which relies on the default, do-nothing fatalError() implementation
+        executor.setLongTaskListener(task -> taskFinished.set(true));
+        Mockito.doThrow(exception).when(callable).call();
+        executor.execute(longTask, callable, "", errorHandler);
+        Mockito.verify(errorHandler, Mockito.timeout(30000)).fatalError(exception);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executor::isRunning, t -> !t);
+        Assert.assertFalse(taskFinished.get());
+    }
+
+    @Test
     public void testExecuteCallableExceptionFuture() throws Exception {
         Mockito.doThrow(new RuntimeException()).when(callable).call();
         Future<Integer> future = executor.execute(longTask, callable, "", errorHandler);
@@ -115,6 +144,30 @@ public class AsynchronousTest {
         executorWithInterruption.cancel();
         Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executorWithInterruption::isRunning, t -> !t);
         Mockito.verify(listener).taskFinished(Mockito.any());
+    }
+
+    @Test
+    public void testCancelRunnableInterruptFailingTask() {
+        Mockito.when(longTask.cancel()).thenReturn(false);
+        Mockito.doAnswer(invocation -> {
+            try {
+                Thread.sleep(30000);
+            } catch (InterruptedException e) {
+                // The task fails on interruption, that is after the cancel timer already
+                // claimed its completion and reported it to the listener
+                throw new RuntimeException(e);
+            }
+            return null;
+        }).when(runnable).run();
+        executorWithInterruption.setLongTaskListener(listener);
+        executorWithInterruption.setDefaultErrorHandler(errorHandler);
+        executorWithInterruption.execute(longTask, runnable);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(executorWithInterruption::isRunning);
+        executorWithInterruption.cancel();
+        Mockito.verify(errorHandler, Mockito.timeout(30000)).fatalError(Mockito.any(RuntimeException.class));
+        Mockito.verify(listener, Mockito.timeout(30000)).taskFinished(Mockito.any());
+        // Exactly one of the two listener methods is called per task
+        Mockito.verify(listener, Mockito.after(500).never()).fatalError(Mockito.any());
     }
 
     @Test

--- a/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/SynchronousTest.java
+++ b/modules/LongTaskAPI/src/test/java/org/gephi/utils/longtask/api/SynchronousTest.java
@@ -43,6 +43,9 @@ public class SynchronousTest {
     LongTaskErrorHandler errorHandler;
 
     @Mock
+    LongTaskErrorHandler defaultErrorHandler;
+
+    @Mock
     LongTaskListener listener;
 
     @Mock
@@ -83,6 +86,114 @@ public class SynchronousTest {
     }
 
     @Test
+    public void testExecuteRunnableExceptionListenerFatalError() {
+        RuntimeException exception = new RuntimeException();
+        executor.setLongTaskListener(listener);
+        Mockito.doThrow(exception).when(runnable).run();
+        executor.execute(longTask, runnable);
+        Mockito.verify(listener).fatalError(exception);
+        Mockito.verify(listener, Mockito.never()).taskFinished(Mockito.any());
+    }
+
+    @Test
+    public void testExecuteRunnableExceptionErrorHandlerAndListenerFatalError() {
+        RuntimeException exception = new RuntimeException();
+        executor.setLongTaskListener(listener);
+        Mockito.doThrow(exception).when(runnable).run();
+        executor.execute(longTask, runnable, "", errorHandler);
+        // The listener's fatalError() complements the error handler, it doesn't replace it
+        Mockito.verify(errorHandler).fatalError(exception);
+        Mockito.verify(listener).fatalError(exception);
+        Mockito.verify(listener, Mockito.never()).taskFinished(Mockito.any());
+    }
+
+    @Test
+    public void testExecuteRunnableExceptionDefaultErrorHandlerAndListenerFatalError() {
+        RuntimeException exception = new RuntimeException();
+        executor.setDefaultErrorHandler(defaultErrorHandler);
+        executor.setLongTaskListener(listener);
+        Mockito.doThrow(exception).when(runnable).run();
+        executor.execute(longTask, runnable);
+        Mockito.verify(defaultErrorHandler).fatalError(exception);
+        Mockito.verify(listener).fatalError(exception);
+        Mockito.verify(listener, Mockito.never()).taskFinished(Mockito.any());
+    }
+
+    @Test
+    public void testExecuteRunnableExceptionListenerWithoutFatalError() {
+        RuntimeException exception = new RuntimeException();
+        AtomicBoolean taskFinished = new AtomicBoolean();
+        // A listener which relies on the default, do-nothing fatalError() implementation
+        executor.setLongTaskListener(task -> taskFinished.set(true));
+        Mockito.doThrow(exception).when(runnable).run();
+        executor.execute(longTask, runnable, "", errorHandler);
+        Mockito.verify(errorHandler).fatalError(exception);
+        Assert.assertFalse(taskFinished.get());
+        Assert.assertFalse(executor.isRunning());
+    }
+
+    @Test
+    public void testExecuteRunnableExceptionErrorHandlerTakesPrecedence() {
+        RuntimeException exception = new RuntimeException();
+        executor.setDefaultErrorHandler(defaultErrorHandler);
+        Mockito.doThrow(exception).when(runnable).run();
+        executor.execute(longTask, runnable, "", errorHandler);
+        Mockito.verify(errorHandler).fatalError(exception);
+        Mockito.verifyNoInteractions(defaultErrorHandler);
+    }
+
+    @Test
+    public void testExecuteRunnableExceptionDefaultErrorHandler() {
+        RuntimeException exception = new RuntimeException();
+        executor.setDefaultErrorHandler(defaultErrorHandler);
+        Mockito.doThrow(exception).when(runnable).run();
+        executor.execute(longTask, runnable);
+        Mockito.verify(defaultErrorHandler).fatalError(exception);
+    }
+
+    @Test
+    public void testExecuteRunnableExceptionErrorHandlerThrows() {
+        RuntimeException exception = new RuntimeException("task");
+        Mockito.doThrow(new IllegalStateException("errorHandler")).when(errorHandler).fatalError(exception);
+        Mockito.doThrow(exception).when(runnable).run();
+        executor.setLongTaskListener(listener);
+        try {
+            executor.execute(longTask, runnable, "", errorHandler);
+            Assert.fail("The error handler exception is expected to propagate");
+        } catch (IllegalStateException expected) {
+            // The error handler isn't shielded from its own exceptions, as before
+        }
+        // The listener is still notified, it complements the error handler
+        Mockito.verify(listener).fatalError(exception);
+        Assert.assertFalse(executor.isRunning());
+    }
+
+    @Test
+    public void testExecuteRunnableExceptionListenerFatalErrorThrows() {
+        Mockito.doThrow(new RuntimeException("task")).when(runnable).run();
+        executor.setLongTaskListener(new LongTaskListener() {
+            @Override
+            public void taskFinished(LongTask task) {
+            }
+
+            @Override
+            public void fatalError(Throwable t) {
+                throw new IllegalStateException("listener");
+            }
+        });
+        try {
+            executor.execute(longTask, runnable, "", errorHandler);
+            Assert.fail("The listener exception is expected to propagate");
+        } catch (IllegalStateException expected) {
+            // The listener isn't shielded either, just like the error handler
+        }
+        Mockito.verify(errorHandler).fatalError(Mockito.any(RuntimeException.class));
+        // The task is completed before the listener is called, so a failing listener
+        // can't leave the executor 'running' forever
+        Assert.assertFalse(executor.isRunning());
+    }
+
+    @Test
     public void testExecuteRunnableProgressWithException() {
         Mockito.doThrow(new RuntimeException()).when(runnable).run();
         executor.execute(longTask, runnable);
@@ -94,6 +205,14 @@ public class SynchronousTest {
         executor.setLongTaskListener(listener);
         executor.execute(longTask, runnable);
         Mockito.verify(listener).taskFinished(Mockito.eq(longTask));
+    }
+
+    @Test
+    public void testExecuteRunnableListenerNoFatalErrorOnSuccess() {
+        executor.setLongTaskListener(listener);
+        executor.execute(longTask, runnable);
+        Mockito.verify(listener).taskFinished(Mockito.eq(longTask));
+        Mockito.verify(listener, Mockito.never()).fatalError(Mockito.any());
     }
 
     @Test

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -67,6 +67,11 @@
             <li>Added <code>hasIssues()</code> to <code>Report</code> class to check if the report contains any issues.</li>
             <li>Added a new <code>ImportException</code> base class for known, user-facing import failures, along with an <code>EmptyFileException</code> subclass. Empty files are now detected centrally in <code>ImportController</code> and raised as <code>EmptyFileException</code> with a localized message, so UIs can present a clean error instead of the default unexpected-exception treatment.</li>
         </ul>
+        <h4>LongTask API</h4>
+        <ul>
+            <li>Added a <code>fatalError(Throwable)</code> default method to <code>LongTaskListener</code>. It is called when a task terminates with an uncaught exception, instead of <code>taskFinished()</code>, so that a single listener receives both outcomes. The default implementation does nothing, therefore existing listeners are unaffected.</li>
+            <li><code>LongTaskErrorHandler</code> and <code>LongTaskExecutor.setDefaultErrorHandler()</code> are deprecated in favor of <code>LongTaskListener.fatalError(Throwable)</code>. They remain fully functional and are still invoked, in addition to the listener.</li>
+        </ul>
         <h3>0.10.0</h3>
         <h4>Project API</h4>
         <ul>


### PR DESCRIPTION
## Description

`LongTaskExecutor` splits task-completion notification across two independent objects:

- `LongTaskListener.taskFinished(LongTask)` — called only when a task completes **successfully**.
- `LongTaskErrorHandler.fatalError(Throwable)` — a separate object, registered independently via `setDefaultErrorHandler(...)` or passed per call, invoked only on **failure**.

Because both have to be wired up separately, it is easy to register a listener and forget the error handler. The failure then falls through to `Logger.getLogger("").log(Level.SEVERE, "", e)` with no context, and since `finished(this, false)` doesn't notify the listener, any state the listener was supposed to clear (a "running" flag, for instance) stays stuck. `StatisticsControllerImpl` was exactly that case until #3249, which fixed the symptom; this PR addresses the structural cause.

**What changed** (all in `modules/LongTaskAPI`):

- `LongTaskListener` gets a `default void fatalError(Throwable t) {}` hook, so a caller who registers a single listener is notified of both outcomes.
- `LongTaskErrorHandler` and `LongTaskExecutor.setDefaultErrorHandler(...)` are `@Deprecated` in favor of it. Both remain fully functional and are still invoked; the `execute(..., LongTaskErrorHandler)` overloads are untouched, since a per-executor listener can't replace a per-task handler that captures per-task context.
- In `RunningLongTask.call()`'s catch block, the listener's `fatalError()` is called **in addition to**, never instead of, the existing `errorHandler` → `defaultErrorHandler` → log-fallback dispatch. It sits in the `finally`, guarded by the same `claimFinish()` that guards `finished(this, false)` and placed right after it, so that:
  - a throwing error handler can't skip the listener notification,
  - a throwing listener can't leave the executor stuck with `isRunning() == true`,
  - a task whose completion was already claimed by the cancel timer — which reports it through `taskFinished()` — isn't reported to the listener twice. Exactly one of `taskFinished()` / `fatalError()` is delivered per task.

**Why it is non-breaking:** `taskFinished()` still fires on success only and `finished(this, false)` still doesn't notify the listener on failure, so every existing implementer (`LayoutModelImpl`, `StatisticsControllerUIImpl`, `ProjectControllerUIImpl`, `StatisticsFrontEnd`) keeps its current behavior. The only new call targets a default method that nothing in the repo overrides. Adding a default method is source- and binary-compatible, and no class implements both `LongTaskListener` and `LongTaskErrorHandler` (all listener usages are lambdas or anonymous classes), so there is no default/abstract clash. The deprecations produce compiler warnings only — no build uses `-Werror`.

A follow-up PR will migrate `StatisticsControllerImpl` / `StatisticsControllerUIImpl` onto this hook; this PR is deliberately self-contained to `LongTaskAPI`.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed

New tests in `SynchronousTest` and `AsynchronousTest` (27 tests total, up from 20), covering:

- a failing task with a listener overriding `fatalError()` → `fatalError()` receives the actual thrown exception and `taskFinished()` is never called;
- a failing task with **both** a per-task (or default) error handler and a listener → both are invoked;
- a failing task with a listener relying on the do-nothing default (a real lambda, not a mock) → nothing escapes and the task still completes;
- a failing task with no listener → the `errorHandler` → `defaultErrorHandler` → log-fallback precedence chain behaves exactly as before;
- a throwing error handler → the listener is still notified;
- a throwing `fatalError()` → the exception propagates as an error handler's would, but the executor is no longer `isRunning()`;
- a task that fails after the cancel timer claimed its completion → the listener gets `taskFinished()` only, never both;
- the success path → `taskFinished()` fires and `fatalError()` doesn't.

The pre-existing tests are unmodified and still pass. Reverting the production change makes 6 of the new tests fail, so they aren't vacuous.

## Added to documentation?
- [ ] 👍 README.md
- [x] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed
