### PR TITLE
Fix NodesDragger ignoring fixed/settled nodes

### DIFF
--- a/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/NodesDragger.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/NodesDragger.java
@@ -102,6 +102,9 @@ public class NodesDragger implements Tool {
                 if (nodes != null && nodes.length > 0) {
                     for (int i = 0; i < nodes.length; i++) {
                         Node n = nodes[i];
+                        if (n.isFixed()) {
+                            continue;
+                        }
                         n.setX(initialX[i] + displacementXWorld);
                         n.setY(initialY[i] + displacementYWorld);
                     }


### PR DESCRIPTION
## Description

The node dragging tool moved every selected node regardless of its `fixed` (settle/freeze) property, so nodes that were pinned/settled could still be dragged around the canvas. Layout algorithms (`ForceAtlas2`, `NoverlapLayout`, etc.) already respect `Node.isFixed()` and leave those nodes in place — `NodesDragger` now does the same, skipping any node where `isFixed()` returns `true`.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren’t needed