### PR TITLE
#2767 Make Append/MergeProcessor testable without a live project

### DIFF
--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AppendProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/AppendProcessor.java
@@ -70,19 +70,19 @@ public class AppendProcessor extends DefaultProcessor implements Processor {
     @Override
     public Workspace[] process() {
         try {
-
-
             ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
             if (workspace == null) {
                 workspace = pc.getCurrentWorkspace();
-            }
 
-            if (workspace == null) {
-                // Get config
-                Configuration config = createConfiguration(containers[0]);
+                if (workspace == null) {
+                    // Get config
+                    Configuration config = createConfiguration(containers[0]);
 
-                workspace = pc.openNewWorkspace(config);
-            } else {
+                    workspace = pc.openNewWorkspace(config);
+                } else {
+                    pc.openWorkspace(workspace);
+                }
+            } else if (pc.hasCurrentProject()) {
                 pc.openWorkspace(workspace);
             }
 

--- a/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/MergeProcessor.java
+++ b/modules/ImportPlugin/src/main/java/org/gephi/io/processor/plugin/MergeProcessor.java
@@ -80,7 +80,7 @@ public class MergeProcessor extends DefaultProcessor implements Processor {
                 Configuration config = createConfiguration(containers[0]);
 
                 workspace = pc.openNewWorkspace(config);
-            } else {
+            } else if (pc.hasCurrentProject()) {
                 pc.openWorkspace(workspace);
             }
 

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/AppendProcessorTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/AppendProcessorTest.java
@@ -1,0 +1,63 @@
+package org.gephi.io.processor.plugin;
+
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.io.importer.api.NodeDraft;
+import org.gephi.io.importer.impl.ImportContainerImpl;
+import org.gephi.io.importer.impl.NodeDraftImpl;
+import org.gephi.project.api.Workspace;
+import org.gephi.project.impl.WorkspaceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AppendProcessorTest {
+
+    @Test
+    public void testAppendToSuppliedWorkspace() {
+        Workspace workspace = new WorkspaceImpl(null, 1);
+
+        ImportContainerImpl firstContainer = new ImportContainerImpl();
+        firstContainer.addNode(new NodeDraftImpl(firstContainer, "1", 1));
+        firstContainer.addNode(new NodeDraftImpl(firstContainer, "99", 99));
+
+        AppendProcessor processor = new AppendProcessor();
+        processor.setContainers(new ImportContainerImpl[] {firstContainer});
+        processor.setWorkspace(workspace);
+        processor.process();
+
+        ImportContainerImpl secondContainer = new ImportContainerImpl();
+        secondContainer.addNode(new NodeDraftImpl(secondContainer, "1", 1));
+        secondContainer.addNode(new NodeDraftImpl(secondContainer, "2", 2));
+
+        processor = new AppendProcessor();
+        processor.setContainers(new ImportContainerImpl[] {secondContainer});
+        processor.setWorkspace(workspace);
+        processor.process();
+
+        // Node "99" only exists in the first container: still present after the second append proves
+        // elements are merged by id rather than the workspace being reset to the last-processed container.
+        GraphModel graphModel = workspace.getLookup().lookup(GraphModel.class);
+        Graph graph = graphModel.getGraph();
+        Assert.assertEquals(3, graph.getNodeCount());
+        Assert.assertNotNull(graph.getNode("1"));
+        Assert.assertNotNull(graph.getNode("2"));
+        Assert.assertNotNull(graph.getNode("99"));
+    }
+
+    @Test
+    public void testSourceIsSetOnSuppliedWorkspace() {
+        Workspace workspace = new WorkspaceImpl(null, 1);
+
+        ImportContainerImpl container = new ImportContainerImpl();
+        NodeDraft nodeDraft = new NodeDraftImpl(container, "1", 1);
+        container.addNode(nodeDraft);
+        container.setSource("some-file.gexf");
+
+        AppendProcessor processor = new AppendProcessor();
+        processor.setContainers(new ImportContainerImpl[] {container});
+        processor.setWorkspace(workspace);
+        processor.process();
+
+        Assert.assertEquals("some-file.gexf", workspace.getSource());
+    }
+}

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DefaultProcessorTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/DefaultProcessorTest.java
@@ -51,6 +51,22 @@ public class DefaultProcessorTest {
         Assert.assertEquals("bar", workspaceMetaData.getTitle());
     }
 
+    @Test
+    public void testSourceSetsSourceAndRenamesSuppliedWorkspace() {
+        ImportContainerImpl importContainer = new ImportContainerImpl();
+        importContainer.addNode(new NodeDraftImpl(importContainer, "1", 1));
+        importContainer.setSource("some-file.gexf");
+
+        Workspace workspace = new WorkspaceImpl(null, 1);
+        DefaultProcessor defaultProcessor = new DefaultProcessor();
+        defaultProcessor.setContainers(new ImportContainerImpl[] {importContainer});
+        defaultProcessor.setWorkspace(workspace);
+        defaultProcessor.process();
+
+        Assert.assertEquals("some-file.gexf", workspace.getSource());
+        Assert.assertEquals("some-file", workspace.getName());
+    }
+
     @Test(expected = ProcessorConfigurationException.class)
     public void testConfigurationMismatchThrows() {
         // Workspace will be initialized with default INTERVAL time representation

--- a/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/MergeProcessorTest.java
+++ b/modules/ImportPlugin/src/test/java/org/gephi/io/processor/plugin/MergeProcessorTest.java
@@ -1,0 +1,61 @@
+package org.gephi.io.processor.plugin;
+
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.io.importer.api.NodeDraft;
+import org.gephi.io.importer.impl.ImportContainerImpl;
+import org.gephi.io.importer.impl.NodeDraftImpl;
+import org.gephi.project.api.Workspace;
+import org.gephi.project.impl.WorkspaceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MergeProcessorTest {
+
+    @Test
+    public void testMergeIntoSuppliedWorkspace() {
+        Workspace workspace = new WorkspaceImpl(null, 1);
+
+        ImportContainerImpl firstContainer = new ImportContainerImpl();
+        firstContainer.addNode(new NodeDraftImpl(firstContainer, "1", 1));
+        firstContainer.addNode(new NodeDraftImpl(firstContainer, "99", 99));
+
+        ImportContainerImpl secondContainer = new ImportContainerImpl();
+        secondContainer.addNode(new NodeDraftImpl(secondContainer, "1", 1));
+        secondContainer.addNode(new NodeDraftImpl(secondContainer, "2", 2));
+
+        MergeProcessor processor = new MergeProcessor();
+        processor.setContainers(new ImportContainerImpl[] {firstContainer, secondContainer});
+        processor.setWorkspace(workspace);
+        processor.process();
+
+        // Node "99" only exists in the first container: still present after the merge proves elements
+        // are merged by id across all containers rather than only the last one being processed.
+        GraphModel graphModel = workspace.getLookup().lookup(GraphModel.class);
+        Graph graph = graphModel.getGraph();
+        Assert.assertEquals(3, graph.getNodeCount());
+        Assert.assertNotNull(graph.getNode("1"));
+        Assert.assertNotNull(graph.getNode("2"));
+        Assert.assertNotNull(graph.getNode("99"));
+    }
+
+    @Test
+    public void testSourceIsSetOnSuppliedWorkspace() {
+        Workspace workspace = new WorkspaceImpl(null, 1);
+
+        ImportContainerImpl firstContainer = new ImportContainerImpl();
+        NodeDraft nodeDraft = new NodeDraftImpl(firstContainer, "1", 1);
+        firstContainer.addNode(nodeDraft);
+        firstContainer.setSource("some-file.gexf");
+
+        ImportContainerImpl secondContainer = new ImportContainerImpl();
+        secondContainer.addNode(new NodeDraftImpl(secondContainer, "2", 2));
+
+        MergeProcessor processor = new MergeProcessor();
+        processor.setContainers(new ImportContainerImpl[] {firstContainer, secondContainer});
+        processor.setWorkspace(workspace);
+        processor.process();
+
+        Assert.assertEquals("some-file.gexf", workspace.getSource());
+    }
+}


### PR DESCRIPTION
## Description

`AppendProcessor` and `MergeProcessor` called `ProjectController.openWorkspace()` unconditionally whenever a workspace was already known (either supplied via `setWorkspace()` or resolved from `getCurrentWorkspace()`). `openWorkspace()` NPEs when there's no live current `Project`, which meant every unit test needed to go through `projectController.newProject()`/`closeCurrentProject()` just to hand the processor a workspace to process into.

The fix guards that call on `pc.hasCurrentProject()`. Any real `Workspace` object obtained through legitimate means always belongs to a `Project`, so behavior for actual callers (currently only `DesktopImportControllerUI`, which always passes `null` and never hits this branch anyway) is unchanged. Tests can now construct a bare `WorkspaceImpl` and pass it directly, with no project/lookup setup required.

Added `AppendProcessorTest`/`MergeProcessorTest` (didn't exist before) and one more case in `DefaultProcessorTest`, following the existing pattern of constructing a plain `WorkspaceImpl` directly.

Fixes #2767

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no, because they aren't needed