### PR TITLE
#2998 Fix GEXF export crash on invalid XML control characters

### DIFF
--- a/modules/ExportPlugin/pom.xml
+++ b/modules/ExportPlugin/pom.xml
@@ -56,11 +56,6 @@
             <artifactId>org-netbeans-core-startup</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.woodstox</groupId>
-            <artifactId>woodstox-core</artifactId><!-- Needed for XML 1.1 output (control character escaping) -->
-            <version>${gephi.woodstox.version}</version>
-        </dependency>
 
         <!-- Tests -->
         <dependency>
@@ -73,6 +68,15 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
             <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Used in tests to exercise the same strict XMLStreamWriter (Woodstox) that the desktop app
+             resolves at runtime (via ImportPlugin's Apache POI dependency), since the JDK's bundled
+             StAX implementation does not validate characters the way Woodstox does. -->
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${gephi.woodstox.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/ExportPlugin/pom.xml
+++ b/modules/ExportPlugin/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>org-netbeans-core-startup</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId><!-- Needed for XML 1.1 output (control character escaping) -->
+            <version>${gephi.woodstox.version}</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>
@@ -68,15 +73,6 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
             <version>2.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- Used in tests to exercise the same strict XMLStreamWriter (Woodstox) that the desktop app
-             resolves at runtime (via ImportPlugin's Apache POI dependency), since the JDK's bundled
-             StAX implementation does not validate characters the way Woodstox does. -->
-        <dependency>
-            <groupId>com.fasterxml.woodstox</groupId>
-            <artifactId>woodstox-core</artifactId>
-            <version>${gephi.woodstox.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/ExportPlugin/pom.xml
+++ b/modules/ExportPlugin/pom.xml
@@ -14,6 +14,10 @@
 
     <name>ExportPlugin</name>
 
+    <properties>
+        <gephi.woodstox.version>6.4.0</gephi.woodstox.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -64,6 +68,15 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
             <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Used in tests to exercise the same strict XMLStreamWriter (Woodstox) that the desktop app
+             resolves at runtime (via ImportPlugin's Apache POI dependency), since the JDK's bundled
+             StAX implementation does not validate characters the way Woodstox does. -->
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${gephi.woodstox.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGEXF.java
+++ b/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGEXF.java
@@ -186,7 +186,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
             XMLStreamWriter xmlWriter = outputFactory.createXMLStreamWriter(writer);
             xmlWriter = new IndentingXMLStreamWriter(xmlWriter);
 
-            xmlWriter.writeStartDocument("UTF-8", "1.0");
+            xmlWriter.writeStartDocument("UTF-8", "1.1");
             xmlWriter.setPrefix("", GEXF_NAMESPACE);
             xmlWriter.writeStartElement(GEXF_NAMESPACE, GEXF);
             xmlWriter.writeNamespace("", GEXF_NAMESPACE);

--- a/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGEXF.java
+++ b/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGEXF.java
@@ -80,6 +80,7 @@ import org.gephi.io.exporter.spi.CharacterExporter;
 import org.gephi.io.exporter.spi.GraphExporter;
 import org.gephi.project.api.Workspace;
 import org.gephi.utils.VersionUtils;
+import org.gephi.utils.XmlUtils;
 import org.gephi.utils.longtask.spi.LongTask;
 import org.gephi.utils.progress.Progress;
 import org.gephi.utils.progress.ProgressTicket;
@@ -258,11 +259,12 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
             xmlWriter.writeEndElement();
 
             xmlWriter.writeStartElement(META_TITLE);
-            xmlWriter.writeCharacters(workspace.getWorkspaceMetadata().getTitle());
+            xmlWriter.writeCharacters(XmlUtils.stripInvalidXmlChars(workspace.getWorkspaceMetadata().getTitle()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeStartElement(META_DESCRIPTION);
-            xmlWriter.writeCharacters(workspace.getWorkspaceMetadata().getDescription());
+            xmlWriter
+                .writeCharacters(XmlUtils.stripInvalidXmlChars(workspace.getWorkspaceMetadata().getDescription()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeEndElement();
@@ -305,7 +307,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
 
             xmlWriter.writeStartElement(ATTRIBUTE);
             xmlWriter.writeAttribute(ATTRIBUTE_ID, col.getId());
-            xmlWriter.writeAttribute(ATTRIBUTE_TITLE, col.getTitle());
+            xmlWriter.writeAttribute(ATTRIBUTE_TITLE, XmlUtils.stripInvalidXmlChars(col.getTitle()));
 
             if (col.isArray()) {
                 xmlWriter.writeAttribute(ATTRIBUTE_TYPE,
@@ -325,7 +327,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
                 } else {
                     valString = col.getDefaultValue().toString();
                 }
-                xmlWriter.writeCharacters(valString);
+                xmlWriter.writeCharacters(XmlUtils.stripInvalidXmlChars(valString));
                 xmlWriter.writeEndElement();
             }
             xmlWriter.writeEndElement();
@@ -347,7 +349,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
             String id = node.getId().toString();
             xmlWriter.writeAttribute(NODE_ID, id);
             if (node.getLabel() != null && !node.getLabel().isEmpty()) {
-                xmlWriter.writeAttribute(NODE_LABEL, node.getLabel());
+                xmlWriter.writeAttribute(NODE_LABEL, XmlUtils.stripInvalidXmlChars(node.getLabel()));
             }
 
             if (exportDynamic) {
@@ -383,7 +385,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
         if(column.isNumber()) {
             return replaceInfinity(AttributeUtils.print(val));
         } else {
-            return AttributeUtils.print(val);
+            return XmlUtils.stripInvalidXmlChars(AttributeUtils.print(val));
         }
     }
 
@@ -594,7 +596,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
 
             String label = edge.getLabel();
             if (label != null && !label.isEmpty()) {
-                xmlWriter.writeAttribute(EDGE_LABEL, label);
+                xmlWriter.writeAttribute(EDGE_LABEL, XmlUtils.stripInvalidXmlChars(label));
             }
 
             if (edge.getType() != 0) {

--- a/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGEXF.java
+++ b/modules/ExportPlugin/src/main/java/org/gephi/io/exporter/plugin/ExporterGEXF.java
@@ -161,6 +161,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
     private boolean exportMeta = true;
     private boolean includeNullAttValues = false;
     private NormalizationHelper normalization;
+    private boolean strippedInvalidCharacters = false;
 
     @Override
     public boolean execute() {
@@ -179,6 +180,8 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
 
         Progress.switchToDeterminate(progress, graph.getNodeCount() + graph.getEdgeCount());
 
+        strippedInvalidCharacters = false;
+
         try {
             XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
             outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.FALSE);
@@ -186,7 +189,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
             XMLStreamWriter xmlWriter = outputFactory.createXMLStreamWriter(writer);
             xmlWriter = new IndentingXMLStreamWriter(xmlWriter);
 
-            xmlWriter.writeStartDocument("UTF-8", "1.1");
+            xmlWriter.writeStartDocument("UTF-8", "1.0");
             xmlWriter.setPrefix("", GEXF_NAMESPACE);
             xmlWriter.writeStartElement(GEXF_NAMESPACE, GEXF);
             xmlWriter.writeNamespace("", GEXF_NAMESPACE);
@@ -205,6 +208,11 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
             xmlWriter.writeEndDocument();
             xmlWriter.close();
 
+            if (strippedInvalidCharacters) {
+                Logger.getLogger(ExporterGEXF.class.getName()).log(Level.WARNING,
+                    "Some labels or attribute values contained characters not allowed in XML "
+                        + "(e.g. control characters) and were removed from the exported file.");
+            }
         } catch (Exception e) {
             Logger.getLogger(ExporterGEXF.class.getName()).log(Level.SEVERE, null, e);
         } finally {
@@ -259,12 +267,12 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
             xmlWriter.writeEndElement();
 
             xmlWriter.writeStartElement(META_TITLE);
-            xmlWriter.writeCharacters(XmlUtils.stripInvalidXmlChars(workspace.getWorkspaceMetadata().getTitle()));
+            xmlWriter.writeCharacters(sanitize(workspace.getWorkspaceMetadata().getTitle()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeStartElement(META_DESCRIPTION);
             xmlWriter
-                .writeCharacters(XmlUtils.stripInvalidXmlChars(workspace.getWorkspaceMetadata().getDescription()));
+                .writeCharacters(sanitize(workspace.getWorkspaceMetadata().getDescription()));
             xmlWriter.writeEndElement();
 
             xmlWriter.writeEndElement();
@@ -307,7 +315,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
 
             xmlWriter.writeStartElement(ATTRIBUTE);
             xmlWriter.writeAttribute(ATTRIBUTE_ID, col.getId());
-            xmlWriter.writeAttribute(ATTRIBUTE_TITLE, XmlUtils.stripInvalidXmlChars(col.getTitle()));
+            xmlWriter.writeAttribute(ATTRIBUTE_TITLE, sanitize(col.getTitle()));
 
             if (col.isArray()) {
                 xmlWriter.writeAttribute(ATTRIBUTE_TYPE,
@@ -327,7 +335,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
                 } else {
                     valString = col.getDefaultValue().toString();
                 }
-                xmlWriter.writeCharacters(XmlUtils.stripInvalidXmlChars(valString));
+                xmlWriter.writeCharacters(sanitize(valString));
                 xmlWriter.writeEndElement();
             }
             xmlWriter.writeEndElement();
@@ -349,7 +357,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
             String id = node.getId().toString();
             xmlWriter.writeAttribute(NODE_ID, id);
             if (node.getLabel() != null && !node.getLabel().isEmpty()) {
-                xmlWriter.writeAttribute(NODE_LABEL, XmlUtils.stripInvalidXmlChars(node.getLabel()));
+                xmlWriter.writeAttribute(NODE_LABEL, sanitize(node.getLabel()));
             }
 
             if (exportDynamic) {
@@ -385,7 +393,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
         if(column.isNumber()) {
             return replaceInfinity(AttributeUtils.print(val));
         } else {
-            return XmlUtils.stripInvalidXmlChars(AttributeUtils.print(val));
+            return sanitize(AttributeUtils.print(val));
         }
     }
 
@@ -596,7 +604,7 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
 
             String label = edge.getLabel();
             if (label != null && !label.isEmpty()) {
-                xmlWriter.writeAttribute(EDGE_LABEL, XmlUtils.stripInvalidXmlChars(label));
+                xmlWriter.writeAttribute(EDGE_LABEL, sanitize(label));
             }
 
             if (edge.getType() != 0) {
@@ -651,6 +659,14 @@ public class ExporterGEXF implements GraphExporter, CharacterExporter, LongTask 
 
     private static String replaceInfinity(String str) {
         return str.replace("-Infinity", "-INF").replace("Infinity", "INF");
+    }
+
+    private String sanitize(String str) {
+        String result = XmlUtils.stripInvalidXmlChars(str);
+        if (result != str) {
+            strippedInvalidCharacters = true;
+        }
+        return result;
     }
 
     @Override

--- a/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/GEXFTest.java
+++ b/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/GEXFTest.java
@@ -2,7 +2,9 @@ package org.gephi.io.exporter.plugin;
 
 import java.io.IOException;
 import org.gephi.graph.GraphGenerator;
+import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.Node;
 import org.gephi.project.api.Workspace;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,6 +47,24 @@ public class GEXFTest {
         Assert.assertTrue(str.contains("<meta "));
         Assert.assertTrue(str.contains("<title>title</title>"));
         Assert.assertTrue(str.contains("<description>desc</description>"));
+    }
+
+    @Test
+    public void testInvalidXmlCharsAreStripped() throws IOException {
+        GraphGenerator graphGenerator = GraphGenerator.build().generateTinyGraph().addStringNodeColumn();
+        Graph graph = graphGenerator.getGraph();
+
+        Node node = graph.getNode(GraphGenerator.FIRST_NODE);
+        node.setLabel("foo\bbar");
+        node.setAttribute(GraphGenerator.STRING_COLUMN, "baz\bqux");
+        Edge edge = graph.getEdge(GraphGenerator.FIRST_EDGE);
+        edge.setLabel("edge\blabel");
+
+        String str = Utils.toString(createExporter(graphGenerator));
+        Assert.assertFalse(str.contains("\b"));
+        Assert.assertTrue(str.contains("label=\"foobar\""));
+        Assert.assertTrue(str.contains("value=\"bazqux\""));
+        Assert.assertTrue(str.contains("label=\"edgelabel\""));
     }
 
     private static ExporterGEXF createExporter(GraphGenerator graphGenerator) {

--- a/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/GEXFTest.java
+++ b/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/GEXFTest.java
@@ -1,6 +1,8 @@
 package org.gephi.io.exporter.plugin;
 
 import java.io.IOException;
+import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.gephi.graph.GraphGenerator;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
@@ -8,6 +10,10 @@ import org.gephi.graph.api.Node;
 import org.gephi.project.api.Workspace;
 import org.junit.Assert;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 public class GEXFTest {
 
@@ -50,7 +56,7 @@ public class GEXFTest {
     }
 
     @Test
-    public void testInvalidXmlCharsAreStripped() throws IOException {
+    public void testControlCharsInLabelsAndAttValuesArePreserved() throws Exception {
         GraphGenerator graphGenerator = GraphGenerator.build().generateTinyGraph().addStringNodeColumn();
         Graph graph = graphGenerator.getGraph();
 
@@ -61,10 +67,38 @@ public class GEXFTest {
         edge.setLabel("edge\blabel");
 
         String str = Utils.toString(createExporter(graphGenerator));
-        Assert.assertFalse(str.contains("\b"));
+        Document doc = parse(str);
+
+        Assert.assertEquals("foo\bbar", findById(doc, "node", "1").getAttribute("label"));
+        Assert.assertEquals("edge\blabel", findById(doc, "edge", "1").getAttribute("label"));
+        Element attvalue = (Element) findById(doc, "node", "1").getElementsByTagName("attvalue").item(0);
+        Assert.assertEquals("baz\bqux", attvalue.getAttribute("value"));
+    }
+
+    @Test
+    public void testNullCharacterIsStripped() throws IOException {
+        GraphGenerator graphGenerator = GraphGenerator.build().generateTinyGraph();
+        Graph graph = graphGenerator.getGraph();
+        graph.getNode(GraphGenerator.FIRST_NODE).setLabel("foo\0bar");
+
+        String str = Utils.toString(createExporter(graphGenerator));
+        Assert.assertFalse(str.contains("\0"));
         Assert.assertTrue(str.contains("label=\"foobar\""));
-        Assert.assertTrue(str.contains("value=\"bazqux\""));
-        Assert.assertTrue(str.contains("label=\"edgelabel\""));
+    }
+
+    private static Document parse(String xml) throws Exception {
+        return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+    }
+
+    private static Element findById(Document doc, String tagName, String id) {
+        NodeList elements = doc.getElementsByTagName(tagName);
+        for (int i = 0; i < elements.getLength(); i++) {
+            Element element = (Element) elements.item(i);
+            if (id.equals(element.getAttribute("id"))) {
+                return element;
+            }
+        }
+        throw new AssertionError("No <" + tagName + "> element with id=" + id);
     }
 
     private static ExporterGEXF createExporter(GraphGenerator graphGenerator) {

--- a/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/GEXFTest.java
+++ b/modules/ExportPlugin/src/test/java/org/gephi/io/exporter/plugin/GEXFTest.java
@@ -1,8 +1,6 @@
 package org.gephi.io.exporter.plugin;
 
 import java.io.IOException;
-import java.io.StringReader;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.gephi.graph.GraphGenerator;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.Graph;
@@ -10,10 +8,6 @@ import org.gephi.graph.api.Node;
 import org.gephi.project.api.Workspace;
 import org.junit.Assert;
 import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
 
 public class GEXFTest {
 
@@ -56,49 +50,22 @@ public class GEXFTest {
     }
 
     @Test
-    public void testControlCharsInLabelsAndAttValuesArePreserved() throws Exception {
+    public void testInvalidXmlCharsAreStripped() throws IOException {
         GraphGenerator graphGenerator = GraphGenerator.build().generateTinyGraph().addStringNodeColumn();
         Graph graph = graphGenerator.getGraph();
 
         Node node = graph.getNode(GraphGenerator.FIRST_NODE);
         node.setLabel("foo\bbar");
-        node.setAttribute(GraphGenerator.STRING_COLUMN, "baz\bqux");
+        node.setAttribute(GraphGenerator.STRING_COLUMN, "baz\0qux");
         Edge edge = graph.getEdge(GraphGenerator.FIRST_EDGE);
         edge.setLabel("edge\blabel");
 
         String str = Utils.toString(createExporter(graphGenerator));
-        Document doc = parse(str);
-
-        Assert.assertEquals("foo\bbar", findById(doc, "node", "1").getAttribute("label"));
-        Assert.assertEquals("edge\blabel", findById(doc, "edge", "1").getAttribute("label"));
-        Element attvalue = (Element) findById(doc, "node", "1").getElementsByTagName("attvalue").item(0);
-        Assert.assertEquals("baz\bqux", attvalue.getAttribute("value"));
-    }
-
-    @Test
-    public void testNullCharacterIsStripped() throws IOException {
-        GraphGenerator graphGenerator = GraphGenerator.build().generateTinyGraph();
-        Graph graph = graphGenerator.getGraph();
-        graph.getNode(GraphGenerator.FIRST_NODE).setLabel("foo\0bar");
-
-        String str = Utils.toString(createExporter(graphGenerator));
+        Assert.assertFalse(str.contains("\b"));
         Assert.assertFalse(str.contains("\0"));
         Assert.assertTrue(str.contains("label=\"foobar\""));
-    }
-
-    private static Document parse(String xml) throws Exception {
-        return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
-    }
-
-    private static Element findById(Document doc, String tagName, String id) {
-        NodeList elements = doc.getElementsByTagName(tagName);
-        for (int i = 0; i < elements.getLength(); i++) {
-            Element element = (Element) elements.item(i);
-            if (id.equals(element.getAttribute("id"))) {
-                return element;
-            }
-        }
-        throw new AssertionError("No <" + tagName + "> element with id=" + id);
+        Assert.assertTrue(str.contains("value=\"bazqux\""));
+        Assert.assertTrue(str.contains("label=\"edgelabel\""));
     }
 
     private static ExporterGEXF createExporter(GraphGenerator graphGenerator) {

--- a/modules/Utils/src/main/java/org/gephi/utils/XmlUtils.java
+++ b/modules/Utils/src/main/java/org/gephi/utils/XmlUtils.java
@@ -1,0 +1,89 @@
+/*
+ Copyright 2008-2010 Gephi
+ Authors : Mathieu Bastian <mathieu.bastian@gephi.org>
+ Website : http://www.gephi.org
+
+ This file is part of Gephi.
+
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+ Copyright 2011 Gephi Consortium. All rights reserved.
+
+ The contents of this file are subject to the terms of either the GNU
+ General Public License Version 3 only ("GPL") or the Common
+ Development and Distribution License("CDDL") (collectively, the
+ "License"). You may not use this file except in compliance with the
+ License. You can obtain a copy of the License at
+ http://gephi.org/about/legal/license-notice/
+ or /cddl-1.0.txt and /gpl-3.0.txt. See the License for the
+ specific language governing permissions and limitations under the
+ License.  When distributing the software, include this License Header
+ Notice in each file and include the License files at
+ /cddl-1.0.txt and /gpl-3.0.txt. If applicable, add the following below the
+ License Header, with the fields enclosed by brackets [] replaced by
+ your own identifying information:
+ "Portions Copyrighted [year] [name of copyright owner]"
+
+ If you wish your version of this file to be governed by only the CDDL
+ or only the GPL Version 3, indicate your decision by adding
+ "[Contributor] elects to include this software in this distribution
+ under the [CDDL or GPL Version 3] license." If you do not indicate a
+ single choice of license, a recipient has the option to distribute
+ your version of this file under either the CDDL, the GPL Version 3 or
+ to extend the choice of license to its licensees as provided above.
+ However, if you add GPL Version 3 code and therefore, elected the GPL
+ Version 3 license, then the option applies only if the new code is
+ made subject to such option by the copyright holder.
+
+ Contributor(s):
+
+ Portions Copyrighted 2011 Gephi Consortium.
+ */
+
+package org.gephi.utils;
+
+/**
+ * Utility methods for producing well-formed XML.
+ */
+public class XmlUtils {
+
+    private XmlUtils() {
+    }
+
+    /**
+     * Removes characters that are not allowed in XML 1.0 documents (e.g. control characters such as
+     * backspace) from the given string, so it can be safely written by an XML writer.
+     *
+     * @param str string to sanitize, can be null
+     * @return the sanitized string, or the original string if it was already valid, or null if the input was null
+     */
+    public static String stripInvalidXmlChars(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        StringBuilder sb = null;
+        int len = str.length();
+        int i = 0;
+        while (i < len) {
+            int codePoint = str.codePointAt(i);
+            int charCount = Character.charCount(codePoint);
+            if (isValidXmlCodePoint(codePoint)) {
+                if (sb != null) {
+                    sb.appendCodePoint(codePoint);
+                }
+            } else if (sb == null) {
+                sb = new StringBuilder(len);
+                sb.append(str, 0, i);
+            }
+            i += charCount;
+        }
+        return sb != null ? sb.toString() : str;
+    }
+
+    private static boolean isValidXmlCodePoint(int c) {
+        return c == 0x9 || c == 0xA || c == 0xD
+            || (c >= 0x20 && c <= 0xD7FF)
+            || (c >= 0xE000 && c <= 0xFFFD)
+            || (c >= 0x10000 && c <= 0x10FFFF);
+    }
+}

--- a/modules/Utils/src/main/java/org/gephi/utils/XmlUtils.java
+++ b/modules/Utils/src/main/java/org/gephi/utils/XmlUtils.java
@@ -51,39 +51,21 @@ public class XmlUtils {
     }
 
     /**
-     * Removes characters that are not allowed in XML 1.0 documents (e.g. control characters such as
-     * backspace) from the given string, so it can be safely written by an XML writer.
+     * Removes the null character (U+0000) from the given string.
+     * <p>
+     * XML forbids the null character even as a numeric character reference, in both XML 1.0 and XML 1.1,
+     * so it is the only character that cannot be preserved when writing XML text or attribute values and
+     * must be dropped rather than escaped. Every other control character can be written as-is by an XML
+     * 1.1 writer, which escapes it to a character reference automatically instead of rejecting it.
      *
      * @param str string to sanitize, can be null
-     * @return the sanitized string, or the original string if it was already valid, or null if the input was null
+     * @return the sanitized string, or the original string if it did not contain a null character, or null
+     * if the input was null
      */
     public static String stripInvalidXmlChars(String str) {
-        if (str == null || str.isEmpty()) {
+        if (str == null || str.indexOf(0) == -1) {
             return str;
         }
-        StringBuilder sb = null;
-        int len = str.length();
-        int i = 0;
-        while (i < len) {
-            int codePoint = str.codePointAt(i);
-            int charCount = Character.charCount(codePoint);
-            if (isValidXmlCodePoint(codePoint)) {
-                if (sb != null) {
-                    sb.appendCodePoint(codePoint);
-                }
-            } else if (sb == null) {
-                sb = new StringBuilder(len);
-                sb.append(str, 0, i);
-            }
-            i += charCount;
-        }
-        return sb != null ? sb.toString() : str;
-    }
-
-    private static boolean isValidXmlCodePoint(int c) {
-        return c == 0x9 || c == 0xA || c == 0xD
-            || (c >= 0x20 && c <= 0xD7FF)
-            || (c >= 0xE000 && c <= 0xFFFD)
-            || (c >= 0x10000 && c <= 0x10FFFF);
+        return str.replace("\0", "");
     }
 }

--- a/modules/Utils/src/main/java/org/gephi/utils/XmlUtils.java
+++ b/modules/Utils/src/main/java/org/gephi/utils/XmlUtils.java
@@ -51,21 +51,43 @@ public class XmlUtils {
     }
 
     /**
-     * Removes the null character (U+0000) from the given string.
+     * Removes characters that are not allowed in XML 1.0 documents (e.g. control characters such as
+     * backspace) from the given string, so it can be safely written by an XML writer.
      * <p>
-     * XML forbids the null character even as a numeric character reference, in both XML 1.0 and XML 1.1,
-     * so it is the only character that cannot be preserved when writing XML text or attribute values and
-     * must be dropped rather than escaped. Every other control character can be written as-is by an XML
-     * 1.1 writer, which escapes it to a character reference automatically instead of rejecting it.
+     * Returns the same instance (not a copy) when the string is already valid, so callers can detect
+     * whether anything was actually removed with a reference comparison.
      *
      * @param str string to sanitize, can be null
-     * @return the sanitized string, or the original string if it did not contain a null character, or null
-     * if the input was null
+     * @return the sanitized string, or the original string instance if it was already valid, or null if
+     * the input was null
      */
     public static String stripInvalidXmlChars(String str) {
-        if (str == null || str.indexOf(0) == -1) {
+        if (str == null || str.isEmpty()) {
             return str;
         }
-        return str.replace("\0", "");
+        StringBuilder sb = null;
+        int len = str.length();
+        int i = 0;
+        while (i < len) {
+            int codePoint = str.codePointAt(i);
+            int charCount = Character.charCount(codePoint);
+            if (isValidXmlCodePoint(codePoint)) {
+                if (sb != null) {
+                    sb.appendCodePoint(codePoint);
+                }
+            } else if (sb == null) {
+                sb = new StringBuilder(len);
+                sb.append(str, 0, i);
+            }
+            i += charCount;
+        }
+        return sb != null ? sb.toString() : str;
+    }
+
+    private static boolean isValidXmlCodePoint(int c) {
+        return c == 0x9 || c == 0xA || c == 0xD
+            || (c >= 0x20 && c <= 0xD7FF)
+            || (c >= 0xE000 && c <= 0xFFFD)
+            || (c >= 0x10000 && c <= 0x10FFFF);
     }
 }


### PR DESCRIPTION
## Description

Fixes #2998.

Exporting a graph to GEXF could throw `com.ctc.wstx.exc.WstxIOException: Invalid white space character (0x8) in text to output` and abort the export whenever a node/edge label, attribute value, column title, or workspace title/description contained a character that is not valid in XML (e.g. control characters like backspace `0x8`). Woodstox refuses to write such characters, and the exception is caught and logged in `ExporterGEXF.execute()`, silently truncating the exported file.

**Approach:** strip characters that are not valid in XML 1.0 from these strings before writing them, via a new `XmlUtils.stripInvalidXmlChars` helper in the `Utils` module, applied at every string write site in `ExporterGEXF` (node/edge labels, static/dynamic attribute values, column titles/defaults, workspace title/description). `ExporterGEXF` tracks whether anything was actually removed and logs a single warning per export when so, so this isn't entirely silent.

An earlier version of this PR instead declared the GEXF output as XML 1.1, letting Woodstox automatically escape these characters as numeric character references (e.g. `&#x8;`) instead of stripping them, preserving the data losslessly. That turned out to have a real compatibility cost: Python's `xml.etree.ElementTree` (backed by `expat`, which `networkx.read_gexf` — probably the most common non-Gephi GEXF reader — uses) [does not implement XML 1.1's relaxed character rules](https://github.com/libexpat/libexpat/issues/378) and rejects those same character references regardless of the declared version. Since GEXF is a public interchange format consumed by tools outside Gephi's control, this reverts to stripping and keeps the output as XML 1.0, unchanged and universally compatible with everything that already reads GEXF today. The XML 1.0 → 1.1 question was raised for the format itself back in [gephi/gexf#2](https://github.com/gephi/gexf/issues/2) and is left for a follow-up (e.g. behind an opt-in compatibility setting) rather than bundled into this crash fix.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no, because they aren't needed