### PR TITLE
Fix crash when entering edit mode races with a queued empty selection update

### DIFF
--- a/modules/DesktopAttributes/pom.xml
+++ b/modules/DesktopAttributes/pom.xml
@@ -79,6 +79,11 @@
 
 
         <!-- Test only -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesUIControllerImpl.java
+++ b/modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesUIControllerImpl.java
@@ -262,7 +262,7 @@ public class AttributesUIControllerImpl implements AttributesUIController, Contr
         AttributesUIModelImpl model = getModel();
         if (model != null && !model.isEditMode()) {
             runAction(() -> {
-                if (model == getModel()) {
+                if (model == getModel() && !model.isEditMode()) {
                     setSelectedNodes(nodes);
                 }
             });

--- a/modules/DesktopAttributes/src/test/java/org/gephi/desktop/attributes/AttributesUIControllerImplTest.java
+++ b/modules/DesktopAttributes/src/test/java/org/gephi/desktop/attributes/AttributesUIControllerImplTest.java
@@ -1,0 +1,72 @@
+package org.gephi.desktop.attributes;
+
+import java.util.concurrent.CountDownLatch;
+import javax.swing.SwingUtilities;
+import org.gephi.graph.api.Node;
+import org.gephi.project.api.Project;
+import org.gephi.project.api.ProjectController;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openide.util.Lookup;
+
+/**
+ * Regression test for the race between {@link AttributesUIControllerImpl#selectNodes(Node[])}
+ * and edit mode. VizController's MOUSE_MOVE handler calls selectNodes with an empty array from
+ * outside the EDT whenever nothing is under the cursor; the call is deferred with
+ * SwingUtilities.invokeLater. If the user enters edit mode with a real selection while that
+ * deferred call is still queued, it must not overwrite the real selection with the stale empty
+ * array once it finally runs.
+ */
+public class AttributesUIControllerImplTest {
+
+    private AttributesUIControllerImpl controller;
+    private AttributesUIModelImpl model;
+
+    @Before
+    public void setUp() {
+        ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
+        Project project = pc.newProject();
+        model = project.getCurrentWorkspace().getLookup().lookup(AttributesUIModelImpl.class);
+        controller = new AttributesUIControllerImpl();
+    }
+
+    @After
+    public void tearDown() {
+        Lookup.getDefault().lookup(ProjectController.class).closeCurrentProject();
+    }
+
+    @Test
+    public void testDeferredEmptySelectionDoesNotOverwriteLaterEditModeSelection() throws Exception {
+        Node node = Mockito.mock(Node.class);
+        CountDownLatch blockEdt = new CountDownLatch(1);
+
+        // Hold the EDT so the callback queued by selectNodes() below cannot run until we release it.
+        SwingUtilities.invokeLater(() -> {
+            try {
+                blockEdt.await();
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Like VizController's MOUSE_MOVE handler: call selectNodes with an empty array from
+        // outside the EDT while not in edit mode. The guard passes and a deferred callback is queued.
+        Thread mouseMove = new Thread(() -> controller.selectNodes(new Node[0]));
+        mouseMove.start();
+        mouseMove.join();
+
+        // The user enters edit mode with a real selection before that deferred callback runs.
+        model.setEditMode(true);
+        model.setSelectedNodes(new Node[] {node});
+
+        // Release the EDT so the queued callback finally runs, then flush the queue.
+        blockEdt.countDown();
+        SwingUtilities.invokeAndWait(() -> {
+        });
+
+        Assert.assertArrayEquals(new Node[] {node}, model.getSelectedNodes());
+    }
+}


### PR DESCRIPTION
## Description

Affects 16 users / 85 events in production (Sentry `GEPHI-5VZ`).

`VizController.enableMouseHandler()`'s `MOUSE_MOVE` listener (`modules/VisualizationImpl/src/main/java/org/gephi/visualization/VizController.java:106-117`) calls `attributesUIController.selectNodes(selectedNodes.toArray(new Node[0]))` on every mouse move over the canvas, from a thread other than the EDT, passing an empty array whenever nothing is under the cursor.

In `AttributesUIControllerImpl.selectNodes()` (`modules/DesktopAttributes/src/main/java/org/gephi/desktop/attributes/AttributesUIControllerImpl.java:261-271`), the edit-mode guard is only checked *before* deferring the update with `SwingUtilities.invokeLater` (line 263). The deferred lambda re-checked that the workspace model hadn't changed (`model == getModel()`) but never re-checked `isEditMode()`. So the sequence is:

1. Mouse moves over empty canvas while not in edit mode: `selectNodes(new Node[0])` passes the guard and queues a callback on the EDT.
2. Before that callback runs, the user double-clicks a node. `editNode()` runs synchronously on the EDT, setting edit mode and the real selection.
3. The stale queued callback from step 1 now runs. It only checks that the model is the same, so it overwrites the real selection with the empty array and fires a `SELECTED_ELEMENTS` change.
4. `AttributesTopComponent.propertyChange` → `refreshSelection()` sees edit mode is on and calls `EditPanel.refreshSelected()` → `editNodes(nodes)`, which only checks `nodes != null` (`EditPanel.java:69-73`), not emptiness.
5. `EditNodes`'s constructor unconditionally does `nodes[0]` when there's not more than one node (`EditNodes.java:104-108`), throwing on the zero-length array.

<details>
<summary>Stack trace (GEPHI-5VZ)</summary>

```
ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
at java.awt.EventDispatchThread.run(Unknown Source)
at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
at java.awt.EventDispatchThread.pumpEventsForHierarchy(Unknown Source)
at java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
at java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
at org.netbeans.core.TimableEventQueue.dispatchEvent(TimableEventQueue.java:136)
at java.awt.EventQueue.dispatchEvent(Unknown Source)
at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
at java.security.AccessController.doPrivileged(Unknown Source)
at java.awt.EventQueue$4.run(Unknown Source)
at java.awt.EventQueue$4.run(Unknown Source)
at java.awt.EventQueue.dispatchEventImpl(Unknown Source)
at java.awt.event.InvocationEvent.dispatch(Unknown Source)
at org.gephi.desktop.attributes.AttributesUIControllerImpl.lambda$selectNodes$9(AttributesUIControllerImpl.java:266)
at org.gephi.desktop.attributes.AttributesUIControllerImpl.setSelectedNodes(AttributesUIControllerImpl.java:149)
at org.gephi.desktop.attributes.AttributesUIControllerImpl.firePropertyChangeEvent(AttributesUIControllerImpl.java:295)
at org.gephi.desktop.attributes.AttributesTopComponent.propertyChange(AttributesTopComponent.java:112)
at org.gephi.desktop.attributes.AttributesTopComponent.refreshSelection(AttributesTopComponent.java:129)
at org.gephi.desktop.attributes.edit.EditPanel.refreshSelected(EditPanel.java:71)
at org.gephi.desktop.attributes.edit.EditPanel.editNodes(EditPanel.java:85)
at org.gephi.desktop.attributes.edit.EditNodes.<init>(EditNodes.java:108)
```

</details>

### Fix

Re-check `!model.isEditMode()` inside the deferred lambda in `selectNodes()` (`AttributesUIControllerImpl.java:265`), alongside the existing `model == getModel()` check. This closes the actual race window (a stale selection update applying after edit mode has already changed) rather than patching the symptom in `EditPanel`/`EditNodes`, and matches the existing style of that guard (it was already re-checking one piece of state that can change while the callback is queued; it just wasn't re-checking all of it).

Sentry issue: https://gephi.sentry.io/issues/GEPHI-5VZ

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

Added `AttributesUIControllerImplTest` (`modules/DesktopAttributes/src/test/java/org/gephi/desktop/attributes/AttributesUIControllerImplTest.java`), which deterministically reproduces the race: it blocks the EDT, queues an empty-selection callback from a background thread while not in edit mode (mirroring the mouse handler), switches the model into edit mode with a real selection while that callback is still queued, then releases the EDT and asserts the real selection survives. It fails against the pre-fix code with the exact same empty-array outcome, and passes with the fix.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed