### PR TITLE
Fix Error crash when import report panels are constructed on the EDT

### DIFF
--- a/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/ProcessorIssuesReportPanel.java
+++ b/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/ProcessorIssuesReportPanel.java
@@ -50,7 +50,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -67,11 +66,11 @@ import javax.swing.tree.TreePath;
 import org.gephi.io.importer.api.Issue;
 import org.gephi.io.importer.api.Report;
 import org.gephi.ui.components.BusyUtils;
+import org.gephi.ui.utils.UIUtils;
 import org.netbeans.swing.outline.DefaultOutlineModel;
 import org.netbeans.swing.outline.OutlineModel;
 import org.netbeans.swing.outline.RenderDataProvider;
 import org.netbeans.swing.outline.RowModel;
-import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
@@ -100,19 +99,13 @@ public class ProcessorIssuesReportPanel extends javax.swing.JPanel {
     // End of variables declaration//GEN-END:variables
 
     public ProcessorIssuesReportPanel() {
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    initComponents();
-                    initIcons();
-                }
-            });
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (InvocationTargetException ex) {
-            Exceptions.printStackTrace(ex);
-        }
+        UIUtils.runInEventDispatchThreadAndWait(new Runnable() {
+            @Override
+            public void run() {
+                initComponents();
+                initIcons();
+            }
+        });
 
         fillingThreads = new ThreadGroup("Report Panel Issues");
 

--- a/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/ReportPanel.java
+++ b/modules/DesktopImport/src/main/java/org/gephi/desktop/importer/ReportPanel.java
@@ -54,7 +54,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -83,11 +82,11 @@ import org.gephi.io.importer.api.Report;
 import org.gephi.io.processor.spi.Processor;
 import org.gephi.io.processor.spi.ProcessorUI;
 import org.gephi.ui.components.BusyUtils;
+import org.gephi.ui.utils.UIUtils;
 import org.netbeans.swing.outline.DefaultOutlineModel;
 import org.netbeans.swing.outline.OutlineModel;
 import org.netbeans.swing.outline.RenderDataProvider;
 import org.netbeans.swing.outline.RowModel;
-import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
@@ -155,22 +154,16 @@ public class ReportPanel extends javax.swing.JPanel {
     // End of variables declaration//GEN-END:variables
 
     public ReportPanel() {
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    initComponents();
-                    initIcons();
-                    initProcessors();
-                    initMoreOptionsPanel();
-                    initMergeStrategyCombo();
-                }
-            });
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (InvocationTargetException ex) {
-            Exceptions.printStackTrace(ex);
-        }
+        UIUtils.runInEventDispatchThreadAndWait(new Runnable() {
+            @Override
+            public void run() {
+                initComponents();
+                initIcons();
+                initProcessors();
+                initMoreOptionsPanel();
+                initMergeStrategyCombo();
+            }
+        });
 
         fillingThreads = new ThreadGroup("Report Panel Issues");
 


### PR DESCRIPTION
## Description

`ReportPanel` and `ProcessorIssuesReportPanel` (both in the `DesktopImport` module) called `SwingUtilities.invokeAndWait()` **unconditionally** in their constructors, with no check for whether the calling thread was already the event dispatch thread.

`SwingUtilities.invokeAndWait()` throws `java.lang.Error("Cannot call invokeAndWait from the event dispatcher thread")` when called from the EDT. Since constructing Swing components on the EDT is the normal, expected pattern, either panel being built from the EDT would crash with an uncaught `Error` instead of just running its initialization inline. The `try`/`catch` blocks only caught `InterruptedException` and `InvocationTargetException`, so the `Error` propagated unhandled.

Both constructors now delegate to `UIUtils.runInEventDispatchThreadAndWait()`, which already implements exactly the needed guard: run the `Runnable` directly when on the EDT, otherwise fall back to `invokeAndWait()`. Behaviour from background threads is unchanged.

`UIUtils` was already a dependency of `DesktopImport` and `org.gephi.ui.utils` is declared as a public package of that module, so no new dependency was introduced — this reuses the existing helper rather than duplicating the guard-and-dispatch logic in two more places. The now-unused `InvocationTargetException` and `Exceptions` imports were dropped from both files.

This addresses the portion of #3102's "Critical Issue 2: Excessive `SwingUtilities.invokeAndWait()` Usage" that is still valid on master. Most call sites flagged there are either already guarded by an `isEventDispatchThread()` check or are legitimate blocking calls made from background threads; these two constructors were the genuinely unguarded ones.

Verified with `mvn -pl modules/DesktopImport -am compile` and again under the `enableCheckStyle` profile, both clean.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

<!-- The fix routes through an existing, already-used helper; the failure mode is a thread-affinity Error that would require driving real Swing construction from the EDT to reproduce in a test. -->

## Added to documentation?
- [x] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)