### PR TITLE
Fix gephi.conf permissions in Linux tar.gz bundle

### DIFF
--- a/modules/application/pom.xml
+++ b/modules/application/pom.xml
@@ -971,6 +971,9 @@
 
                                         <!-- Configure relative JRE path into gephi.conf -->
                                         <replace file="${project.build.directory}/${brandingToken}/etc/${brandingToken}.conf" token="#jdkhome=&quot;/path/to/jdk&quot;" value="jdkhome=&quot;jre-${gephi.bundle.arch}/${bundle.jre.name}&quot;"/>
+                                        <!-- nbm-maven-plugin ships this file mode 600; fix it so it's still
+                                             readable when unpacked as root and run as a regular user (#3219) -->
+                                        <chmod file="${project.build.directory}/${brandingToken}/etc/${brandingToken}.conf" perm="644"/>
                                         <chmod file="${project.build.directory}/${brandingToken}/jre-${gephi.bundle.arch}/**" perm="+x" type="both"/>
                                     </target>
                                 </configuration>


### PR DESCRIPTION
## Summary
- `etc/gephi.conf` in the generated Linux app tree ships with mode `600` (confirmed against the published `gephi-0.11.2-linux-x64.tar.gz`, where it's the only file out of ~2500 with that mode — everything else is `644`/`755`).
- Root-owned, unreadable-by-others files are harmless when a user extracts and owns the tar.gz themselves, but break installs where the app runs as a different user than the one who unpacked it — notably the Gephi snap package, where the payload is root-owned inside the confined snap while the launcher runs as the invoking user, causing `Permission denied` on startup.
- Adds a `chmod` to `644` for `etc/${brandingToken}.conf` right next to the existing JRE `chmod` in the `create-targz` Ant target, so every Linux consumer of this tar.gz gets a readable config file.

Fixes #3219

## Test plan
- [ ] `mvn -pl modules/application -P deployment,create-targz package` and confirm `target/gephi/etc/gephi.conf` is `644` in the resulting tar.gz
- [ ] Rebuild the snap from this tar.gz and confirm `snap run gephi` starts on Ubuntu 24.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)