### PR TITLE
Fix graph read-lock leaks in layout plugins and PartitionColorTransformerPanel

### DIFF
--- a/modules/AppearancePluginUI/src/main/java/org/gephi/ui/appearance/plugin/PartitionColorTransformerPanel.java
+++ b/modules/AppearancePluginUI/src/main/java/org/gephi/ui/appearance/plugin/PartitionColorTransformerPanel.java
@@ -114,9 +114,8 @@ public class PartitionColorTransformerPanel extends javax.swing.JPanel {
         Partition partition = function.getPartition();
         Graph graph = function.getGraph();
 
+        graph.readLock();
         try {
-            graph.readLock();
-
             boolean ignoreNull = !function.getModel().isTransformNullValues();
             values = function.isValid() ? partition.getSortedValues(function.getGraph()) : Collections.EMPTY_LIST;
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas/ForceAtlasLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas/ForceAtlasLayout.java
@@ -121,10 +121,9 @@ public class ForceAtlasLayout extends AbstractLayout implements Layout {
     public void goAlgo() {
         this.graph = graphModel.getGraphVisible();
         graph.readLock();
-        boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
-        Interval interval = graph.getView().getTimeInterval();
-
         try {
+            boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
+            Interval interval = graph.getView().getTimeInterval();
             Node[] nodes = graph.getNodes().toArray();
             Edge[] edges = graph.getEdges().toArray();
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/forceAtlas2/ForceAtlas2.java
@@ -152,10 +152,9 @@ public class ForceAtlas2 implements Layout {
         }
         graph = graphModel.getGraphVisible();
         graph.readLock();
-        boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
-        Interval interval = graph.getView().getTimeInterval();
-
         try {
+            boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
+            Interval interval = graph.getView().getTimeInterval();
             Node[] nodes = graph.getNodes().toArray();
             Edge[] edges = graph.getEdges().toArray();
 

--- a/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/openord/OpenOrdLayout.java
+++ b/modules/LayoutPlugin/src/main/java/org/gephi/layout/plugin/openord/OpenOrdLayout.java
@@ -115,10 +115,9 @@ public class OpenOrdLayout implements Layout, LongTask {
         //Get graph
         graph = graphModel.getUndirectedGraphVisible();
         graph.readLock();
-        boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
-        Interval interval = graph.getView().getTimeInterval();
-
         try {
+            boolean isDynamicWeight = graphModel.getEdgeTable().getColumn("weight").isDynamic();
+            Interval interval = graph.getView().getTimeInterval();
             int numNodes = graph.getNodeCount();
 
             //Prepare data structure - nodes and neighbors map


### PR DESCRIPTION
## Description

Follow-up to #3297 (which fixed the same bug class in `GraphSelectionImpl`/`GraphIndexImpl`). A full-repo audit of `graph.readLock()` call sites found 4 more places where the read lock could leak or be released without ever being held:

- `ForceAtlas2.goAlgo()`, `ForceAtlasLayout.goAlgo()`, `OpenOrdLayout.initAlgo()`: two statements ran between `readLock()` and the `try` block. If either threw, the lock leaked permanently. Fixed by moving them inside `try`.
- `PartitionColorTransformerPanel.setup()`: `readLock()` was the first statement *inside* `try`, with an unconditional `readUnlock()` in `finally`. If `readLock()` itself threw, `finally` would call `readUnlock()` on a lock never acquired (unbalanced unlock, throws `IllegalMonitorStateException`). Fixed by moving `readLock()` to right before `try`.

All four now follow the established convention:
```java
graph.readLock();
try {
    ...
} finally {
    graph.readUnlock(); // or readUnlockAll()
}
```

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

These are lock-acquisition ordering fixes with no behavioral change on the happy path; the affected failure path only occurs when an internal lookup throws, which isn't practical to trigger from existing test scaffolding.

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed