### PR TITLE
Fix javadoc warnings surfaced in release CI build

### DIFF
--- a/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
+++ b/modules/DesktopTimeline/src/main/java/org/gephi/desktop/timeline/CustomBoundsDialog.java
@@ -423,7 +423,7 @@ public class CustomBoundsDialog extends javax.swing.JPanel {
          * Validates that the interval value does not exceed the custom bounds.
          *
          * @param boundField the min or max bounds text field to validate against
-         * @param upper      if true, validates value <= boundField (for end); if false, validates value >= boundField (for start)
+         * @param upper      if true, validates value {@code <=} boundField (for end); if false, validates value {@code >=} boundField (for start)
          */
         public IntervalBoundsValidator(JTextField boundField, boolean upper) {
             this.boundField = boundField;

--- a/modules/MostRecentFilesAPI/src/main/java/org/gephi/desktop/mrufiles/impl/MostRecentFilesImpl.java
+++ b/modules/MostRecentFilesAPI/src/main/java/org/gephi/desktop/mrufiles/impl/MostRecentFilesImpl.java
@@ -136,14 +136,18 @@ public class MostRecentFilesImpl implements MostRecentFiles {
     }
 
     /**
-     * {@inheritDoc}
+     * Adds a listener notified when the MRU file list changes.
+     *
+     * @param listener the listener to add
      */
     public void addPropertyChangeListener(PropertyChangeListener listener) {
         listenerList.add(PropertyChangeListener.class, listener);
     }
 
     /**
-     * {@inheritDoc}
+     * Removes a listener previously added with {@link #addPropertyChangeListener(PropertyChangeListener)}.
+     *
+     * @param listener the listener to remove
      */
     public void removePropertyChangeListener(PropertyChangeListener listener) {
         listenerList.remove(PropertyChangeListener.class, listener);

--- a/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PDFTarget.java
+++ b/modules/PreviewAPI/src/main/java/org/gephi/preview/api/PDFTarget.java
@@ -50,7 +50,7 @@ import org.apache.pdfbox.pdmodel.font.PDFont;
  * Rendering target to PDF format.
  * <p>
  * This target is used by renderers objects to render a graph to PDF and uses
- * the <a href=https://pdfbox.apache.org/">PDFBox</a> Java library.
+ * the <a href="https://pdfbox.apache.org/">PDFBox</a> Java library.
  * <p>
  * The target give access to the <code>PDPageContentStream</code> object from PDFBox to
  * draw items.

--- a/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/StatisticalInferenceClustering.java
+++ b/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/StatisticalInferenceClustering.java
@@ -71,7 +71,7 @@ import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
 
 /**
- * @author Mathieu Jacomy & Tiago Peixoto
+ * @author Mathieu Jacomy &amp; Tiago Peixoto
  */
 
 public class StatisticalInferenceClustering implements Statistics, LongTask {

--- a/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/builder/StatisticalInferenceBuilder.java
+++ b/modules/StatisticsPlugin/src/main/java/org/gephi/statistics/plugin/builder/StatisticalInferenceBuilder.java
@@ -49,7 +49,7 @@ import org.openide.util.NbBundle;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
- * @author Mathieu Jacomy & Tiago Peixoto
+ * @author Mathieu Jacomy &amp; Tiago Peixoto
  */
 @ServiceProvider(service = StatisticsBuilder.class)
 public class StatisticalInferenceBuilder implements StatisticsBuilder {


### PR DESCRIPTION
## Description

Fixes the javadoc warnings from Gephi's own code seen in the [0.11.3 release build](https://github.com/gephi/gephi/actions/runs/33085553233):

- `PDFTarget.java` — malformed HTML link (`<a href=...">` missing opening quote).
- `StatisticalInferenceBuilder.java` / `StatisticalInferenceClustering.java` — unescaped `&` in `@author` tag.
- `CustomBoundsDialog.java` — unescaped `<=`/`>=` in `@param` doc text, wrapped in `{@code}`.
- `MostRecentFilesImpl.java` — `{@inheritDoc}` on `addPropertyChangeListener`/`removePropertyChangeListener`, which don't actually override anything (the `MostRecentFiles` interface doesn't declare them); replaced with real doc text.

The other warnings from that run (Node 20 deprecation notice on `stCarolas/setup-maven`, Homebrew `aws/tap` trust notice, and the `jogamp/text/util/*` javadoc warnings in vendored JOGL source) are infra/vendor noise, not addressed here.

Doc-comment-only changes; no behavior change. Compiled the four affected modules locally to confirm no regressions.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)