### PR TITLE
Avoid EDT graphstore read-lock in EdgePencil workspace listener

### DIFF
--- a/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
@@ -50,6 +50,7 @@ import javax.swing.SwingUtilities;
 import org.gephi.datalab.api.GraphElementsController;
 import org.gephi.graph.api.Edge;
 import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.GraphModel;
 import org.gephi.graph.api.Node;
 import org.gephi.project.api.ProjectController;
 import org.gephi.project.api.Workspace;
@@ -90,12 +91,14 @@ public class EdgePencil implements Tool {
         Lookup.getDefault().lookup(ProjectController.class).addWorkspaceListener(new WorkspaceListener() {
             @Override
             public void initialize(Workspace workspace) {
-                SwingUtilities.invokeLater(() -> updatePanel());
+                Boolean directedOrMixed = isDirectedOrMixed(workspace);
+                SwingUtilities.invokeLater(() -> updatePanel(directedOrMixed));
             }
 
             @Override
             public void select(Workspace workspace) {
-                SwingUtilities.invokeLater(() -> updatePanel());
+                Boolean directedOrMixed = isDirectedOrMixed(workspace);
+                SwingUtilities.invokeLater(() -> updatePanel(directedOrMixed));
             }
 
             @Override
@@ -113,14 +116,23 @@ public class EdgePencil implements Tool {
     }
 
     private void updatePanel() {
+        updatePanel(isDirectedOrMixed(null));
+    }
+
+    private void updatePanel(Boolean directedOrMixed) {
         if (edgePencilPanel != null) {
-            GraphController gc = Lookup.getDefault().lookup(GraphController.class);
-            if (gc.getGraphModel() != null) {
-                edgePencilPanel.setType(gc.getGraphModel().isDirected() || gc.getGraphModel().isMixed());
+            if (directedOrMixed != null) {
+                edgePencilPanel.setType(directedOrMixed);
             }
             sourceNode = null;
             edgePencilPanel.setStatus(NbBundle.getMessage(EdgePencil.class, "EdgePencil.status1"));
         }
+    }
+
+    private static Boolean isDirectedOrMixed(Workspace workspace) {
+        GraphController gc = Lookup.getDefault().lookup(GraphController.class);
+        GraphModel graphModel = workspace != null ? gc.getGraphModel(workspace) : gc.getGraphModel();
+        return graphModel != null ? graphModel.isDirected() || graphModel.isMixed() : null;
     }
 
     @Override

--- a/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
@@ -91,13 +91,14 @@ public class EdgePencil implements Tool {
         Lookup.getDefault().lookup(ProjectController.class).addWorkspaceListener(new WorkspaceListener() {
             @Override
             public void initialize(Workspace workspace) {
-                Boolean directedOrMixed = isDirectedOrMixed(workspace);
-                SwingUtilities.invokeLater(() -> updatePanel(directedOrMixed));
+                //No-op: a workspace that becomes current also fires select(), which updates the panel.
+                //Workspaces created without being opened (e.g. "New Workspace") never become current.
             }
 
             @Override
             public void select(Workspace workspace) {
-                Boolean directedOrMixed = isDirectedOrMixed(workspace);
+                GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel(workspace);
+                Boolean directedOrMixed = isDirectedOrMixed(graphModel);
                 SwingUtilities.invokeLater(() -> updatePanel(directedOrMixed));
             }
 
@@ -117,7 +118,7 @@ public class EdgePencil implements Tool {
 
     private void updatePanel() {
         GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
-        updatePanel(graphModel != null ? graphModel.isDirected() || graphModel.isMixed() : null);
+        updatePanel(isDirectedOrMixed(graphModel));
     }
 
     private void updatePanel(Boolean directedOrMixed) {
@@ -130,8 +131,7 @@ public class EdgePencil implements Tool {
         }
     }
 
-    private static Boolean isDirectedOrMixed(Workspace workspace) {
-        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel(workspace);
+    private static Boolean isDirectedOrMixed(GraphModel graphModel) {
         return graphModel != null ? graphModel.isDirected() || graphModel.isMixed() : null;
     }
 

--- a/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
+++ b/modules/ToolsPlugin/src/main/java/org/gephi/tools/plugin/EdgePencil.java
@@ -116,7 +116,8 @@ public class EdgePencil implements Tool {
     }
 
     private void updatePanel() {
-        updatePanel(isDirectedOrMixed(null));
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel();
+        updatePanel(graphModel != null ? graphModel.isDirected() || graphModel.isMixed() : null);
     }
 
     private void updatePanel(Boolean directedOrMixed) {
@@ -130,8 +131,7 @@ public class EdgePencil implements Tool {
     }
 
     private static Boolean isDirectedOrMixed(Workspace workspace) {
-        GraphController gc = Lookup.getDefault().lookup(GraphController.class);
-        GraphModel graphModel = workspace != null ? gc.getGraphModel(workspace) : gc.getGraphModel();
+        GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel(workspace);
         return graphModel != null ? graphModel.isDirected() || graphModel.isMixed() : null;
     }
 


### PR DESCRIPTION
## Summary
- `EdgePencil`'s `WorkspaceListener.initialize()`/`select()` callbacks run on a background thread but posted the `getGraphModel().isDirected()/isMixed()` checks into the EDT via `invokeLater`, so the EDT took the graphstore auto-read-lock and could stall behind long write-lock holds during filter/statistics processing.
- Compute the `isDirected() || isMixed()` boolean on the calling (non-EDT) thread using the `workspace` argument already passed to the listener, and post only the resulting boolean to the EDT for the Swing update.

## Test plan
- [x] `mvn -pl modules/ToolsPlugin -am compile` succeeds
- [ ] Manual: switch/open workspaces while a long-running filter/statistics operation holds the write lock and confirm the UI no longer stalls