### PR TITLE
Fix filter toolbar stop button not resetting when toggling Filter/Select

### DIFF
--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterControllerImpl.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterControllerImpl.java
@@ -259,8 +259,7 @@ public class FilterControllerImpl implements FilterController, PropertyExecutor,
             && currentThread.getInitialQuery() == query) {
             return;
         }
-        model.setFiltering(query != null);
-        model.setCurrentQuery(query);
+        model.setFilterState(query != null, false, query);
 
         if (currentThread != null) {
             currentThread.setRunning(false);
@@ -299,8 +298,7 @@ public class FilterControllerImpl implements FilterController, PropertyExecutor,
             && currentThread.getInitialQuery() == query) {
             return;
         }
-        model.setSelecting(query != null);
-        model.setCurrentQuery(query);
+        model.setFilterState(false, query != null, query);
 
         if (currentThread != null) {
             currentThread.setRunning(false);

--- a/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelImpl.java
+++ b/modules/FiltersImpl/src/main/java/org/gephi/filters/FilterModelImpl.java
@@ -186,22 +186,33 @@ public class FilterModelImpl implements FilterModel, Model {
         return currentQuery != null && filtering;
     }
 
-    public void setFiltering(boolean filtering) {
-        this.filtering = filtering;
-        if (filtering) {
-            this.selecting = false;
-        }
-    }
-
     @Override
     public boolean isSelecting() {
         return currentQuery != null && selecting;
     }
 
-    public void setSelecting(boolean selecting) {
+    /**
+     * Atomically updates the filtering/selecting flags together with the current query, firing a single
+     * change event if any of them actually changed. Doing this in one step (rather than setting the flags
+     * and the current query separately) avoids notifying listeners with a transiently inconsistent state
+     * (e.g. the new filtering/selecting flag paired with the previous current query).
+     */
+    void setFilterState(boolean filtering, boolean selecting, Query currentQuery) {
+        if (filtering) {
+            selecting = false;
+        } else if (selecting) {
+            filtering = false;
+        }
+        if (currentQuery != null) {
+            currentQuery = ((AbstractQueryImpl) currentQuery).getRoot();
+        }
+        boolean changed =
+            this.filtering != filtering || this.selecting != selecting || this.currentQuery != currentQuery;
+        this.filtering = filtering;
         this.selecting = selecting;
-        if (selecting) {
-            this.filtering = false;
+        this.currentQuery = currentQuery;
+        if (changed) {
+            fireChangeEvent();
         }
     }
 


### PR DESCRIPTION
## Description

The Filters panel toolbar shows a Stop button while a filter/select is running, and a Filter button otherwise. Switching between Filter and Select mode on the same already-selected query left the toolbar showing the stale button, in either direction:

- Filter Q running (Stop visible) → click Select on Q → select runs correctly, but Stop stays visible instead of switching back to Filter.
- Select Q running → click Filter on Q → same issue in reverse.

Root cause: `FilterModelImpl.setFiltering()`/`setSelecting()` flipped their flags without firing a change event. The only change event fired was from `setCurrentQuery()`, gated on the query *reference* actually changing — which it doesn't when toggling mode on the same query. So `FiltersPanel`'s `stateChanged()` → `updateControls()` (the only place that repositions the stop/filter/select buttons) never ran.

Fix: replace the two separate setters with a single atomic `FilterModelImpl.setFilterState(filtering, selecting, query)` that updates `filtering`/`selecting`/`currentQuery` together and fires one change event when anything actually changes, preserving the existing mutual-exclusion invariant between filtering and selecting.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)