### PR TITLE
Add config-independent async takeScreenshot to ScreenshotController

### DIFF
--- a/modules/VisualizationAPI/src/main/java/org/gephi/visualization/api/ScreenshotController.java
+++ b/modules/VisualizationAPI/src/main/java/org/gephi/visualization/api/ScreenshotController.java
@@ -1,6 +1,7 @@
 package org.gephi.visualization.api;
 
 import java.io.File;
+import java.util.concurrent.Future;
 
 /**
  * Controller for taking screenshots of the visualization.
@@ -13,6 +14,25 @@ public interface ScreenshotController {
      * Triggers the screenshot task in a background thread. This method returns immediately.
      */
     void takeScreenshot();
+
+    /**
+     * Takes a screenshot in a background thread and writes it to the given file as a PNG. This method returns
+     * immediately.
+     * <p>
+     * Unlike {@link #takeScreenshot()}, this method is independent of the controller's configured settings
+     * (scale factor, transparent background, auto-save, default directory) and never shows a file chooser: the
+     * parameters passed here are used as-is and the screenshot is always written to {@code file}.
+     * <p>
+     * The returned future completes with {@code file} once the screenshot has been written to disk, or completes
+     * exceptionally if the screenshot could not be taken or the file could not be written. Do not block on the
+     * returned future from the AWT event dispatch thread.
+     *
+     * @param scaleFactor            the scale factor to apply
+     * @param transparentBackground true if the background should be transparent
+     * @param file                   the file to write the screenshot to
+     * @return a future that completes with the file once the screenshot has been written
+     */
+    Future<File> takeScreenshot(int scaleFactor, boolean transparentBackground, File file);
 
     /**
      * Sets the scale factor for screenshots.

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/screenshot/ScreenshotControllerImpl.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/screenshot/ScreenshotControllerImpl.java
@@ -43,8 +43,14 @@
 package org.gephi.visualization.screenshot;
 
 import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.gephi.desktop.visualization.screenshot.ScreenshotSettingsPanel;
 import org.gephi.utils.longtask.api.LongTaskExecutor;
+import org.gephi.utils.longtask.spi.LongTask;
 import org.gephi.visualization.VizController;
 import org.gephi.visualization.api.ScreenshotController;
 import org.openide.DialogDescriptor;
@@ -99,6 +105,51 @@ public class ScreenshotControllerImpl implements ScreenshotController {
                         NbBundle.getMessage(ScreenshotControllerImpl.class, "ScreenshotMaker.progress.message"), null);
             });
 
+    }
+
+    @Override
+    public Future<File> takeScreenshot(int scaleFactor, boolean transparentBackground, File file) {
+        return vizController.getModel().getEngine().<Future<File>>map(engine -> {
+            ScreenshotToFileTask task = new ScreenshotToFileTask(engine, scaleFactor, transparentBackground, file);
+            Future<File> future = executor.execute(task, task,
+                NbBundle.getMessage(ScreenshotControllerImpl.class, "ScreenshotMaker.progress.message"), null);
+            return cancellable(future, task);
+        }).orElseGet(() -> CompletableFuture.failedFuture(new IllegalStateException("No rendering engine available")));
+    }
+
+    /**
+     * Wraps a future so cancelling it also triggers the task's cooperative cancellation, instead of only
+     * interrupting the executor thread (which the tiled screenshot render loop does not check).
+     */
+    private static <V> Future<V> cancellable(Future<V> future, LongTask task) {
+        return new Future<V>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                task.cancel();
+                return future.cancel(mayInterruptIfRunning);
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return future.isCancelled();
+            }
+
+            @Override
+            public boolean isDone() {
+                return future.isDone();
+            }
+
+            @Override
+            public V get() throws InterruptedException, ExecutionException {
+                return future.get();
+            }
+
+            @Override
+            public V get(long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+                return future.get(timeout, unit);
+            }
+        };
     }
 
     public int getSurfaceWidth() {

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/screenshot/ScreenshotToFileTask.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/screenshot/ScreenshotToFileTask.java
@@ -1,0 +1,53 @@
+package org.gephi.visualization.screenshot;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import javax.imageio.ImageIO;
+import org.gephi.utils.longtask.spi.LongTask;
+import org.gephi.utils.progress.ProgressTicket;
+import org.gephi.viz.engine.VizEngine;
+import org.gephi.viz.engine.jogl.JOGLRenderingTarget;
+
+public class ScreenshotToFileTask implements LongTask, Callable<File> {
+
+    private final JOGLRenderingTarget renderingTarget;
+    private final int scaleFactor;
+    private final boolean transparentBackground;
+    private final File file;
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private final BooleanSupplier isCancelled = cancelled::get;
+    private ProgressTicket progressTicket;
+
+    public ScreenshotToFileTask(VizEngine<JOGLRenderingTarget, ?> engine, int scaleFactor,
+                                boolean transparentBackground, File file) {
+        this.renderingTarget = engine.getRenderingTarget();
+        this.scaleFactor = scaleFactor;
+        this.transparentBackground = transparentBackground;
+        this.file = file;
+    }
+
+    @Override
+    public File call() throws Exception {
+        BufferedImage image =
+            renderingTarget.requestScreenshot(scaleFactor, transparentBackground, isCancelled).get();
+        if (!ImageIO.write(image, "png", file)) {
+            throw new IOException("No image writer found for PNG format");
+        }
+        return file;
+    }
+
+    @Override
+    public boolean cancel() {
+        cancelled.set(true);
+        return true;
+    }
+
+    @Override
+    public void setProgressTicket(ProgressTicket progressTicket) {
+        this.progressTicket = progressTicket;
+    }
+}


### PR DESCRIPTION
## Description

Adds `ScreenshotController.takeScreenshot(int scaleFactor, boolean transparentBackground, File file)`, returning a `Future<File>` that completes once the screenshot has been written to disk, or fails (e.g. on an IO error), so callers can wait for and handle the result programmatically.

Unlike the existing `takeScreenshot()`, this new overload is independent of the controller's shared/persisted settings and never shows the interactive file-chooser dialog — the scale factor, transparency, and destination file are passed explicitly and used as-is.

Implementation notes:
- Added `ScreenshotToFileTask`, a `Callable<File>` + `LongTask` counterpart to the existing `ScreenshotTask` (which is a `Runnable` bound to the shared model and dialog flow) — submitted through the same `LongTaskExecutor` via its `Callable` overload, which is what yields the `Future`.
- The returned future's `cancel()` is wrapped so it also triggers the task's own cooperative cancellation flag (checked by the tiled-render loop), not just an interrupt of the executor thread.
- `ImageIO.write`'s boolean return value is checked; a `false` result (no PNG writer available) fails the future instead of silently reporting success.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

No unit tests added: the screenshot pipeline renders through a live JOGL/GL rendering target, and the existing sibling class (`ScreenshotTask`) has no unit test coverage either for the same reason. Verified by compiling both affected modules (`VisualizationAPI`, `VisualizationImpl`).

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [x] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren't needed

Javadoc added on the new interface method describing the returned future's semantics and the EDT-blocking caveat.