### PR TITLE
Fix radius mouse-selection tool broken by JOML 1.10.9 upgrade

### DIFF
--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/structure/GraphIndexImpl.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/structure/GraphIndexImpl.java
@@ -117,8 +117,13 @@ public class GraphIndexImpl implements GraphIndex {
         final float searchExpansion = getScaledNodeSearchExpansion(nodeScale);
         return getVisibleGraph().getSpatialIndex().getNodesInArea(
             getCircleRect2D(centerX, centerY, radius + searchExpansion),
-            node -> Intersectionf.testCircleCircle(centerX, centerY, radius, node.x(), node.y(),
-                node.size() * nodeScale));
+            node -> {
+                final float nodeSize = node.size() * nodeScale;
+
+                // testCircleCircle takes radii pre-squared, like testPointCircle/testAarCircle below.
+                return Intersectionf.testCircleCircle(centerX, centerY, radius * radius, node.x(), node.y(),
+                    nodeSize * nodeSize);
+            });
     }
 
     @Override


### PR DESCRIPTION
## Description

JOML `1.10.9` (bumped via dependabot in 19f796818) silently changed `Intersectionf.testCircleCircle(float...)`'s parameter semantics: the two radius arguments must now be passed pre-squared, instead of as plain radii. The signature didn't change, so this compiled fine but changed behavior.

`GraphIndexImpl.getNodesInsideCircle` — which backs the "select nodes within radius" mouse tool — still passed plain radii. That silently shrank the effective search radius from `radius` down to `sqrt(radius)`, so the tool stopped picking up nodes outside a very small area around the cursor.

Click-under-pointer selection (`testPointCircle`) and rectangle selection (`testAarCircle`) already used the radius-squared convention, so they were unaffected — only the mouse-selection-radius tool regressed.

Fix: square both `radius` and `node.size() * nodeScale` before passing them to `testCircleCircle`, matching the other two intersection tests already in this file.

Verified against the real 1.10.9 jar with a standalone repro: a node at distance 55 with `radius=50, nodeSize=10` (sum of radii = 60, should be selected) returned `false` before the fix and `true` after.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)