### PR TITLE
Fix concurrency/locking bugs in the filter subsystem

### DIFF
--- a/modules/FiltersImpl/pom.xml
+++ b/modules/FiltersImpl/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>filters-plugin</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterControllerImpl.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterControllerImpl.java
@@ -370,20 +370,19 @@ public class FilterControllerImpl implements FilterController, PropertyExecutor,
     @Override
     public void exportToNewWorkspace(Query query) {
         FilterModelImpl model = getModel();
-        Graph result;
-        if (model.getCurrentQuery() == query) {
-            GraphView view = model.getCurrentResult();
-            if (view == null) {
-                return;
-            }
-            result = model.getGraphModel().getGraph(view);
-        } else {
+
+        //A fresh, private view (query isn't the model's current one) can be computed
+        //up front - nothing else references it, so nothing can race it. The model's
+        //cached current-result view, on the other hand, is shared and can be destroyed
+        //by a concurrent filter pass, so it's deliberately NOT fetched here: see below.
+        Graph precomputedResult = null;
+        if (model.getCurrentQuery() != query) {
             FilterProcessor processor = new FilterProcessor();
             GraphModel graphModel = model.getGraphModel();
-            result = processor.process((AbstractQueryImpl) query, graphModel);
+            precomputedResult = processor.process((AbstractQueryImpl) query, graphModel);
         }
 
-        final Graph graphView = result;
+        final Graph fixedResult = precomputedResult;
         new Thread(new Runnable() {
 
             @Override
@@ -396,24 +395,53 @@ public class FilterControllerImpl implements FilterController, PropertyExecutor,
                     ticket = progressProvider.createTicket(msg, null);
                 }
                 Progress.start(ticket);
-                ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
-                Workspace newWorkspace = pc.newWorkspace(pc.getCurrentProject(), graphView.getModel().getConfiguration().copy());
-                GraphModel graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel(newWorkspace);
-                graphModel.bridge().copyNodes(graphView.getNodes().toArray());
-                Graph graph = graphModel.getGraph();
-                List<Edge> edgesToRemove = new ArrayList<>();
-                for (Edge edge : graph.getEdges()) {
-                    if (!graphView.hasEdge(edge.getId())) {
-                        edgesToRemove.add(edge);
-                    }
-                }
-                if (!edgesToRemove.isEmpty()) {
-                    graph.removeAllEdges(edgesToRemove);
-                }
+                try {
+                    ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
+                    Workspace newWorkspace = pc.newWorkspace(pc.getCurrentProject(),
+                        model.getGraphModel().getConfiguration().copy());
+                    GraphModel graphModel =
+                        Lookup.getDefault().lookup(GraphController.class).getGraphModel(newWorkspace);
+                    Graph graph = graphModel.getGraph();
 
-                Progress.finish(ticket);
-                String workspaceName = newWorkspace.getLookup().lookup(WorkspaceInformation.class).getName();
-                //StatusDisplayer.getDefault().setStatusText(NbBundle.getMessage(FilterControllerImpl.class, "FilterController.exportToNewWorkspace.status", workspaceName));
+                    //Fetched as late as possible, immediately before locking it: any work
+                    //done between reading the model's cached result and locking it is a
+                    //window for a concurrent filter pass to destroy this exact view.
+                    Graph graphView = fixedResult;
+                    if (graphView == null) {
+                        GraphView view = model.getCurrentResult();
+                        if (view == null) {
+                            return;
+                        }
+                        graphView = model.getGraphModel().getGraph(view);
+                    }
+
+                    graphView.readLock();
+                    try {
+                        graph.writeLock();
+                        try {
+                            graphModel.bridge().copyNodes(graphView.getNodes().toArray());
+                            List<Edge> edgesToRemove = new ArrayList<>();
+                            for (Edge edge : graph.getEdges()) {
+                                if (!graphView.hasEdge(edge.getId())) {
+                                    edgesToRemove.add(edge);
+                                }
+                            }
+                            if (!edgesToRemove.isEmpty()) {
+                                graph.removeAllEdges(edgesToRemove);
+                            }
+                        } finally {
+                            graph.writeUnlock();
+                            graph.readUnlockAll();
+                        }
+                    } finally {
+                        graphView.readUnlockAll();
+                    }
+
+                    String workspaceName = newWorkspace.getLookup().lookup(WorkspaceInformation.class).getName();
+                    //StatusDisplayer.getDefault().setStatusText(NbBundle.getMessage(FilterControllerImpl.class, "FilterController.exportToNewWorkspace.status", workspaceName));
+                } finally {
+                    Progress.finish(ticket);
+                }
             }
         }, "Export filter to workspace").start();
     }

--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelImpl.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelImpl.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.gephi.filters.api.FilterLibrary;
@@ -83,7 +84,7 @@ public class FilterModelImpl implements FilterModel, Model {
         this.workspace = workspace;
         filterLibraryImpl = new FilterLibraryImpl(workspace);
         queries = new LinkedList<>();
-        listeners = new ArrayList<>();
+        listeners = new CopyOnWriteArrayList<>();
         autoRefresh = true;
 
         graphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel(workspace);
@@ -280,7 +281,10 @@ public class FilterModelImpl implements FilterModel, Model {
     }
 
     public void setCurrentResult(GraphView currentResult) {
-        this.currentResult = currentResult;
+        if (this.currentResult != currentResult) {
+            this.currentResult = currentResult;
+            fireChangeEvent();
+        }
         if (currentResult != null && autoRefresh) {
             autoRefreshor.setEnable(true);
         } else if (currentResult == null && autoRefresh) {

--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterThread.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterThread.java
@@ -70,7 +70,7 @@ public class FilterThread extends Thread {
     private final Object lock = new Object();
     private final boolean filtering;
     ConcurrentHashMap<String, PropertyModifier> modifiersMap;
-    private boolean running = true;
+    private volatile boolean running = true;
 
     public FilterThread(FilterModelImpl model, AbstractQueryImpl initialQuery) {
         super("Filter Thread - " + model.getWorkspace().toString());
@@ -96,13 +96,13 @@ public class FilterThread extends Thread {
 
         while (running) {
             AbstractQueryImpl q;
-            while ((q = rootQuery.getAndSet(null)) == null && running) {
-                try {
-                    synchronized (this.lock) {
+            synchronized (this.lock) {
+                while ((q = rootQuery.getAndSet(null)) == null && running) {
+                    try {
                         lock.wait();
+                    } catch (InterruptedException ex) {
+                        Exceptions.printStackTrace(ex);
                     }
-                } catch (InterruptedException ex) {
-                    Exceptions.printStackTrace(ex);
                 }
             }
             if (!running) {

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/ExportToNewWorkspaceTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/ExportToNewWorkspaceTest.java
@@ -1,0 +1,173 @@
+package org.gephi.filters;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.gephi.filters.api.FilterController;
+import org.gephi.filters.api.FilterModel;
+import org.gephi.filters.api.Query;
+import org.gephi.filters.plugin.graph.GiantComponentBuilder;
+import org.gephi.graph.GraphGenerator;
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.graph.api.Node;
+import org.gephi.project.api.Project;
+import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openide.util.Lookup;
+
+/**
+ * Regression tests for {@link FilterControllerImpl#exportToNewWorkspace(Query)}, which
+ * used to read the source filtered view (copyNodes/hasEdge) with no lock at all while
+ * mutating the destination graph, racing against a concurrent filter pass replacing the
+ * exact same view.
+ */
+public class ExportToNewWorkspaceTest {
+
+    private Project project;
+    private Workspace workspace;
+
+    @Before
+    public void setUp() {
+        ProjectController pc = Lookup.getDefault().lookup(ProjectController.class);
+        project = pc.newProject();
+        workspace = project.getCurrentWorkspace();
+    }
+
+    @After
+    public void cleanUp() {
+        Lookup.getDefault().lookup(ProjectController.class).closeCurrentProject();
+        project = null;
+    }
+
+    /**
+     * Builds two connected components: a chain of 3 nodes ("1"-"2"-"3") and an isolated
+     * node ("4"). The Giant Component filter must keep only the 3-node component.
+     */
+    private Query buildGiantComponentQuery() {
+        GraphGenerator generator = GraphGenerator.build(workspace);
+        GraphModel graphModel = generator.getGraphModel();
+
+        Node n1 = graphModel.factory().newNode("1");
+        Node n2 = graphModel.factory().newNode("2");
+        Node n3 = graphModel.factory().newNode("3");
+        Node n4 = graphModel.factory().newNode("4");
+        Edge e1 = graphModel.factory().newEdge("1", n1, n2, 0, 1.0, false);
+        Edge e2 = graphModel.factory().newEdge("2", n2, n3, 0, 1.0, false);
+
+        Graph graph = graphModel.getGraph();
+        graph.addNode(n1);
+        graph.addNode(n2);
+        graph.addNode(n3);
+        graph.addNode(n4);
+        graph.addEdge(e1);
+        graph.addEdge(e2);
+
+        FilterController filterController = Lookup.getDefault().lookup(FilterController.class);
+        GiantComponentBuilder builder = Lookup.getDefault().lookup(GiantComponentBuilder.class);
+        return filterController.createQuery(builder);
+    }
+
+    private Workspace awaitNewWorkspace(Collection<Workspace> before) {
+        await().atMost(10, TimeUnit.SECONDS).until(() -> project.getWorkspaces().size() > before.size());
+        for (Workspace w : project.getWorkspaces()) {
+            if (!before.contains(w)) {
+                return w;
+            }
+        }
+        throw new AssertionError("New workspace not found");
+    }
+
+    private void assertGiantComponentExported(GraphModel newGraphModel) {
+        await().atMost(10, TimeUnit.SECONDS).until(() -> newGraphModel.getGraph().getNodeCount() > 0);
+        Graph newGraph = newGraphModel.getGraph();
+        assertEquals(3, newGraph.getNodeCount());
+        assertEquals(2, newGraph.getEdgeCount());
+        assertNotNull(newGraph.getNode("1"));
+        assertNotNull(newGraph.getNode("2"));
+        assertNotNull(newGraph.getNode("3"));
+        assertNull(newGraph.getNode("4"));
+    }
+
+    @Test
+    public void testExportProducesFilteredSubgraph() {
+        //Query is never made "current", so exportToNewWorkspace processes it directly
+        //rather than reusing a cached FilterModel result.
+        Query query = buildGiantComponentQuery();
+        Collection<Workspace> before = new ArrayList<>(project.getWorkspaces());
+
+        FilterController filterController = Lookup.getDefault().lookup(FilterController.class);
+        filterController.exportToNewWorkspace(query);
+
+        Workspace newWorkspace = awaitNewWorkspace(before);
+        GraphModel newGraphModel = Lookup.getDefault().lookup(GraphController.class).getGraphModel(newWorkspace);
+        assertGiantComponentExported(newGraphModel);
+    }
+
+    /**
+     * Stress test exercising the locking fix: repeatedly re-runs the model's live
+     * FilterThread for the query that exportToNewWorkspace treats as "current" (so the
+     * export reuses the model's cached GraphView), forcing many destroyView() calls on
+     * that exact view concurrently with the export reading it.
+     */
+    @Test
+    public void testConcurrentFilterChurnDoesNotCorruptExport() throws Exception {
+        Query query = buildGiantComponentQuery();
+        FilterController filterController = Lookup.getDefault().lookup(FilterController.class);
+        GraphController graphController = Lookup.getDefault().lookup(GraphController.class);
+        FilterModelImpl filterModel = (FilterModelImpl) workspace.getLookup().lookup(FilterModel.class);
+
+        filterController.add(query);
+        filterController.filterVisible(query);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> filterModel.getCurrentResult() != null);
+        FilterThread filterThread = filterModel.getFilterThread();
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean stopChurn = new AtomicBoolean(false);
+        Thread churnThread = new Thread(() -> {
+            try {
+                //No sleep: churns as fast as possible for the whole export loop below,
+                //rather than a fixed iteration count that could finish before the export
+                //even starts and leave the two operations never actually overlapping.
+                while (!stopChurn.get()) {
+                    filterThread.setRootQuery((AbstractQueryImpl) query);
+                }
+            } catch (Throwable ex) {
+                failure.compareAndSet(null, ex);
+            }
+        });
+        churnThread.start();
+
+        try {
+            int exportRounds = 20;
+            for (int i = 0; i < exportRounds; i++) {
+                Collection<Workspace> before = new ArrayList<>(project.getWorkspaces());
+                filterController.exportToNewWorkspace(query);
+                Workspace newWorkspace = awaitNewWorkspace(before);
+                GraphModel newGraphModel = graphController.getGraphModel(newWorkspace);
+                assertGiantComponentExported(newGraphModel);
+            }
+        } finally {
+            stopChurn.set(true);
+            churnThread.join(20_000);
+            filterThread.setRunning(false);
+            filterThread.join(10_000);
+        }
+
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent filter churn / export threw", failure.get());
+        }
+    }
+}

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/ExportToNewWorkspaceTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/ExportToNewWorkspaceTest.java
@@ -29,10 +29,9 @@ import org.junit.Test;
 import org.openide.util.Lookup;
 
 /**
- * Regression tests for {@link FilterControllerImpl#exportToNewWorkspace(Query)}, which
- * used to read the source filtered view (copyNodes/hasEdge) with no lock at all while
- * mutating the destination graph, racing against a concurrent filter pass replacing the
- * exact same view.
+ * {@link FilterControllerImpl#exportToNewWorkspace(Query)} must produce a correct copy
+ * of the filtered subgraph even while a concurrent filter pass is replacing the source
+ * view it reads from.
  */
 public class ExportToNewWorkspaceTest {
 
@@ -117,10 +116,10 @@ public class ExportToNewWorkspaceTest {
     }
 
     /**
-     * Stress test exercising the locking fix: repeatedly re-runs the model's live
-     * FilterThread for the query that exportToNewWorkspace treats as "current" (so the
-     * export reuses the model's cached GraphView), forcing many destroyView() calls on
-     * that exact view concurrently with the export reading it.
+     * Repeatedly re-runs the model's live FilterThread for the query that
+     * exportToNewWorkspace treats as "current" (so the export reuses the model's cached
+     * GraphView), forcing many destroyView() calls on that exact view concurrently with
+     * the export reading it.
      */
     @Test
     public void testConcurrentFilterChurnDoesNotCorruptExport() throws Exception {

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterModelImplTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterModelImplTest.java
@@ -1,0 +1,37 @@
+package org.gephi.filters;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.gephi.graph.api.GraphView;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FilterModelImplTest {
+
+    /**
+     * Regression test: setCurrentResult() used to be the only mutator in this class
+     * that never fired the model's ChangeListener, so listeners had no way to know
+     * when an async filter/select operation actually finished (only that it started).
+     */
+    @Test
+    public void testSetCurrentResultFiresChangeEvent() {
+        FilterModelImpl filterModel = Utils.newFilterModelWithGraph();
+        AtomicInteger fireCount = new AtomicInteger();
+        filterModel.addChangeListener(e -> fireCount.incrementAndGet());
+
+        GraphView viewA = filterModel.getGraphModel().getGraph().getView();
+        filterModel.setCurrentResult(viewA);
+        assertEquals(1, fireCount.get());
+
+        //Setting the same reference again must not fire a redundant event
+        filterModel.setCurrentResult(viewA);
+        assertEquals(1, fireCount.get());
+
+        GraphView viewB = filterModel.getGraphModel().copyView(viewA);
+        filterModel.setCurrentResult(viewB);
+        assertEquals(2, fireCount.get());
+
+        filterModel.setCurrentResult(null);
+        assertEquals(3, fireCount.get());
+    }
+}

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterModelImplTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterModelImplTest.java
@@ -9,9 +9,8 @@ import static org.junit.Assert.assertEquals;
 public class FilterModelImplTest {
 
     /**
-     * Regression test: setCurrentResult() used to be the only mutator in this class
-     * that never fired the model's ChangeListener, so listeners had no way to know
-     * when an async filter/select operation actually finished (only that it started).
+     * setCurrentResult() must fire the model's ChangeListener whenever the result
+     * actually changes, so listeners can tell when a filter/select pass finishes.
      */
     @Test
     public void testSetCurrentResultFiresChangeEvent() {

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterThreadTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterThreadTest.java
@@ -1,0 +1,83 @@
+package org.gephi.filters;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.gephi.filters.plugin.graph.GiantComponentBuilder;
+import org.junit.Test;
+
+public class FilterThreadTest {
+
+    /**
+     * Regression test for a lost-wakeup race in {@link FilterThread#run()}: the
+     * condition check and the wait() used to happen in separate synchronized
+     * blocks, so a setRootQuery()/setRunning() notify() landing in the gap between
+     * them was lost forever, hanging the thread in wait() indefinitely.
+     */
+    @Test
+    public void testConcurrentSetRootQueryDoesNotHang() throws Exception {
+        FilterModelImpl filterModel = Utils.newFilterModelWithGraph();
+        AtomicInteger completions = new AtomicInteger();
+        filterModel.addChangeListener(e -> {
+            if (filterModel.getCurrentResult() != null) {
+                completions.incrementAndGet();
+            }
+        });
+
+        FilterQueryImpl query = new FilterQueryImpl(null, new GiantComponentBuilder.GiantComponentFilter());
+        filterModel.setFiltering(true);
+        filterModel.setCurrentQuery(query);
+
+        FilterThread filterThread = new FilterThread(filterModel, query);
+        filterThread.setRootQuery(query);
+        filterThread.start();
+
+        //Hammer setRootQuery() from many threads at once, as happens when filter
+        //properties are edited in rapid succession while a query is mid-flight
+        int before = completions.get();
+        int threadCount = 16;
+        int iterationsPerThread = 200;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < iterationsPerThread; j++) {
+                        filterThread.setRootQuery(query);
+                    }
+                } catch (Throwable ex) {
+                    failure.compareAndSet(null, ex);
+                }
+            });
+            threads.add(t);
+            t.start();
+        }
+        startLatch.countDown();
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent setRootQuery() calls threw", failure.get());
+        }
+
+        //If the race reproduces, the last hammered query is left sitting unconsumed and
+        //the thread is stuck in wait() forever - no further setRootQuery() is issued here,
+        //so recovery must come entirely from the hammering above. Bound the wait so a
+        //regression fails fast instead of hanging the build.
+        await().atMost(10, TimeUnit.SECONDS)
+            .until(() -> filterThread.getRootQuery() == null && completions.get() > before);
+
+        filterThread.setRunning(false);
+        filterThread.join(10_000);
+        assertFalse(filterThread.isAlive());
+    }
+}

--- a/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterThreadTest.java
+++ b/modules/FiltersImpl/src/test/java/org/gephi/filters/FilterThreadTest.java
@@ -15,10 +15,9 @@ import org.junit.Test;
 public class FilterThreadTest {
 
     /**
-     * Regression test for a lost-wakeup race in {@link FilterThread#run()}: the
-     * condition check and the wait() used to happen in separate synchronized
-     * blocks, so a setRootQuery()/setRunning() notify() landing in the gap between
-     * them was lost forever, hanging the thread in wait() indefinitely.
+     * A {@link FilterThread} must keep making progress when setRootQuery() is called
+     * concurrently from many threads - a notify() landing at the wrong moment must
+     * never leave it parked in wait() forever.
      */
     @Test
     public void testConcurrentSetRootQueryDoesNotHang() throws Exception {
@@ -69,10 +68,9 @@ public class FilterThreadTest {
             throw new AssertionError("Concurrent setRootQuery() calls threw", failure.get());
         }
 
-        //If the race reproduces, the last hammered query is left sitting unconsumed and
-        //the thread is stuck in wait() forever - no further setRootQuery() is issued here,
-        //so recovery must come entirely from the hammering above. Bound the wait so a
-        //regression fails fast instead of hanging the build.
+        //No further setRootQuery() call is made here: the last one issued by the
+        //hammering above must, on its own, eventually be consumed and processed.
+        //Bounded so a hang fails the test instead of the build.
         await().atMost(10, TimeUnit.SECONDS)
             .until(() -> filterThread.getRootQuery() == null && completions.get() > before);
 


### PR DESCRIPTION
## Summary

While investigating why an external plugin's filter-related code was polling instead of getting a clean completion signal from Gephi's `FilterController`, we root-caused three real concurrency/locking bugs in `modules/FiltersImpl`:

- **`FilterThread` lost-wakeup race** (`FilterThread.java`): the mailbox check (`rootQuery.getAndSet(null) == null`) and the `wait()` call ran in separate `synchronized` blocks, so a `setRootQuery()`/`setRunning()` notify landing in the gap between them was lost forever, hanging the thread indefinitely. Also made `running` `volatile` — it was read unsynchronized in a couple of spots the wait/notify fix didn't otherwise cover.
- **Missing completion signal** (`FilterModelImpl.java`): `setCurrentResult()` never fired the model's `ChangeListener`, so there was no signal for when an async filter/select pass actually *finished* (only when it *started*), forcing callers to poll graph counts instead. Now fires it, guarded like `setCurrentQuery`. Switched `listeners` to `CopyOnWriteArrayList` — firing from the `FilterThread` this much more often turned the previously-unsynchronized `ArrayList` into a live `ConcurrentModificationException` risk against UI-thread `addChangeListener`/`removeChangeListener` calls.
- **Unlocked read/write race in `exportToNewWorkspace`** (`FilterControllerImpl.java`): the background export thread read the source filtered view and mutated the destination graph with no locking at all, racing a concurrent filter pass that could destroy the exact view being read. Now locks the source view for reads and the destination graph for writes, and fetches the shared cached view as late as possible — immediately before locking it — to minimize the window during which a concurrent pass could still destroy it first.

Deliberately out of scope: turning the async filter/export APIs into a `Future`/`CompletableFuture`-returning public API — that's a larger, separate refactor.

## Test plan

- [x] `mvn -pl modules/FiltersImpl -am test` — full suite (10 test classes, including 3 new ones: `FilterThreadTest`, `FilterModelImplTest`, `ExportToNewWorkspaceTest`) passes clean
- [x] `mvn -pl modules/FiltersImpl -am -PenableCheckStyle checkstyle:check` — clean
- [x] Reviewed by an independent adversarial pass that reproduced a real regression (the `ConcurrentModificationException` above) and two non-discriminating tests, both since fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)