### PR TITLE
Exclude viz-engine-demo from Maven Central publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1243,6 +1243,10 @@
                             <autoPublish>false</autoPublish>
                             <deploymentName>${project.version}</deploymentName>
                             <ignorePublishedComponents>true</ignorePublishedComponents>
+                            <!-- Internal demo module only, never publish it to Maven Central -->
+                            <excludeArtifacts>
+                                <excludeArtifact>viz-engine-demo</excludeArtifact>
+                            </excludeArtifacts>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Description

`modules/VizEngineDemo` is registered in the root reactor and inherits the `central-publishing-maven-plugin` config from `gephi-parent`. That plugin unconditionally stages/deploys every reactor module it's declared in (there's no per-module `maven.deploy.skip` opt-out). Without this change, the next snapshot push or release would publish `org.gephi:viz-engine-demo` to Maven Central alongside the real API/plugin modules, even though it's only a standalone dev demo and isn't bundled into the actual Gephi application (`modules/application` doesn't depend on it).

This adds `viz-engine-demo` to the plugin's `excludeArtifacts` list, which filters it out of both the snapshot-deploy and release-staging paths while leaving it fully buildable as part of the reactor.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)