### PR TITLE
Fix graphstore read-lock leak in ContextPanel's timer task

### DIFF
--- a/modules/DesktopContext/pom.xml
+++ b/modules/DesktopContext/pom.xml
@@ -56,6 +56,14 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-nodes</artifactId>
         </dependency>
+
+        <!-- Test only -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>graph-api</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/DesktopContext/src/main/java/org/gephi/desktop/context/ContextPanel.java
+++ b/modules/DesktopContext/src/main/java/org/gephi/desktop/context/ContextPanel.java
@@ -87,7 +87,7 @@ public class ContextPanel extends javax.swing.JPanel {
         this.model = model;
         setEnable(model != null);
         if (this.model != null) {
-            consumerThread = new ContextRefreshThread(model, new RefreshRunnable());
+            consumerThread = new ContextRefreshThread(model, new RefreshRunnable(model));
         }
     }
 
@@ -207,23 +207,35 @@ public class ContextPanel extends javax.swing.JPanel {
 
     private class RefreshRunnable implements Runnable {
 
+        private final GraphModel model;
         private int[] data = new int[] {-1, -1, -1, -1, -1};
+
+        private RefreshRunnable(GraphModel model) {
+            this.model = model;
+        }
 
         @Override
         public void run() {
             Graph visibleGraph = model.getGraphVisible();
             Graph fullGraph = model.getGraph();
 
+            final int nodesFull;
+            final int nodesVisible;
+            final int edgesFull;
+            final int edgesVisible;
+            final GraphType graphType;
             fullGraph.readLock();
-            final int nodesFull = fullGraph.getNodeCount();
-            final int nodesVisible = visibleGraph.getNodeCount();
-            final int edgesFull = fullGraph.getEdgeCount();
-            final int edgesVisible = visibleGraph.getEdgeCount();
-            final GraphType graphType =
-                model.isDirected() ? GraphType.DIRECTED :
-                    model.isUndirected() ? GraphType.UNDIRECTED : GraphType.MIXED;
-
-            fullGraph.readUnlock();
+            try {
+                nodesFull = fullGraph.getNodeCount();
+                nodesVisible = visibleGraph.getNodeCount();
+                edgesFull = fullGraph.getEdgeCount();
+                edgesVisible = visibleGraph.getEdgeCount();
+                graphType =
+                    model.isDirected() ? GraphType.DIRECTED :
+                        model.isUndirected() ? GraphType.UNDIRECTED : GraphType.MIXED;
+            } finally {
+                fullGraph.readUnlock();
+            }
 
             int[] newData =
                 new int[] {nodesFull, nodesVisible, edgesFull, edgesVisible, graphType.ordinal()};

--- a/modules/DesktopContext/src/main/java/org/gephi/desktop/context/ContextRefreshThread.java
+++ b/modules/DesktopContext/src/main/java/org/gephi/desktop/context/ContextRefreshThread.java
@@ -56,6 +56,7 @@ public class ContextRefreshThread extends TimerTask {
     private final Timer timer;
     private final GraphModel graphModel;
     private final Runnable listener;
+    private volatile boolean cancelled;
     private int previousVersion = -1;
 
     public ContextRefreshThread(GraphModel graphModel, Runnable listener) {
@@ -69,6 +70,9 @@ public class ContextRefreshThread extends TimerTask {
 
     @Override
     public void run() {
+        if (cancelled) {
+            return;
+        }
         Graph graph = graphModel.getGraphVisible();
         int graphVersion = graph.getVersion();
         if (graphVersion != previousVersion) {
@@ -78,6 +82,7 @@ public class ContextRefreshThread extends TimerTask {
     }
 
     public void shutdown() {
+        cancelled = true;
         timer.cancel();
     }
 }

--- a/modules/DesktopContext/src/test/java/org/gephi/desktop/context/ContextRefreshThreadTest.java
+++ b/modules/DesktopContext/src/test/java/org/gephi/desktop/context/ContextRefreshThreadTest.java
@@ -1,0 +1,45 @@
+package org.gephi.desktop.context;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.gephi.graph.GraphGenerator;
+import org.gephi.graph.api.GraphModel;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ContextRefreshThreadTest {
+
+    private ContextRefreshThread thread;
+
+    @After
+    public void tearDown() {
+        if (thread != null) {
+            thread.shutdown();
+        }
+    }
+
+    @Test
+    public void testShutdownPreventsFurtherListenerInvocations() {
+        GraphModel graphModel = GraphGenerator.build().generateTinyGraph().getGraphModel();
+        AtomicInteger invocationCount = new AtomicInteger();
+        thread = new ContextRefreshThread(graphModel, invocationCount::incrementAndGet);
+
+        thread.shutdown();
+        thread.run();
+
+        Assert.assertEquals(0, invocationCount.get());
+    }
+
+    @Test
+    public void testRunInvokesListenerOnlyWhenGraphVersionChanges() {
+        GraphModel graphModel = GraphGenerator.build().generateTinyGraph().getGraphModel();
+        AtomicInteger invocationCount = new AtomicInteger();
+        thread = new ContextRefreshThread(graphModel, invocationCount::incrementAndGet);
+
+        thread.run();
+        Assert.assertEquals(1, invocationCount.get());
+
+        thread.run();
+        Assert.assertEquals(1, invocationCount.get());
+    }
+}


### PR DESCRIPTION
## Description

`ContextPanel`'s periodic `ContextRefreshThread` timer task took a graphstore read lock with no try/finally, and its `RefreshRunnable` read `ContextPanel`'s mutable, non-volatile `model` field instead of a captured reference.

`Timer.cancel()` (called from `ContextRefreshThread.shutdown()`) only stops *future* scheduled runs, not one already in flight. If an in-flight run was between `readLock()`/`readUnlock()` when `disable()` concurrently nulled the `model` field on the EDT, the next dereference of that field NPE'd inside the locked region — leaking the read lock and killing the Timer thread (an uncaught exception in a `TimerTask` terminates its `Timer`).

Fix:
- `RefreshRunnable` now captures its own `GraphModel` reference at construction instead of reading the shared mutable field.
- The locked region is wrapped in try/finally so the read lock is always released.
- `ContextRefreshThread` gets a `volatile cancelled` flag, set in `shutdown()`, so it stops doing work once shut down instead of relying solely on `Timer.cancel()`.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no, because they aren't needed