### PR TITLE
Fix flaky IllegalThreadStateException from double-started FilterAutoRefreshor

### DIFF
--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterAutoRefreshor.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterAutoRefreshor.java
@@ -54,21 +54,23 @@ public class FilterAutoRefreshor extends Thread {
     private static final int TIMER = 1000;
     private final GraphModel graphModel;
     private final FilterModelImpl filterModel;
-    private GraphObserver observer;
-    private boolean running = true;
+    private volatile GraphObserver observer;
+    private volatile boolean running = true;
 
     public FilterAutoRefreshor(FilterModelImpl filterModel, GraphModel graphModel) {
         super("Filter Auto-Refresh - " + filterModel.getWorkspace().toString());
         setDaemon(true);
         this.graphModel = graphModel;
         this.filterModel = filterModel;
+        start();
     }
 
     @Override
     public void run() {
         while (running) {
             try {
-                if (observer != null && observer.hasGraphChanged()) {
+                GraphObserver currentObserver = observer;
+                if (currentObserver != null && currentObserver.hasGraphChanged()) {
                     manualRefresh();
                 }
                 Thread.sleep(TIMER);
@@ -78,7 +80,7 @@ public class FilterAutoRefreshor extends Thread {
         }
     }
 
-    public void setEnable(boolean enable) {
+    public synchronized void setEnable(boolean enable) {
         if (enable) {
             if (observer == null) {
                 observer = graphModel.createGraphObserver(graphModel.getGraph(), false);
@@ -87,12 +89,9 @@ public class FilterAutoRefreshor extends Thread {
             observer.destroy();
             observer = null;
         }
-        if (!isAlive()) {
-            start();
-        }
     }
 
-    public void setRunning(boolean running) {
+    public synchronized void setRunning(boolean running) {
         this.running = running;
         if (!running) {
             if (observer != null && !observer.isDestroyed()) {

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterAutoRefreshorTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterAutoRefreshorTest.java
@@ -1,0 +1,49 @@
+package org.gephi.filters;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+public class FilterAutoRefreshorTest {
+
+    @Test
+    public void testConcurrentSetEnableDoesNotThrow() throws Exception {
+        FilterModelImpl filterModel = Utils.newFilterModelWithGraph();
+        FilterAutoRefreshor autoRefreshor = filterModel.getAutoRefreshor();
+
+        //Simulate the caller thread and a background FilterThread both toggling
+        //auto-refresh around the same time, as happens when a filter/select operation
+        //completes right as the model's current result is set/cleared elsewhere
+        int threadCount = 16;
+        int iterationsPerThread = 200;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < iterationsPerThread; j++) {
+                        autoRefreshor.setEnable(true);
+                        autoRefreshor.setEnable(false);
+                    }
+                } catch (Throwable ex) {
+                    failure.compareAndSet(null, ex);
+                }
+            });
+            threads.add(t);
+            t.start();
+        }
+        startLatch.countDown();
+        for (Thread t : threads) {
+            t.join();
+        }
+        autoRefreshor.setRunning(false);
+
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent setEnable() calls threw", failure.get());
+        }
+    }
+}


### PR DESCRIPTION
## Description

`FilterAutoRefreshor` extends `Thread` and is instantiated once per `FilterModelImpl`, but was only started lazily from `setEnable()` via an unsynchronized `if (!isAlive()) start()` check-then-act. `setEnable()` is reachable concurrently both from the calling thread (e.g. `FilterControllerImpl.filterVisible()` -> `FilterModelImpl.setCurrentResult()`) and from a background `FilterThread` finishing an async filter/select operation. When both raced to enable auto-refresh before the thread had ever started, both observed `!isAlive()` and both called `start()`, and the second call threw `IllegalThreadStateException` with no message.

This was intermittently failing `TimelineControllerImplTest.testSetIntervalWithDynamicRangeAsSubQuery` in CI (3 of the last 4 CI failures), regardless of which module the PR under test actually touched — a classic flaky-test signature.

The thread is now started once from the constructor, and `setEnable()`/`setRunning()` are synchronized so they can't race on the shared `observer` field either. A code review pass also caught that `run()` read that field twice (`observer != null && observer.hasGraphChanged()`), which could see it nulled out by a concurrent `setEnable(false)`/`setRunning(false)` between the two reads and crash the auto-refresh thread with an uncaught NPE; it now captures the field once per loop iteration.

Verified the fix reproduces and resolves the original race: temporarily reverting just the source fix while keeping the new test reliably reproduces the exact `IllegalThreadStateException` at the old `if (!isAlive()) start()` line; with the fix applied the same stress test (16 threads × 200 concurrent `setEnable()` toggles) passes cleanly.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no, because they aren't needed