### PR TITLE
Fix StatisticsModelUI.getRunning comparing a Class to a Statistics instance

### DIFF
--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
@@ -129,7 +129,7 @@ public class StatisticsModelUIImpl implements StatisticsModelUI {
     @Override
     public Statistics getRunning(StatisticsUI statisticsUI) {
         for (Statistics s : runningList.toArray(new Statistics[0])) {
-            if (statisticsUI.getStatisticsClass().equals(s)) {
+            if (statisticsUI.getStatisticsClass().equals(s.getClass())) {
                 return s;
             }
         }

--- a/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsModelUIImplTest.java
+++ b/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsModelUIImplTest.java
@@ -1,0 +1,130 @@
+package org.gephi.desktop.statistics;
+
+import javax.swing.JPanel;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.statistics.spi.Statistics;
+import org.gephi.statistics.spi.StatisticsUI;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Checks that {@link StatisticsModelUIImpl#getRunning(StatisticsUI)} finds the running
+ * {@link Statistics} instance by comparing its class to the {@link StatisticsUI}'s class, the
+ * same way {@link StatisticsModelUIImpl#isRunning(StatisticsUI)} does, instead of comparing the
+ * class to the instance itself.
+ */
+public class StatisticsModelUIImplTest {
+
+    @Test
+    public void testGetRunningReturnsSameInstanceWhileRunning() {
+        StatisticsModelUIImpl model = new StatisticsModelUIImpl(null);
+        Statistics statistics = new StubStatistics();
+        StatisticsUI ui = new StubStatisticsUI(StubStatistics.class);
+
+        model.setRunning(statistics, true);
+
+        Assert.assertSame(statistics, model.getRunning(ui));
+        Assert.assertTrue(model.isRunning(ui));
+    }
+
+    @Test
+    public void testGetRunningReturnsNullOnceStopped() {
+        StatisticsModelUIImpl model = new StatisticsModelUIImpl(null);
+        Statistics statistics = new StubStatistics();
+        StatisticsUI ui = new StubStatisticsUI(StubStatistics.class);
+
+        model.setRunning(statistics, true);
+        model.setRunning(statistics, false);
+
+        Assert.assertNull(model.getRunning(ui));
+        Assert.assertFalse(model.isRunning(ui));
+    }
+
+    @Test
+    public void testGetRunningReturnsNullForAnUnrelatedClass() {
+        StatisticsModelUIImpl model = new StatisticsModelUIImpl(null);
+        Statistics statistics = new StubStatistics();
+        StatisticsUI otherUi = new StubStatisticsUI(OtherStatistics.class);
+
+        model.setRunning(statistics, true);
+
+        Assert.assertNull(model.getRunning(otherUi));
+        Assert.assertFalse(model.isRunning(otherUi));
+    }
+
+    public static class StubStatistics implements Statistics {
+
+        @Override
+        public void execute(GraphModel graphModel) {
+        }
+
+        @Override
+        public String getReport() {
+            return null;
+        }
+    }
+
+    public static class OtherStatistics implements Statistics {
+
+        @Override
+        public void execute(GraphModel graphModel) {
+        }
+
+        @Override
+        public String getReport() {
+            return null;
+        }
+    }
+
+    public static class StubStatisticsUI implements StatisticsUI {
+
+        private final Class<? extends Statistics> statisticsClass;
+
+        public StubStatisticsUI(Class<? extends Statistics> statisticsClass) {
+            this.statisticsClass = statisticsClass;
+        }
+
+        @Override
+        public JPanel getSettingsPanel() {
+            return null;
+        }
+
+        @Override
+        public void setup(Statistics statistics) {
+        }
+
+        @Override
+        public void unsetup() {
+        }
+
+        @Override
+        public Class<? extends Statistics> getStatisticsClass() {
+            return statisticsClass;
+        }
+
+        @Override
+        public String getValue() {
+            return null;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Stub";
+        }
+
+        @Override
+        public String getShortDescription() {
+            return "Stub";
+        }
+
+        @Override
+        public String getCategory() {
+            return StatisticsUI.CATEGORY_NETWORK_OVERVIEW;
+        }
+
+        @Override
+        public int getPosition() {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Description

`StatisticsModelUIImpl.getRunning(StatisticsUI)` compared `statisticsUI.getStatisticsClass()` (a `Class<? extends Statistics>`) directly against a running `Statistics` **instance**:

```java
if (statisticsUI.getStatisticsClass().equals(s)) {
```

`Class.equals(Object)` is identity comparison inherited from `Object`, and a `Class` object is never equal to an instance of that class. So this condition is always `false`, and `getRunning` always returns `null`.

Compare with the sibling `isRunning(StatisticsUI)` a few lines above, which gets it right:

```java
if (statisticsUI.getStatisticsClass().equals(s.getClass())) {
```

The fix makes `getRunning` compare against `s.getClass()`, matching `isRunning`.

### User-visible consequence

`StatisticsFrontEnd.refreshModel(StatisticsModelUI)` is the recovery path used when a `StatisticsFrontEnd` is rebuilt while a statistics algorithm is still running. In that case its `currentStatistics` field is `null`, so it tries to recover the running instance via `currentModel.getRunning(statisticsUI)`. Because `getRunning` always returned `null`, `currentStatistics` stayed `null`. Then `cancel()`, which only acts when `currentStatistics != null && currentStatistics instanceof LongTask`, silently did nothing. Concretely: the row shows a "Cancel" button, the user clicks it, and nothing happens.

Spotted during review of #3265.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

`getRunning` is declared on the public `org.gephi.desktop.statistics.api.StatisticsModelUI` interface, but only its buggy behaviour changes here — no signature change — so no API changelog entry is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)