### PR TITLE
Fix graph write-lock contention in Data Laboratory on workspace switch

### DIFF
--- a/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
+++ b/modules/DesktopDataLaboratory/src/main/java/org/gephi/desktop/datalab/DataTableTopComponent.java
@@ -276,11 +276,6 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
     }
 
     private void deactivateAll() {
-        DataTablesObservers observers = dataTablesObservers;
-        if (observers != null) {
-            observers.destroy();
-        }
-
         graphModel = null;
         dataTablesModel = null;
         dataTablesObservers = null;
@@ -318,6 +313,13 @@ public class DataTableTopComponent extends TopComponent implements AWTEventListe
 
             @Override
             public void close(Workspace workspace) {
+                //Graph observer destruction needs the graph write lock, so it must not happen on unselect:
+                //a long-running task on this workspace could be holding a read lock at that time. Destroying
+                //observers here instead, once the workspace is actually going away, avoids that contention.
+                DataTablesObservers observers = workspace.getLookup().lookup(DataTablesObservers.class);
+                if (observers != null) {
+                    observers.destroy();
+                }
             }
 
             @Override


### PR DESCRIPTION
## Description

`DataTableTopComponent` destroyed its workspace's `GraphObserver` (plus its table/column observers) inside `WorkspaceListener.unselect()`, which runs on every workspace switch. Destroying a `GraphObserver` requires the graph write lock, so switching away from a workspace could block the switch on a concurrent read lock held by a long-running task on that workspace (e.g. a Statistics run), stalling the UI.

This moves the `destroy()` call from `unselect()` to `close()`, so observers are torn down only when the workspace actually closes, not on every switch — matching the existing pattern already used in `FilterControllerImpl` for `FilterModel`.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

No existing test infrastructure exists for `DataTableTopComponent`/`DataTablesObservers` (NetBeans desktop UI wiring with no unit tests in this module). Verified via a scoped build (`compile` + `checkstyle:check`, 0 violations) and manual trace of `ProjectControllerImpl`'s workspace-event ordering confirming `close()` fires exactly once per workspace in every teardown path, and never fires on a plain switch.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 API Changes
- [ ] 👍 Additional documentation in docs
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)