### PR TITLE
Cancel running Statistics task when its workspace closes

### DIFF
--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
@@ -136,6 +136,10 @@ public class StatisticsModelUIImpl implements StatisticsModelUI {
         return null;
     }
 
+    public Statistics[] getRunning() {
+        return runningList.toArray(new Statistics[0]);
+    }
+
     public void setVisible(StatisticsUI statisticsUI, boolean visible) {
         if (visible) {
             if (invisibleList.remove(statisticsUI)) {

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsTopComponent.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsTopComponent.java
@@ -54,7 +54,9 @@ import org.gephi.desktop.statistics.api.StatisticsControllerUI;
 import org.gephi.project.api.ProjectController;
 import org.gephi.project.api.Workspace;
 import org.gephi.project.api.WorkspaceListener;
+import org.gephi.statistics.spi.Statistics;
 import org.gephi.ui.utils.UIUtils;
+import org.gephi.utils.longtask.spi.LongTask;
 import org.netbeans.api.settings.ConvertAsProperties;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
@@ -122,6 +124,7 @@ public final class StatisticsTopComponent extends TopComponent implements Change
 
             @Override
             public void close(Workspace workspace) {
+                cancelRunningStatistics(workspace);
             }
 
             @Override
@@ -155,6 +158,17 @@ public final class StatisticsTopComponent extends TopComponent implements Change
                 }
             }
         });
+    }
+
+    private void cancelRunningStatistics(Workspace workspace) {
+        StatisticsModelUIImpl m = workspace.getLookup().lookup(StatisticsModelUIImpl.class);
+        if (m != null) {
+            for (Statistics statistics : m.getRunning()) {
+                if (statistics instanceof LongTask) {
+                    ((LongTask) statistics).cancel();
+                }
+            }
+        }
     }
 
     private void refreshModel(StatisticsModelUIImpl model) {

--- a/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsModelUIImplTest.java
+++ b/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsModelUIImplTest.java
@@ -52,6 +52,25 @@ public class StatisticsModelUIImplTest {
         Assert.assertFalse(model.isRunning(otherUi));
     }
 
+    @Test
+    public void testGetRunningReturnsAllRunningStatistics() {
+        StatisticsModelUIImpl model = new StatisticsModelUIImpl(null);
+        Statistics statistics1 = new StubStatistics();
+        Statistics statistics2 = new OtherStatistics();
+
+        model.setRunning(statistics1, true);
+        model.setRunning(statistics2, true);
+
+        Assert.assertArrayEquals(new Statistics[] {statistics1, statistics2}, model.getRunning());
+    }
+
+    @Test
+    public void testGetRunningIsEmptyWhenNothingRunning() {
+        StatisticsModelUIImpl model = new StatisticsModelUIImpl(null);
+
+        Assert.assertArrayEquals(new Statistics[0], model.getRunning());
+    }
+
     public static class StubStatistics implements Statistics {
 
         @Override


### PR DESCRIPTION
## Description

A Statistics algorithm (e.g. GraphDistance, Modularity, PageRank, ClusteringCoefficient) holds the graph read lock for its entire run. Previously, nothing signalled a running Statistics task to stop when its workspace/project closed — `StatisticsTopComponent`'s `WorkspaceListener.close` was an empty no-op. If the workspace closed while a statistic was still running, shutdown could hang indefinitely waiting on that lock.

This mirrors the existing precedent in `LayoutControllerImpl.close(Workspace)`, which cancels a running layout on workspace close: `StatisticsTopComponent.close(Workspace)` now cancels any currently running `Statistics` (that implements `LongTask`) for that workspace via a new `StatisticsModelUIImpl#getRunning()` accessor.

Cancellation is intentionally only wired into `close`, not `unselect` — `unselect` fires on ordinary workspace switching too, and a running statistic should keep running when the user just navigates to another workspace.

Known follow-ups, deliberately out of scope for this PR:
- Some Statistics implementations (e.g. `ConnectedComponents`'s directed-graph path, parts of `ClusteringCoefficient`) don't check their cancellation flag throughout their locked computation, so cancellation may not unwind promptly for those.
- Cancellation flags in `StatisticsPlugin` aren't `volatile`.
- `ProjectControllerImpl` fires `UNSELECT` for the whole project before `CLOSE` for any workspace, and some other component's `unselect` handler can itself block on the graph write lock before our `close` handler runs — so this doesn't close every possible variant of the hang.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [ ] 🙅 no, because they aren't needed