### PR TITLE
Fix generator cancellation and skip workspace creation on cancel

### DIFF
--- a/modules/DesktopGenerate/src/main/java/org/gephi/desktop/generate/DesktopGeneratorController.java
+++ b/modules/DesktopGenerate/src/main/java/org/gephi/desktop/generate/DesktopGeneratorController.java
@@ -42,6 +42,7 @@ Portions Copyrighted 2011 Gephi Consortium.
 
 package org.gephi.desktop.generate;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.JPanel;
 import org.gephi.io.generator.api.GeneratorController;
 import org.gephi.io.generator.spi.Generator;
@@ -53,6 +54,8 @@ import org.gephi.io.processor.plugin.DefaultProcessor;
 import org.gephi.lib.validation.DialogDescriptorWithValidation;
 import org.gephi.utils.longtask.api.LongTaskErrorHandler;
 import org.gephi.utils.longtask.api.LongTaskExecutor;
+import org.gephi.utils.longtask.spi.LongTask;
+import org.gephi.utils.progress.ProgressTicket;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
@@ -109,13 +112,32 @@ public class DesktopGeneratorController implements GeneratorController {
             }
         };
 
+        //Tracks whether cancel() was requested, so a cancelled run doesn't still
+        //create and populate a workspace with the partial graph.
+        final AtomicBoolean cancelled = new AtomicBoolean(false);
+        LongTask cancellableTask = new LongTask() {
+
+            @Override
+            public boolean cancel() {
+                cancelled.set(true);
+                return generator.cancel();
+            }
+
+            @Override
+            public void setProgressTicket(ProgressTicket progressTicket) {
+                generator.setProgressTicket(progressTicket);
+            }
+        };
+
         //Execute
-        executor.execute(generator, new Runnable() {
+        executor.execute(cancellableTask, new Runnable() {
 
             @Override
             public void run() {
                 generator.generate(container.getLoader());
-                finishGenerate(container);
+                if (!cancelled.get()) {
+                    finishGenerate(container);
+                }
             }
         }, taskname, errorHandler);
     }

--- a/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/DynamicGraph.java
+++ b/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/DynamicGraph.java
@@ -62,9 +62,11 @@ public class DynamicGraph implements Generator {
 
     protected int numberOfNodes = 50;
     protected double wiringProbability = 0.05;
+    protected volatile boolean cancel = false;
 
     @Override
     public void generate(ContainerLoader container) {
+        cancel = false;
         Random random = new Random();
         final double start = 2000.0;
         final double end = 2015.0;
@@ -73,7 +75,7 @@ public class DynamicGraph implements Generator {
         container.setTimeRepresentation(TimeRepresentation.TIMESTAMP);
 
         NodeDraft[] nodeArray = new NodeDraft[numberOfNodes];
-        for (int i = 0; i < numberOfNodes; i++) {
+        for (int i = 0; i < numberOfNodes && !cancel; i++) {
             NodeDraft nodeDraft = container.factory().newNodeDraft("n" + i);
             container.addNode(nodeDraft);
 
@@ -91,9 +93,9 @@ public class DynamicGraph implements Generator {
         if (wiringProbability > 0) {
             ColumnDraft edgeWeightCol = container.addEdgeColumn("weight", Double.class, true);
 
-            for (int i = 0; i < numberOfNodes - 1; i++) {
+            for (int i = 0; i < numberOfNodes - 1 && !cancel; i++) {
                 NodeDraft node1 = nodeArray[i];
-                for (int j = i + 1; j < numberOfNodes; j++) {
+                for (int j = i + 1; j < numberOfNodes && !cancel; j++) {
                     NodeDraft node2 = nodeArray[j];
                     if (random.nextDouble() < wiringProbability) {
                         EdgeDraft edgeDraft = container.factory().newEdgeDraft();
@@ -128,6 +130,7 @@ public class DynamicGraph implements Generator {
 
     @Override
     public boolean cancel() {
+        cancel = true;
         return true;
     }
 

--- a/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/MultiGraph.java
+++ b/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/MultiGraph.java
@@ -61,12 +61,14 @@ public class MultiGraph implements Generator {
     protected int numberOfNodes = 50;
     protected double wiringProbability = 0.05;
     protected int numberOfEdgeTypes = 3;
+    protected volatile boolean cancel = false;
 
     @Override
     public void generate(ContainerLoader container) {
+        cancel = false;
 
         NodeDraft[] nodeArray = new NodeDraft[numberOfNodes];
-        for (int i = 0; i < numberOfNodes; i++) {
+        for (int i = 0; i < numberOfNodes && !cancel; i++) {
             NodeDraft nodeDraft = container.factory().newNodeDraft("n" + i);
             container.addNode(nodeDraft);
 
@@ -81,9 +83,9 @@ public class MultiGraph implements Generator {
         Random random = new Random();
 
         if (wiringProbability > 0) {
-            for (int i = 0; i < numberOfNodes - 1; i++) {
+            for (int i = 0; i < numberOfNodes - 1 && !cancel; i++) {
                 NodeDraft node1 = nodeArray[i];
-                for (int j = i + 1; j < numberOfNodes; j++) {
+                for (int j = i + 1; j < numberOfNodes && !cancel; j++) {
                     NodeDraft node2 = nodeArray[j];
                     if (random.nextDouble() < wiringProbability) {
                         if (random.nextDouble() < 0.3) {
@@ -131,6 +133,7 @@ public class MultiGraph implements Generator {
 
     @Override
     public boolean cancel() {
+        cancel = true;
         return true;
     }
 

--- a/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/RandomGraph.java
+++ b/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/RandomGraph.java
@@ -63,10 +63,11 @@ public class RandomGraph implements Generator {
     protected int numberOfNodes = 50;
     protected double wiringProbability = 0.05;
     protected ProgressTicket progress;
-    protected boolean cancel = false;
+    protected volatile boolean cancel = false;
 
     @Override
     public void generate(ContainerLoader container) {
+        cancel = false;
 
         int max = numberOfNodes;
         if (wiringProbability > 0) {


### PR DESCRIPTION
## Description

`DynamicGraph` and `MultiGraph` implemented `Generator.cancel()` as a no-op stub (no backing field), so cancelling generation had no effect and the loops always ran to completion. They now track a `cancel` flag and check it in every loop (node creation + nested wiring loop), matching `RandomGraph`'s existing pattern.

Also:
- Reset the `cancel` flag at the start of `generate()` in all three generators. `Generator` instances are cached NetBeans `Lookup` singletons, so without this a single cancel would permanently disable that generator for the rest of the session (silent empty-graph imports on every subsequent run) — this was previously a latent, harmless bug in `RandomGraph` since its own cancel path did work, but is now fixed alongside the other two.
- Made the `cancel` field `volatile` on all three for correct cross-thread visibility between the EDT (Cancel button) and the background generation thread.
- `DesktopGeneratorController.generate()` now tracks whether `cancel()` was requested and skips `finishGenerate()` (workspace creation + import processing) when it was, so a cancelled run no longer creates a workspace populated with a partial graph.

Verified: `LongTaskExecutor`'s cancel path runs synchronously on the EDT with no blocking/joins, so this doesn't introduce any UI hang or deadlock risk. Compiled `GeneratorPlugin` and `DesktopGenerate` modules successfully.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed