### PR TITLE
Fix lock contention between TableObserverExecutor.stop() and run()

### DIFF
--- a/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/TableObserverExecutor.java
+++ b/modules/DesktopAppearance/src/main/java/org/gephi/desktop/appearance/TableObserverExecutor.java
@@ -49,23 +49,27 @@ public class TableObserverExecutor implements Runnable {
 
     @Override
     public void run() {
-        synchronized (this) {
-            try {
+        try {
+            boolean changed;
+            synchronized (this) {
                 String selectedElementClass = model.selectedElementClass;
                 if (nodeTableObserver != null && selectedElementClass.equals(AppearanceUIController.NODE_ELEMENT)) {
-                    if (nodeTableObserver.hasTableChanged()) {
-                        Lookup.getDefault().lookup(AppearanceUIController.class).refreshColumnsList();
-                    }
+                    changed = nodeTableObserver.hasTableChanged();
                 } else if (edgeTableObserver != null &&
                     selectedElementClass.equals(AppearanceUIController.EDGE_ELEMENT)) {
-                    if (edgeTableObserver.hasTableChanged()) {
-                        Lookup.getDefault().lookup(AppearanceUIController.class).refreshColumnsList();
-                    }
+                    changed = edgeTableObserver.hasTableChanged();
+                } else {
+                    changed = false;
                 }
-            } catch (Exception e) {
-                Logger.getLogger(TableObserverExecutor.class.getName())
-                    .log(Level.SEVERE, "Error while refreshing appearance's column list", e);
             }
+            // Fire the refresh outside the lock: it fans out to UI listeners and must not
+            // hold up stop(), which destroys the observers under the same monitor.
+            if (changed) {
+                Lookup.getDefault().lookup(AppearanceUIController.class).refreshColumnsList();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(TableObserverExecutor.class.getName())
+                .log(Level.SEVERE, "Error while refreshing appearance's column list", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- `TableObserverExecutor.run()` held its own monitor for its entire body, including the call to `AppearanceUIController.refreshColumnsList()`, which fans out synchronously to every registered `AppearanceUIModelListener` (Swing UI code).
- `stop()` -- invoked from `AppearanceUIModel.unselect()` on workspace switch/close -- synchronizes on that same monitor to destroy the table observers, so it unnecessarily blocked on whatever listener fan-out was in flight, even though that fan-out never touches the observer fields it's waiting on.
- Shrunk the synchronized block in `run()` to just the observer read and `hasTableChanged()` check, and moved the `refreshColumnsList()` call outside the lock, so `stop()` only ever waits on the cheap check rather than arbitrary listener work.

The sibling `FunctionObserverExecutor` has no such locking, so it wasn't affected by this pattern.

## Test plan
- [x] `mvn -q -pl modules/DesktopAppearance -am compile` succeeds
- [x] Independently reviewed by a second agent pass: confirmed original branch semantics (mutually-exclusive node/edge checks) are preserved exactly, the lock still prevents `TableObserver` use during/after `destroy()`, and the residual race after lock release (a concurrent stop()+start() before the pending refresh fires) is benign -- at worst one redundant/stale UI refresh, already covered by the existing catch-all exception handler.
- No unit tests target this class before or after this change (pre-existing gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)