### PR TITLE
#3084 Apply edges merge strategy to dynamic edge weight merges

### DIFF
--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AbstractProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AbstractProcessor.java
@@ -45,7 +45,9 @@ package org.gephi.io.processor.plugin;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.awt.Color;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.gephi.graph.api.Column;
 import org.gephi.graph.api.Configuration;
@@ -86,6 +88,7 @@ public abstract class AbstractProcessor implements Processor, LongTask {
 
     private final Set<Column> columnsTypeMismatchAlreadyWarned = new HashSet<>();
     private final Object2IntOpenHashMap<Edge> edgeCountForAverage = new Object2IntOpenHashMap<>();
+    private final Map<Edge, Object2IntOpenHashMap<Object>> dynamicWeightCountForAverage = new HashMap<>();
     protected ProgressTicket progressTicket;
     protected Workspace workspace;
     protected ContainerUnloader[] containers;
@@ -99,6 +102,7 @@ public abstract class AbstractProcessor implements Processor, LongTask {
         progressTicket = null;
         columnsTypeMismatchAlreadyWarned.clear();
         edgeCountForAverage.clear();
+        dynamicWeightCountForAverage.clear();
     }
 
     protected int calculateWorkUnits() {
@@ -388,8 +392,18 @@ public abstract class AbstractProcessor implements Processor, LongTask {
                     Object[] vals1 = valMap.toValuesArray();
 
                     for (int i = 0; i < keys1.length; i++) {
+                        Object key = keys1[i];
+                        double newVal = ((Number) vals1[i]).doubleValue();
+
                         try {
-                            newMap.put(keys1[i], ((Number) vals1[i]).doubleValue());
+                            if (newMap.contains(key)) {
+                                //Same timestamp/interval already set by a previously merged edge:
+                                //apply the edges merge strategy instead of silently overwriting it.
+                                double existingVal = ((Number) newMap.get(key, 0d)).doubleValue();
+                                newMap.put(key, mergeDynamicWeightValue(edge, key, existingVal, newVal));
+                            } else {
+                                newMap.put(key, newVal);
+                            }
                         } catch (IllegalArgumentException e) {
                             //Overlapping intervals, ignore
                         }
@@ -429,6 +443,28 @@ public abstract class AbstractProcessor implements Processor, LongTask {
             }
 
             edge.setWeight(result);
+        }
+    }
+
+    private double mergeDynamicWeightValue(Edge edge, Object key, double existingVal, double newVal) {
+        switch (containers[0].getEdgesMergeStrategy()) {
+            case AVG:
+                Object2IntOpenHashMap<Object> counts =
+                    dynamicWeightCountForAverage.computeIfAbsent(edge, e -> new Object2IntOpenHashMap<>());
+                counts.addTo(key, 1);
+                int keyCount = counts.getInt(key);
+                return (existingVal * keyCount + newVal) / (keyCount + 1);
+            case MAX:
+                return Math.max(existingVal, newVal);
+            case MIN:
+                return Math.min(existingVal, newVal);
+            case SUM:
+                return existingVal + newVal;
+            case FIRST:
+                return existingVal;
+            case LAST:
+            default:
+                return newVal;
         }
     }
 

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DynamicEdgeWeightTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DynamicEdgeWeightTest.java
@@ -6,6 +6,7 @@ import org.gephi.graph.api.Configuration;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.TimeRepresentation;
 import org.gephi.graph.api.types.TimestampDoubleMap;
+import org.gephi.io.importer.api.EdgeMergeStrategy;
 import org.gephi.io.importer.impl.EdgeDraftImpl;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,5 +66,42 @@ public class DynamicEdgeWeightTest {
 
         Assert.assertEquals(Collections.EMPTY_LIST, processor.getReport().getIssuesList(100));
         Assert.assertEquals(5.0, edge.getWeight(1.0), 0.0);
+    }
+
+    @Test
+    public void testMergeWeightSameTimestampSumStrategy() {
+        edge.setWeight(1.0, 1.0);
+        processor.getContainer().addEdgeColumn("weight", Double.class, true);
+        edgeDraft.setValue("weight", new TimestampDoubleMap(new double[] {1.0}, new double[] {1.1}));
+
+        processor.flushEdgeWeight(processor.getContainer(), edgeDraft, edge, false);
+
+        Assert.assertEquals(Collections.EMPTY_LIST, processor.getReport().getIssuesList(100));
+        Assert.assertEquals(2.1, edge.getWeight(1.0), 0.0001);
+    }
+
+    @Test
+    public void testMergeWeightSameTimestampMaxStrategy() {
+        edge.setWeight(5.0, 1.0);
+        processor.getContainer().addEdgeColumn("weight", Double.class, true);
+        processor.getContainer().setEdgesMergeStrategy(EdgeMergeStrategy.MAX);
+        edgeDraft.setValue("weight", new TimestampDoubleMap(new double[] {1.0}, new double[] {3.0}));
+
+        processor.flushEdgeWeight(processor.getContainer(), edgeDraft, edge, false);
+
+        Assert.assertEquals(5.0, edge.getWeight(1.0), 0.0);
+    }
+
+    @Test
+    public void testMergeWeightSameTimestampAvgStrategyWithThree() {
+        edge.setWeight(4.0, 1.0);
+        processor.getContainer().addEdgeColumn("weight", Double.class, true);
+        processor.getContainer().setEdgesMergeStrategy(EdgeMergeStrategy.AVG);
+        edgeDraft.setValue("weight", new TimestampDoubleMap(new double[] {1.0}, new double[] {10.0}));
+
+        processor.flushEdgeWeight(processor.getContainer(), edgeDraft, edge, false);
+        processor.flushEdgeWeight(processor.getContainer(), edgeDraft, edge, false);
+
+        Assert.assertEquals(24.0 / 3, edge.getWeight(1.0), 0.0);
     }
 }


### PR DESCRIPTION
## Description

Fixes #3084.

When two rows in an import (e.g. CSV/spreadsheet or GEXF) share the same source/target and get merged into one edge, and the `weight` column is **dynamic** (a timestamp/interval → value map), overlapping timestamps/intervals were merged by blindly overwriting the existing value with the new one in `AbstractProcessor.flushEdgeWeight()`. This completely ignored the configured "Edges merge strategy" (Sum/Avg/Min/Max/First/Last), which was only ever applied to the *static* weight case.

For example, importing two edges 0→1 both carrying a dynamic weight value at the same timestamp (`2001.2`) — `1.0` and `1.1` — produced `1.1` (last write wins) instead of the expected `2.1` under the default Sum strategy.

The fix detects when a timestamp/interval key already exists in the merged map and applies the same merge-strategy logic already used for static weight, instead of overwriting. AVG required a small per-(edge, key) running counter, mirrored from the existing per-edge counter used for the static AVG case.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no, because they aren't needed