### PR TITLE
#3025 Fix crash when Dynamic Range filter is used as a subquery

### DIFF
--- a/modules/TimelineAPI/pom.xml
+++ b/modules/TimelineAPI/pom.xml
@@ -36,6 +36,19 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-util-lookup</artifactId>
         </dependency>
+
+        <!-- Test only -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>filters-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>graph-api</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/TimelineAPI/src/main/java/org/gephi/timeline/TimelineControllerImpl.java
+++ b/modules/TimelineAPI/src/main/java/org/gephi/timeline/TimelineControllerImpl.java
@@ -232,6 +232,7 @@ public class TimelineControllerImpl implements TimelineController, Controller<Ti
 
     private void applyIntervalFilter(TimelineModelImpl currentModel, FilterModel filterModel, double from, double to) {
         Query dynamicQuery = null;
+        Query dynamicRangeQuery = null;
         boolean selecting = false;
 
         if (filterModel.getCurrentQuery() != null) {
@@ -239,6 +240,7 @@ public class TimelineControllerImpl implements TimelineController, Controller<Ti
             Query[] dynamicQueries = query.getQueries(DynamicRangeFilter.class);
             if (dynamicQueries.length > 0) {
                 dynamicQuery = query;
+                dynamicRangeQuery = dynamicQueries[0];
                 selecting = filterModel.isSelecting();
             }
         } else if (filterModel.getQueries().length == 1) {
@@ -246,13 +248,19 @@ public class TimelineControllerImpl implements TimelineController, Controller<Ti
             Query[] dynamicQueries = query.getQueries(DynamicRangeFilter.class);
             if (dynamicQueries.length > 0) {
                 dynamicQuery = query;
+                dynamicRangeQuery = dynamicQueries[0];
             }
         }
 
         FilterController filterController = Lookup.getDefault().lookup(FilterController.class);
         if (Double.isInfinite(from) && Double.isInfinite(to)) {
             if (dynamicQuery != null) {
-                filterController.remove(dynamicQuery);
+                if (dynamicRangeQuery.getParent() != null) {
+                    //Dynamic Range is a subquery: only remove it, keep the rest of the query intact
+                    filterController.removeSubQuery(dynamicRangeQuery, dynamicRangeQuery.getParent());
+                } else {
+                    filterController.remove(dynamicQuery);
+                }
             }
         } else {
             if (dynamicQuery == null) {
@@ -262,12 +270,13 @@ public class TimelineControllerImpl implements TimelineController, Controller<Ti
                     FilterBuilder[] fb = rangeBuilder.getBuilders(filterModel.getWorkspace());
                     if (fb.length > 0) {
                         dynamicQuery = filterController.createQuery(fb[0]);
+                        dynamicRangeQuery = dynamicQuery;
                         filterController.add(dynamicQuery);
                     }
                 }
             }
             if (dynamicQuery != null) {
-                dynamicQuery.getFilter().getProperties()[0].setValue(new Range(from, to));
+                dynamicRangeQuery.getFilter().getProperties()[0].setValue(new Range(from, to));
                 if (selecting) {
                     filterController.selectVisible(dynamicQuery);
                 } else {

--- a/modules/TimelineAPI/src/test/java/org/gephi/timeline/TimelineControllerImplTest.java
+++ b/modules/TimelineAPI/src/test/java/org/gephi/timeline/TimelineControllerImplTest.java
@@ -1,0 +1,116 @@
+package org.gephi.timeline;
+
+import org.gephi.filters.api.FilterController;
+import org.gephi.filters.api.FilterModel;
+import org.gephi.filters.api.Query;
+import org.gephi.filters.plugin.dynamic.DynamicRangeBuilder;
+import org.gephi.filters.plugin.dynamic.DynamicRangeBuilder.DynamicRangeFilter;
+import org.gephi.filters.plugin.graph.DegreeRangeBuilder;
+import org.gephi.filters.plugin.graph.DegreeRangeBuilder.DegreeRangeFilter;
+import org.gephi.filters.spi.FilterBuilder;
+import org.gephi.graph.GraphGenerator;
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.graph.api.GraphView;
+import org.gephi.graph.api.Interval;
+import org.gephi.graph.api.Node;
+import org.gephi.project.api.Project;
+import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
+import org.gephi.timeline.api.TimelineController;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openide.util.Lookup;
+
+public class TimelineControllerImplTest {
+
+    private Project project;
+    private Workspace workspace;
+
+    @Before
+    public void setUp() {
+        ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
+        project = pc.newProject();
+        workspace = project.getCurrentWorkspace();
+    }
+
+    @After
+    public void cleanUp() {
+        Lookup.getDefault().lookup(ProjectController.class).closeCurrentProject();
+        project = null;
+    }
+
+    /**
+     * Regression test for #3025: playing the timeline while the "Time Interval" (Dynamic Range)
+     * filter is a subquery of another filter (here Degree Range) used to corrupt the parent
+     * filter's range property instead of the Dynamic Range filter's own property, crashing
+     * FilterProcessor with "Lower and upper must be the same class".
+     */
+    @Test
+    public void testSetIntervalWithDynamicRangeAsSubQuery() {
+        GraphGenerator generator = GraphGenerator.build(workspace);
+        GraphModel graphModel = generator.getGraphModel();
+
+        Node n1 = graphModel.factory().newNode("1");
+        Node n2 = graphModel.factory().newNode("2");
+        n1.addInterval(new Interval(0.0, 10.0));
+        n2.addInterval(new Interval(0.0, 10.0));
+        Edge e1 = graphModel.factory().newEdge("1", n1, n2, 0, 1.0, true);
+        e1.addInterval(new Interval(0.0, 10.0));
+
+        Graph graph = graphModel.getGraph();
+        graph.addNode(n1);
+        graph.addNode(n2);
+        graph.addEdge(e1);
+
+        FilterController filterController = Lookup.getDefault().lookup(FilterController.class);
+
+        DegreeRangeBuilder degreeRangeBuilder = Lookup.getDefault().lookup(DegreeRangeBuilder.class);
+        Query degreeQuery = filterController.createQuery(degreeRangeBuilder);
+        filterController.add(degreeQuery);
+
+        DynamicRangeBuilder dynamicRangeBuilder = Lookup.getDefault().lookup(DynamicRangeBuilder.class);
+        FilterBuilder[] dynamicBuilders = dynamicRangeBuilder.getBuilders(workspace);
+        Assert.assertTrue(dynamicBuilders.length > 0);
+        Query dynamicQuery = filterController.createQuery(dynamicBuilders[0]);
+        filterController.setSubQuery(degreeQuery, dynamicQuery);
+
+        FilterModel filterModel = filterController.getModel(workspace);
+        Assert.assertSame(degreeQuery, filterModel.getCurrentQuery());
+
+        TimelineController timelineController = Lookup.getDefault().lookup(TimelineController.class);
+        timelineController.setCustomBounds(0.0, 10.0);
+
+        //Simulate the timeline playing through the interval
+        timelineController.setInterval(0.0, 4.0);
+
+        //The Dynamic Range filter's own range must have been updated...
+        DynamicRangeFilter dynamicRangeFilter = (DynamicRangeFilter) dynamicQuery.getFilter();
+        Assert.assertEquals(0.0, dynamicRangeFilter.getRange().getLowerDouble(), 0.0);
+        Assert.assertEquals(4.0, dynamicRangeFilter.getRange().getUpperDouble(), 0.0);
+
+        //...and NOT the Degree Range filter's range, which must stay Integer-typed
+        DegreeRangeFilter degreeRangeFilter = (DegreeRangeFilter) degreeQuery.getFilter();
+        Assert.assertEquals(Integer.class, degreeRangeFilter.getRange().getRangeType());
+
+        //Must not throw IllegalArgumentException: Lower and upper must be the same class
+        GraphView view1 = filterController.filter(degreeQuery);
+        Assert.assertNotNull(view1);
+
+        //Advance the timeline further, still without crashing
+        timelineController.setInterval(4.0, 8.0);
+        Assert.assertEquals(Integer.class, degreeRangeFilter.getRange().getRangeType());
+        GraphView view2 = filterController.filter(degreeQuery);
+        Assert.assertNotNull(view2);
+
+        //Stopping the timeline should only remove the Dynamic Range subquery, not the whole query
+        timelineController.setInterval(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        Assert.assertSame(degreeQuery, filterModel.getCurrentQuery());
+        Assert.assertEquals(0, degreeQuery.getChildren().length);
+
+        filterController.filterVisible(null);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #3025.

`TimelineControllerImpl.applyIntervalFilter()` locates the "Time Interval" (`DynamicRangeFilter`) query via `Query.getQueries(DynamicRangeFilter.class)`, which correctly walks the query tree and returns the matching descendant query. However, the code then discarded that result and always wrote the new interval onto the **root** query's filter (`dynamicQuery = query`) instead of the actually matched query.

When "Time Interval" is used as the root filter this happens to be harmless (root == the matched query), but when it's added as a **subquery** of another filter (e.g. Degree Range, as in the bug report), this injects a `Double`-typed `Range(from, to)` with `null` min/max directly into the *other* filter's `range` property. On the next filter pass, `FilterProcessor.init()` sees this corrupted range and throws:

```
java.lang.IllegalArgumentException: Lower and upper must be the same class
	at org.gephi.filters.api.Range.<init>(Range.java:75)
	...
	at org.gephi.filters.FilterProcessor.init(FilterProcessor.java:254)
```

The same root-cause bug also explains the reported hang after stopping the timeline: disabling the interval called `filterController.remove(dynamicQuery)`, which resolves to the query's root and removes the **entire** query tree (e.g. both Degree Range and Time Interval) instead of just the Time Interval subquery.

### Fix
- Use the actual matched `Query` (`dynamicQueries[0]`) when setting the interval on the filter's `range` property, while still using the root query for `filterVisible`/`selectVisible` (so the whole composed query keeps being applied).
- When disabling the timeline, only remove the Time Interval subquery via `removeSubQuery()` if it has a parent, instead of always removing the whole root query.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no, because they aren't needed