### PR TITLE
Fix EDT-unsafe Swing update and lock contention in layout task completion

### DIFF
--- a/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPanel.java
+++ b/modules/DesktopLayout/src/main/java/org/gephi/desktop/layout/LayoutPanel.java
@@ -65,6 +65,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
+import javax.swing.SwingUtilities;
 import org.gephi.layout.api.LayoutController;
 import org.gephi.layout.api.LayoutModel;
 import org.gephi.layout.spi.Layout;
@@ -292,12 +293,16 @@ public class LayoutPanel extends javax.swing.JPanel implements PropertyChangeLis
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
+        // LayoutModelImpl.setRunning() can be invoked from the layout LongTaskExecutor's
+        // background thread when a task completes, so this callback isn't guaranteed to run
+        // on the EDT. Push the Swing updates back to the EDT rather than mutating components
+        // from whichever thread fired the property change.
         if (evt.getPropertyName().equals(LayoutModel.SELECTED_LAYOUT)) {
-            refreshModel();
+            SwingUtilities.invokeLater(this::refreshModel);
         } else if (evt.getPropertyName().equals(LayoutModel.RUNNING)) {
-            refreshModel();
+            SwingUtilities.invokeLater(this::refreshModel);
         } else if (evt.getPropertyName().equals(LayoutModel.DEFAULTS_APPLIED)) {
-            loadDefaultProperties();
+            SwingUtilities.invokeLater(this::loadDefaultProperties);
         }
     }
 

--- a/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
+++ b/modules/LongTaskAPI/src/main/java/org/gephi/utils/longtask/api/LongTaskExecutor.java
@@ -306,17 +306,26 @@ public final class LongTaskExecutor {
      *                        the listener, failures are reported to the error handler
      *                        and to the listener's <code>fatalError()</code> instead
      */
-    private synchronized void finished(RunningLongTask runningLongTask, boolean notifyListener) {
-        if (cancelTimer != null) {
-            cancelTimer.cancel();
-            cancelTimer = null;
+    private void finished(RunningLongTask runningLongTask, boolean notifyListener) {
+        LongTaskListener listenerToNotify = null;
+        synchronized (this) {
+            if (cancelTimer != null) {
+                cancelTimer.cancel();
+                cancelTimer = null;
+            }
+            if (currentTask == runningLongTask) {
+                currentTask = null;
+            }
+            if (notifyListener && listener != null) {
+                listenerToNotify = listener;
+            }
         }
-        LongTask task = runningLongTask.task;
-        if (currentTask == runningLongTask) {
-            currentTask = null;
-        }
-        if (notifyListener && listener != null) {
-            listener.taskFinished(task);
+        // Notified outside the monitor: the listener can run arbitrary code (e.g. Swing
+        // updates triggered synchronously from a background thread), and holding the lock
+        // here would block other threads calling synchronized methods on this executor,
+        // such as cancel() from the EDT's Stop button, for as long as that code takes.
+        if (listenerToNotify != null) {
+            listenerToNotify.taskFinished(runningLongTask.task);
         }
     }
 


### PR DESCRIPTION
## Summary
- `LayoutPanel.propertyChange()` now dispatches its Swing updates (`refreshModel()`, `loadDefaultProperties()`) via `SwingUtilities.invokeLater()`, since `LayoutModelImpl.setRunning(false)` can fire from the layout `LongTaskExecutor`'s background thread when a task completes, not just the EDT.
- `LongTaskExecutor.finished()` now notifies its `LongTaskListener` outside the `synchronized` block, so arbitrary listener code (including the Swing update above) no longer runs while holding the executor's monitor — the same lock `cancel()` needs, which is called from the EDT's Stop button and from `LayoutControllerImpl.close()`.

Together these removed a path where a background layout thread could mutate Swing components off the EDT while holding a lock contended by the EDT, risking UI corruption and lock contention/deadlock-prone behavior between the Stop button, workspace close, and task completion.

## Test plan
- [x] `mvn compile` on `LongTaskAPI`, `DesktopLayout`, `LayoutAPI` (and dependents) succeeds
- [x] `mvn test` on `LongTaskAPI` — all 27 existing tests pass
- [ ] Manual: run a layout algorithm, click Stop while it's finishing, and close the workspace mid-layout to confirm no UI hangs/corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)