### PR TITLE
Fix range filters crashing on load when persisted bound type differs from live type

### DIFF
--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterProcessor.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterProcessor.java
@@ -250,8 +250,15 @@ public class FilterProcessor {
             } else if (previousRange != null &&
                 (previousRange.getMinimum() == null || previousRange.getMaximum() == null)) {
                 //Opening projects
-                newRange = new Range(previousRange.getLowerBound(), previousRange.getUpperBound(), min, max,
-                    previousRange.isLeftInclusive(), previousRange.isRightInclusive(), values);
+                if (previousRange.getLowerBound().getClass().equals(min.getClass()) &&
+                    previousRange.getUpperBound().getClass().equals(max.getClass())) {
+                    newRange = new Range(previousRange.getLowerBound(), previousRange.getUpperBound(), min, max,
+                        previousRange.isLeftInclusive(), previousRange.isRightInclusive(), values);
+                } else {
+                    //The persisted bounds are a different Number type than the live values (e.g. a
+                    //project saved by an older Gephi version) - discard them instead of crashing
+                    newRange = new Range(min, max, min, max, values);
+                }
                 rangeFilter.getRangeProperty().setValue(newRange);
             } else {
                 //Collect some info

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterProcessorTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterProcessorTest.java
@@ -1,0 +1,26 @@
+package org.gephi.filters;
+
+import org.gephi.filters.api.Range;
+import org.gephi.filters.plugin.attribute.AttributeRangeBuilder.AttributeRangeFilter;
+import org.gephi.graph.GraphGenerator;
+import org.gephi.graph.api.Column;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphModel;
+import org.junit.Test;
+
+public class FilterProcessorTest {
+
+    @Test
+    public void testInitRangeFilterWithIncompatiblePreviousRangeType() {
+        GraphModel graphModel = GraphGenerator.build().generateTinyGraph().addIntNodeColumn().getGraph().getModel();
+        Column column = graphModel.getNodeTable().getColumn(GraphGenerator.INT_COLUMN);
+        Graph graph = graphModel.getGraph();
+        AttributeRangeFilter.Node filter = new AttributeRangeFilter.Node(column);
+
+        //Simulate a range restored from a project file whose bound type (Long) no longer
+        //matches the live column type (Integer), e.g. a file saved by an older Gephi version
+        filter.getRangeProperty().setValue(new Range(0L, 100L));
+
+        new FilterProcessor().init(filter, graph);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #2899. Opening an old project file (e.g. from 0.9.2) whose range filters have a numeric bound type that no longer matches the live type computed for that filter/column throws `IllegalArgumentException: Lower and upper must be the same class` and the project fails to load entirely.

### Root cause

`RangePropertyEditor` only ever persists a `Range`'s lower/upper bound, as `"Type - lower - upper"` text (`RangePropertyEditor.java:65-92`); `min`/`max` are never written. So on every project load, deserializing a range filter always produces a `Range` with `null` min/max, which means `FilterProcessor.init()` always takes its `"Opening projects"` branch (`FilterProcessor.java:250-255`):

```java
} else if (previousRange != null &&
    (previousRange.getMinimum() == null || previousRange.getMaximum() == null)) {
    //Opening projects
    newRange = new Range(previousRange.getLowerBound(), previousRange.getUpperBound(), min, max,
        previousRange.isLeftInclusive(), previousRange.isRightInclusive(), values);
```

This combines the *persisted* `lowerBound`/`upperBound` (whatever concrete `Number` subclass the filter/column produced when the file was saved, possibly years and Gephi versions ago) with freshly computed `min`/`max` (whatever type the same filter returns today from the live graph). Nothing reconciles these two independently-derived `Number`s, and `Range`'s constructor enforces a strict `getClass().equals()` check on them (`Range.java:72-77`), so any drift between the two throws and aborts the load - exactly the crash reported in #2899.

This is a long-standing latent defect (the same code shape exists as far back as v0.9.2) and is also the underlying cause of the older, previously-closed #1600.

### Fix

In the `"Opening projects"` branch, only reuse the persisted bounds when their class actually matches the live `min`/`max` class; otherwise fall back to the live values, the same way a filter with no previous range is already handled a few lines above. This trades a stale/incompatible bound selection for a full-range reset, instead of crashing the whole project load.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

`FilterProcessorTest.testInitRangeFilterWithIncompatiblePreviousRangeType` builds a real `AttributeRangeFilter` over an `Integer` column, sets its range property to a `Range` with `Long` bounds (simulating a persisted range whose type no longer matches the live column type), and calls `FilterProcessor.init()` directly. It fails on `master` with the exact reported stack trace and passes with this change.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed