### PR TITLE
Fix IllegalArgumentException crashing project load with legacy zero label scale

### DIFF
--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/VizModel.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/VizModel.java
@@ -1015,6 +1015,18 @@ public class VizModel implements VisualizationModel {
     }
 
     /**
+     * The old {@code nodesizefactor}/{@code edgesizefactor} values could legally be {@code 0} (or
+     * negative), but the current label scale must be strictly positive, so fall back to the
+     * default rather than propagating an invalid value into {@link GraphRenderingOptionsImpl}.
+     */
+    private static float sanitizeLegacyLabelScale(float legacyValue, float defaultValue) {
+        if (legacyValue <= 0f || Float.isNaN(legacyValue) || Float.isInfinite(legacyValue)) {
+            return defaultValue;
+        }
+        return legacyValue;
+    }
+
+    /**
      * Reads the legacy {@code <textmodel>} element written by Gephi 0.10 and earlier, mapping its
      * content onto the equivalent fields of the current model.
      */
@@ -1096,9 +1108,11 @@ public class VizModel implements VisualizationModel {
                     // nodesizefactor and edgesizefactor used text content in old format
                     if (!reader.isWhiteSpace()) {
                         if (readNodeSizeFactor) {
-                            setNodeLabelScale(Float.parseFloat(reader.getText()));
+                            setNodeLabelScale(sanitizeLegacyLabelScale(
+                                Float.parseFloat(reader.getText()), VizConfig.getDefaultNodeLabelScale()));
                         } else if (readEdgeSizeFactor) {
-                            setEdgeLabelScale(Float.parseFloat(reader.getText()));
+                            setEdgeLabelScale(sanitizeLegacyLabelScale(
+                                Float.parseFloat(reader.getText()), VizConfig.getDefaultEdgeLabelScale()));
                         }
                     }
                     break;

--- a/modules/VisualizationImpl/src/test/java/org/gephi/visualization/PersistenceProviderTest.java
+++ b/modules/VisualizationImpl/src/test/java/org/gephi/visualization/PersistenceProviderTest.java
@@ -238,6 +238,40 @@ public class PersistenceProviderTest {
     }
 
     @Test
+    public void testLegacyTextModelZeroSizeFactorFallsBackToDefault() throws Exception {
+        // Old files (e.g. Gephi 0.9/0.10) could store a 0 nodesizefactor/edgesizefactor, which is
+        // not a valid label scale in the current model (must be > 0). Reading it must not throw
+        // and should fall back to the default scale instead.
+        String legacyXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<vizmodel>"
+            + "<textmodel>"
+            + "<shownodelabels enable=\"true\"/>"
+            + "<showedgelabels enable=\"true\"/>"
+            + "<selectedOnly value=\"false\"/>"
+            + "<nodefont name=\"Arial\" size=\"32\" style=\"1\"/>"
+            + "<edgefont name=\"Arial\" size=\"32\" style=\"1\"/>"
+            + "<nodesizefactor>0.0</nodesizefactor>"
+            + "<edgesizefactor>0.5</edgesizefactor>"
+            + "<colormode class=\"TextColorMode\"/>"
+            + "<sizemode class=\"ScaledSizeMode\"/>"
+            + "<nodecolumns><column id=\"label\"/></nodecolumns>"
+            + "<edgecolumns></edgecolumns>"
+            + "</textmodel>"
+            + "</vizmodel>";
+
+         VizModel model = vizController.getModel(GraphGenerator.build().generateTinyGraph().getWorkspace());
+        StringReader stringReader = new StringReader(legacyXml);
+        XMLStreamReader xmlReader = GephiFormat.newXMLReader(stringReader);
+        new VizModelPersistenceProvider().readXML(xmlReader, model.getWorkspace());
+        xmlReader.close();
+
+        Assert.assertEquals(VizConfig.getDefaultNodeLabelScale(), model.getNodeLabelScale(), 0.0001f);
+        Assert.assertEquals(0.5f, model.getEdgeLabelScale(), 0.0001f);
+        // Must not throw when building rendering options from the sanitized model.
+        model.toGraphRenderingOptions();
+    }
+
+    @Test
     public void testDefaultLabelColumnsRoundTrip() throws Exception {
          VizModel model = vizController.getModel(GraphGenerator.build().generateTinyGraph().getWorkspace());
         // Default label column ("label") must survive the round-trip.


### PR DESCRIPTION
## Description

Old `.gephi` files (0.10 and earlier) could store a `0` `nodesizefactor`/`edgesizefactor` in the legacy `<textmodel>` block. On load, `VizModel.readLegacyTextModel` mapped that value directly onto the current `nodeLabelScale`/`edgeLabelScale`, but `GraphRenderingOptionsImpl.setNodeLabelScale` requires the value to be `> 0`. This threw an `IllegalArgumentException` when the workspace's graph view activated, preventing the project from opening:

```
Caused by: java.lang.IllegalArgumentException: nodeLabelScale should be > 0
	at org.gephi.viz.engine.status.GraphRenderingOptionsImpl.setNodeLabelScale(GraphRenderingOptionsImpl.java:425)
	at org.gephi.visualization.VizModel.toGraphRenderingOptions(VizModel.java:228)
```

Legacy `nodesizefactor`/`edgesizefactor` values that are `<= 0`, `NaN`, or infinite now fall back to the current default label scale instead of being propagated verbatim.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed