### PR TITLE
Show statistics execution failures with a dialog, and recover

### DIFF
--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
@@ -46,10 +46,14 @@ import java.util.ArrayList;
 import org.gephi.desktop.statistics.api.StatisticsControllerUI;
 import org.gephi.statistics.api.StatisticsController;
 import org.gephi.statistics.spi.Statistics;
+import org.gephi.statistics.spi.StatisticsBuilder;
 import org.gephi.statistics.spi.StatisticsUI;
 import org.gephi.utils.longtask.api.LongTaskListener;
 import org.gephi.utils.longtask.spi.LongTask;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -109,57 +113,63 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
 
     @Override
     public void execute(final Statistics statistics) {
-        StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
-        final StatisticsUI[] uis = getUI(statistics);
-
-        for (StatisticsUI s : uis) {
-            s.setup(statistics);
-        }
-        if (model == null) {
-            return;
-        }
-        model.setRunning(statistics, true);
-
-        controller.execute(statistics, new LongTaskListener() {
-
-            @Override
-            public void taskFinished(LongTask task) {
-                model.setRunning(statistics, false);
-                for (StatisticsUI s : uis) {
-                    model.addResult(s);
-                    s.unsetup();
-                }
-            }
-        });
+        execute(statistics, null);
     }
 
     @Override
     public void execute(final Statistics statistics, final LongTaskListener listener) {
-        StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
+        final StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
         final StatisticsUI[] uis = getUI(statistics);
 
         for (StatisticsUI s : uis) {
             s.setup(statistics);
         }
-        if (model == null) {
+        //Capture the model, the execution outcome is reported from a background
+        //thread and the current workspace may have changed in the meantime
+        final StatisticsModelUIImpl uiModel = model;
+        if (uiModel == null) {
             return;
         }
-        model.setRunning(statistics, true);
+        uiModel.setRunning(statistics, true);
 
         controller.execute(statistics, new LongTaskListener() {
 
             @Override
             public void taskFinished(LongTask task) {
-                model.setRunning(statistics, false);
+                uiModel.setRunning(statistics, false);
                 for (StatisticsUI s : uis) {
-                    model.addResult(s);
+                    uiModel.addResult(s);
                     s.unsetup();
                 }
                 if (listener != null) {
                     listener.taskFinished(statistics instanceof LongTask ? (LongTask) statistics : null);
                 }
             }
+
+            @Override
+            public void fatalError(Throwable t) {
+                //No result to collect from a failed execution, but the running state
+                //has to be cleared or the front-end stays stuck on 'Cancel'
+                uiModel.setRunning(statistics, false);
+                for (StatisticsUI s : uis) {
+                    s.unsetup();
+                }
+                notifyExecutionError(controller, statistics, t);
+                if (listener != null) {
+                    listener.fatalError(t);
+                }
+            }
         });
+    }
+
+    private static void notifyExecutionError(StatisticsController controller, Statistics statistics, Throwable t) {
+        StatisticsBuilder builder = controller.getBuilder(statistics.getClass());
+        String name = builder != null ? builder.getName() : statistics.getClass().getSimpleName();
+        String localizedMessage = t.getLocalizedMessage();
+        String error = localizedMessage != null && !localizedMessage.isEmpty() ? localizedMessage : t.toString();
+        DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(
+            NbBundle.getMessage(StatisticsControllerUIImpl.class, "StatisticsControllerUIImpl.executionError", name,
+                error), NotifyDescriptor.ERROR_MESSAGE));
     }
 
     public StatisticsUI[] getUI(Statistics statistics) {

--- a/modules/DesktopStatistics/src/main/resources/org/gephi/desktop/statistics/Bundle.properties
+++ b/modules/DesktopStatistics/src/main/resources/org/gephi/desktop/statistics/Bundle.properties
@@ -21,6 +21,8 @@ StatisticsFrontEnd.runButton.text=Run
 
 StatisticsFrontEnd.notDynamicGraph=Can't run a dynamic statistic if the graph isn't dynamic
 
+StatisticsControllerUIImpl.executionError=Execution of {0} failed with the following error: {1}
+
 DynamicSettingsPanel.TimeUnit.DAYS=DAYS
 DynamicSettingsPanel.TimeUnit.HOURS=HOURS
 DynamicSettingsPanel.TimeUnit.MILLISECONDS=MILLISECONDS

--- a/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsControllerUIImplTest.java
+++ b/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsControllerUIImplTest.java
@@ -1,0 +1,275 @@
+package org.gephi.desktop.statistics;
+
+import java.awt.Dialog;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JPanel;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
+import org.gephi.statistics.spi.Statistics;
+import org.gephi.statistics.spi.StatisticsBuilder;
+import org.gephi.statistics.spi.StatisticsUI;
+import org.gephi.utils.longtask.api.LongTaskListener;
+import org.gephi.utils.longtask.spi.LongTask;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.netbeans.junit.MockServices;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.util.Lookup;
+
+/**
+ * Checks that a statistics algorithm which throws is reported to the user with the name of the
+ * failing algorithm and doesn't leave the front-end stuck in the running state.
+ */
+public class StatisticsControllerUIImplTest {
+
+    private static final String FAILURE_MESSAGE = "Bridging centrality blew up";
+    private static final String BUILDER_NAME = "Test Metric";
+    private static final String RESULT_VALUE = "42";
+    private static final String REPORT = "<html>Report</html>";
+    private static final long TIMEOUT_SECONDS = 5;
+
+    private StatisticsControllerUIImpl controllerUI;
+    private StatisticsModelUIImpl model;
+
+    @Before
+    public void setUp() {
+        MockServices.setServices(CapturingDialogDisplayer.class, TestStatisticsBuilder.class, TestStatisticsUI.class);
+        CapturingDialogDisplayer.reset();
+        TestStatisticsUI.reset();
+
+        ProjectController projectController = Lookup.getDefault().lookup(ProjectController.class);
+        Workspace workspace = projectController.openNewWorkspace();
+
+        model = new StatisticsModelUIImpl(workspace);
+        controllerUI = new StatisticsControllerUIImpl();
+        controllerUI.setup(model);
+    }
+
+    @After
+    public void tearDown() {
+        Lookup.getDefault().lookup(ProjectController.class).closeCurrentProject();
+        CapturingDialogDisplayer.reset();
+        TestStatisticsUI.reset();
+        // Services are registered globally, don't leak them into the next test
+        MockServices.setServices();
+    }
+
+    @Test
+    public void testFatalErrorReportsAlgorithmName() throws InterruptedException {
+        controllerUI.execute(new TestStatistics(true));
+
+        NotifyDescriptor descriptor = CapturingDialogDisplayer.awaitMessage();
+        Assert.assertNotNull("No dialog was shown for the failed execution", descriptor);
+        Assert.assertEquals(NotifyDescriptor.ERROR_MESSAGE, descriptor.getMessageType());
+        String message = String.valueOf(descriptor.getMessage());
+        Assert.assertTrue("Message doesn't name the failing algorithm: " + message, message.contains(BUILDER_NAME));
+        Assert.assertTrue("Message doesn't report the error: " + message, message.contains(FAILURE_MESSAGE));
+
+        StatisticsUI ui = statisticsUI();
+        Assert.assertFalse("The statistics is still reported as running", model.isRunning(ui));
+        Assert.assertNull("A result was added for a failed execution", model.getResult(ui));
+        Assert.assertTrue("The statistics UI wasn't unsetup", TestStatisticsUI.isUnsetup());
+    }
+
+    @Test
+    public void testFatalErrorIsForwardedToListener() throws InterruptedException {
+        RecordingListener listener = new RecordingListener();
+
+        controllerUI.execute(new TestStatistics(true), listener);
+
+        Assert.assertTrue("The listener was never notified", listener.await());
+        Assert.assertEquals(List.of("fatalError:" + FAILURE_MESSAGE), listener.getCalls());
+        Assert.assertNotNull("No dialog was shown for the failed execution",
+            CapturingDialogDisplayer.awaitMessage());
+        Assert.assertFalse("The statistics is still reported as running", model.isRunning(statisticsUI()));
+    }
+
+    @Test
+    public void testSuccessIsUnaffected() throws InterruptedException {
+        RecordingListener listener = new RecordingListener();
+
+        controllerUI.execute(new TestStatistics(false), listener);
+
+        Assert.assertTrue("The listener was never notified", listener.await());
+        Assert.assertEquals(List.of("taskFinished"), listener.getCalls());
+        Assert.assertNull("A dialog was shown for a successful execution", CapturingDialogDisplayer.pollMessage());
+
+        StatisticsUI ui = statisticsUI();
+        Assert.assertFalse("The statistics is still reported as running", model.isRunning(ui));
+        Assert.assertEquals(RESULT_VALUE, model.getResult(ui));
+        Assert.assertEquals(REPORT, model.getReport(TestStatistics.class));
+        Assert.assertTrue("The statistics UI wasn't unsetup", TestStatisticsUI.isUnsetup());
+    }
+
+    private StatisticsUI statisticsUI() {
+        StatisticsUI[] uis = controllerUI.getUI(new TestStatistics(false));
+        Assert.assertEquals("The test StatisticsUI isn't registered in Lookup", 1, uis.length);
+        return uis[0];
+    }
+
+    private static final class RecordingListener implements LongTaskListener {
+
+        private final List<String> calls = new CopyOnWriteArrayList<>();
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void taskFinished(LongTask task) {
+            calls.add("taskFinished");
+            latch.countDown();
+        }
+
+        @Override
+        public void fatalError(Throwable t) {
+            calls.add("fatalError:" + t.getMessage());
+            latch.countDown();
+        }
+
+        boolean await() throws InterruptedException {
+            return latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+
+        List<String> getCalls() {
+            return List.copyOf(calls);
+        }
+    }
+
+    public static class TestStatistics implements Statistics {
+
+        private final boolean fail;
+
+        public TestStatistics(boolean fail) {
+            this.fail = fail;
+        }
+
+        @Override
+        public void execute(GraphModel graphModel) {
+            if (fail) {
+                throw new IllegalStateException(FAILURE_MESSAGE);
+            }
+        }
+
+        @Override
+        public String getReport() {
+            return REPORT;
+        }
+    }
+
+    public static class TestStatisticsBuilder implements StatisticsBuilder {
+
+        @Override
+        public String getName() {
+            return BUILDER_NAME;
+        }
+
+        @Override
+        public Statistics getStatistics() {
+            return new TestStatistics(true);
+        }
+
+        @Override
+        public Class<? extends Statistics> getStatisticsClass() {
+            return TestStatistics.class;
+        }
+    }
+
+    public static class TestStatisticsUI implements StatisticsUI {
+
+        private static volatile boolean unsetup;
+
+        static void reset() {
+            unsetup = false;
+        }
+
+        static boolean isUnsetup() {
+            return unsetup;
+        }
+
+        @Override
+        public JPanel getSettingsPanel() {
+            return null;
+        }
+
+        @Override
+        public void setup(Statistics statistics) {
+            unsetup = false;
+        }
+
+        @Override
+        public void unsetup() {
+            unsetup = true;
+        }
+
+        @Override
+        public Class<? extends Statistics> getStatisticsClass() {
+            return TestStatistics.class;
+        }
+
+        @Override
+        public String getValue() {
+            return RESULT_VALUE;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return BUILDER_NAME;
+        }
+
+        @Override
+        public String getShortDescription() {
+            return BUILDER_NAME;
+        }
+
+        @Override
+        public String getCategory() {
+            return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
+        }
+
+        @Override
+        public int getPosition() {
+            return 0;
+        }
+    }
+
+    public static class CapturingDialogDisplayer extends DialogDisplayer {
+
+        private static final LinkedBlockingQueue<NotifyDescriptor> MESSAGES = new LinkedBlockingQueue<>();
+
+        static void reset() {
+            MESSAGES.clear();
+        }
+
+        static NotifyDescriptor awaitMessage() throws InterruptedException {
+            return MESSAGES.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+
+        static NotifyDescriptor pollMessage() {
+            return MESSAGES.poll();
+        }
+
+        @Override
+        public Object notify(NotifyDescriptor descriptor) {
+            MESSAGES.add(descriptor);
+            return NotifyDescriptor.OK_OPTION;
+        }
+
+        @Override
+        public void notifyLater(NotifyDescriptor descriptor) {
+            //Capture synchronously, the default implementation defers to the event thread
+            MESSAGES.add(descriptor);
+        }
+
+        @Override
+        public Dialog createDialog(DialogDescriptor descriptor) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
## Description

When a statistics algorithm throws, the Statistics panel row keeps spinning on a "Cancel" button that can never clear it, and the user only gets an anonymous "unexpected exception" crash report with no indication of which algorithm failed. This is a long-standing report from the wild (a third-party "Bridging Centrality" plugin feeding `NaN` into `new BigDecimal(...)` is one observed root cause).

The cause is that `StatisticsControllerUIImpl` clears `model.setRunning(statistics, false)` only from `taskFinished(LongTask)`, which `LongTaskExecutor` never calls for a task that threw.

Building on the now-merged gephi/gephi#3262, which added `LongTaskListener.fatalError(Throwable)`, this adds a `fatalError` override to the anonymous listener that `DesktopStatistics` already passes to `StatisticsController.execute(...)`. It:

- clears the running state, so the panel row goes back to "Run" instead of staying stuck;
- calls `StatisticsUI.unsetup()` but **not** `model.addResult(...)` — there is no computed result to surface, and `StatisticsUI.getValue()` reads state off the failed (often half-initialised) statistics instance;
- shows a `NotifyDescriptor.ERROR_MESSAGE` naming the failing algorithm (via `StatisticsController.getBuilder(...).getName()`) and the error message;
- forwards to the caller-supplied `LongTaskListener.fatalError(t)`, mirroring how `taskFinished` already forwards.

Since both overloads only differed by that forwarding, `execute(Statistics)` now simply delegates to `execute(statistics, null)`. The listener also captures the `StatisticsModelUIImpl` at submission time rather than reading the mutable field from the background thread, so the outcome is always applied to the model the run was started on.

**No `StatisticsAPI` change.** `StatisticsControllerImpl.execute(Statistics, LongTaskListener)` already wires the caller's listener with `executor.setLongTaskListener(listener)`, so the new hook fires with zero changes there. This supersedes gephi/gephi#3249, which fixed the same bug by adding a `setDefaultErrorHandler` inside `StatisticsControllerImpl`: that required a new `org-openide-dialogs` dependency in `modules/StatisticsAPI/pom.xml` and a user-facing localized string in StatisticsAPI's own `Bundle.properties`. `StatisticsAPI` is meant to stay headless, and dialogs plus their ~20 translated bundles already live in `DesktopStatistics`, so the message belongs here. #3249 is left open for you to decide on.

The crash-report path is deliberately unchanged: `StatisticsControllerImpl` still registers no `LongTaskErrorHandler`, so `LongTaskExecutor` still falls through to `Logger.getLogger("").log(Level.SEVERE, "", e)` and `ReporterHandler` still picks the exception up for the crash report. The new dialog is additional context for the user, not a replacement for the report.

Only the base `Bundle.properties` gets the new key; the translated siblings are untouched.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed

`modules/DesktopStatistics` had no `src/test` directory; this adds one (no `pom.xml` change needed — `org-netbeans-modules-nbjunit` is already a global test dependency in the root pom). `StatisticsControllerUIImplTest` drives the real `StatisticsControllerUIImpl` against the real `StatisticsControllerImpl` resolved through `Lookup`, with a `MockServices`-registered `StatisticsBuilder`, `StatisticsUI` and capturing `DialogDisplayer`, and asserts that a throwing `Statistics`:

- produces an error dialog naming the algorithm and the error;
- clears the running state;
- adds no result to the model;
- reaches the caller's `fatalError` and not its `taskFinished`.

A third test covers the unchanged success path (result added, report stored, `taskFinished` forwarded).

`mvn -pl modules/DesktopStatistics -am install` and `mvn -pl modules/DesktopStatistics -am --batch-mode -Djava.awt.headless=true verify -P enableCheckStyle` both pass.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed

No public API changed — `StatisticsControllerUIImpl` is an implementation class and `org.gephi.desktop.statistics.api` is untouched, so there is no API changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
