### PR TITLE
Fix graph and spatial-index read-lock leaks in GraphSelectionImpl/GraphIndexImpl

### DIFF
--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/status/GraphSelectionImpl.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/status/GraphSelectionImpl.java
@@ -119,27 +119,33 @@ public class GraphSelectionImpl implements GraphSelection {
             getMode() != GraphSelection.GraphSelectionMode.SINGLE_NODE_SELECTION;
 
         graph.readLock();
-        graph.getSpatialIndex().spatialIndexReadLock();
-        nodesIterable.stream().forEach(node -> {
-            int storeId = node.getStoreId();
-            nodes.set(storeId);
-            nodesList.add(node);
-            nodesWithNeighbours.set(storeId);
-            if (selectEdges || selectNeighbours) {
-                EdgeIterable edgeIterable = graph.getEdges(node);
-                for (Edge edge : edgeIterable) {
-                    edges.set(edge.getStoreId());
-                    if (selectNeighbours) {
-                        Node oppositeNode = graph.getOpposite(node, edge);
-                        if (oppositeNode != null && oppositeNode != node) {
-                            nodesWithNeighbours.set(oppositeNode.getStoreId());
+        try {
+            graph.getSpatialIndex().spatialIndexReadLock();
+            try {
+                nodesIterable.stream().forEach(node -> {
+                    int storeId = node.getStoreId();
+                    nodes.set(storeId);
+                    nodesList.add(node);
+                    nodesWithNeighbours.set(storeId);
+                    if (selectEdges || selectNeighbours) {
+                        EdgeIterable edgeIterable = graph.getEdges(node);
+                        for (Edge edge : edgeIterable) {
+                            edges.set(edge.getStoreId());
+                            if (selectNeighbours) {
+                                Node oppositeNode = graph.getOpposite(node, edge);
+                                if (oppositeNode != null && oppositeNode != node) {
+                                    nodesWithNeighbours.set(oppositeNode.getStoreId());
+                                }
+                            }
                         }
                     }
-                }
+                });
+            } finally {
+                graph.getSpatialIndex().spatialIndexReadUnlock();
             }
-        });
-        graph.getSpatialIndex().spatialIndexReadUnlock();
-        graph.readUnlock();
+        } finally {
+            graph.readUnlock();
+        }
     }
 
     @Override

--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/structure/GraphIndexImpl.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/structure/GraphIndexImpl.java
@@ -47,34 +47,48 @@ public class GraphIndexImpl implements GraphIndex {
     @Override
     public void getVisibleNodes(ElementsCallback<Node> callback, GraphRenderingOptions graphRenderingOptions,
                                 Rect2D viewBoundaries) {
-        graphModel.getGraph().readLock();
-        final Graph visibleGraph = getVisibleGraph();
-        callback.start(visibleGraph, graphRenderingOptions, graphSelection);
+        final Graph graph = graphModel.getGraph();
+        graph.readLock();
+        try {
+            final Graph visibleGraph = getVisibleGraph();
+            callback.start(visibleGraph, graphRenderingOptions, graphSelection);
 
-        SpatialIndex spatialIndex = visibleGraph.getSpatialIndex();
-        spatialIndex.spatialIndexReadLock();
-        spatialIndex.getApproximateNodesInArea(viewBoundaries).parallelStream().forEach(
-            callback);
-        spatialIndex.spatialIndexReadUnlock();
+            SpatialIndex spatialIndex = visibleGraph.getSpatialIndex();
+            spatialIndex.spatialIndexReadLock();
+            try {
+                spatialIndex.getApproximateNodesInArea(viewBoundaries).parallelStream().forEach(
+                    callback);
+            } finally {
+                spatialIndex.spatialIndexReadUnlock();
+            }
 
-        callback.end(visibleGraph);
-        graphModel.getGraph().readUnlock();
+            callback.end(visibleGraph);
+        } finally {
+            graph.readUnlock();
+        }
     }
 
     @Override
     public void getVisibleEdges(ElementsCallback<Edge> callback, GraphRenderingOptions graphRenderingOptions,
                                 Rect2D viewBoundaries) {
-        graphModel.getGraph().readLock();
-        final Graph visibleGraph = getVisibleGraph();
-        callback.start(visibleGraph, graphRenderingOptions, graphSelection);
-        SpatialIndex spatialIndex = visibleGraph.getSpatialIndex();
-        spatialIndex.spatialIndexReadLock();
-        spatialIndex.getApproximateEdgesInArea(viewBoundaries).parallelStream().forEach(
-            callback);
-        spatialIndex.spatialIndexReadUnlock();
+        final Graph graph = graphModel.getGraph();
+        graph.readLock();
+        try {
+            final Graph visibleGraph = getVisibleGraph();
+            callback.start(visibleGraph, graphRenderingOptions, graphSelection);
+            SpatialIndex spatialIndex = visibleGraph.getSpatialIndex();
+            spatialIndex.spatialIndexReadLock();
+            try {
+                spatialIndex.getApproximateEdgesInArea(viewBoundaries).parallelStream().forEach(
+                    callback);
+            } finally {
+                spatialIndex.spatialIndexReadUnlock();
+            }
 
-        callback.end(visibleGraph);
-        graphModel.getGraph().readUnlock();
+            callback.end(visibleGraph);
+        } finally {
+            graph.readUnlock();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

`GraphSelectionImpl.setSelectedNodes` and `GraphIndexImpl.getVisibleNodes`/`getVisibleEdges` acquired the graph read lock and the spatial-index read lock directly, with no `try`/`finally`. If the iteration body (or a rendering `ElementsCallback.start`/`end`) throws, the hold is never released. Since a `ReentrantReadWriteLock` read-hold count has no owner tracking, that leak is permanent and invisible to a thread dump (no lock cycle) — any subsequent writer queues forever and every later reader queues behind it.

Found while reviewing gephi-plugins#337, which documents hitting this exact failure shape from a plugin driving the graph off the EDT. This fix is independent of that PR and closes the leak at the source in the render engine.

Wraps both lock acquisitions in nested `try`/`finally` (spatial-index lock inside the graph-lock's try, unlocked in matching order) so every path — including exceptions from the iterated callback — releases both locks. No behavior change on the success path.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)