### PR TITLE
Update development build links to 0.11.3-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ If you run into any trouble or have questions consult our [discussions](https://
 
 Development builds are [generated regularly](https://github.com/gephi/gephi/actions/workflows/release.yml?query=is%3Asuccess++). Current version is 0.11.3-SNAPSHOT
 
-- [gephi-0.11.3-20260904.210622-15-windows-x64.exe](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260904.210622-15-windows-x64.exe) (Windows)
+- [gephi-0.11.3-20260905.112125-21-windows-x64.exe](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260905.112125-21-windows-x64.exe) (Windows)
 
-- [gephi-0.11.3-20260904.211008-16-macos-x64.dmg](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260904.211008-16-macos-x64.dmg) (Mac OS X)
+- [gephi-0.11.3-20260905.112534-22-macos-x64.dmg](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260905.112534-22-macos-x64.dmg) (Mac OS X)
 
-- [gephi-0.11.3-20260904.212451-18-macos-aarch64.dmg](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260904.212451-18-macos-aarch64.dmg) (Mac OS X Silicon)
+- [gephi-0.11.3-20260905.114240-24-macos-aarch64.dmg](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260905.114240-24-macos-aarch64.dmg) (Mac OS X Silicon)
 
-- [gephi-0.11.3-20260904.212054-17-linux-aarch64.tar.gz](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260904.212054-17-linux-aarch64.tar.gz) (Linux aarch64)
+- [gephi-0.11.3-20260905.114035-23-linux-aarch64.tar.gz](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260905.114035-23-linux-aarch64.tar.gz) (Linux aarch64)
 
-- [gephi-0.11.3-20260904.210427-14-linux-x64.tar.gz](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260904.210427-14-linux-x64.tar.gz) (Linux)
+- [gephi-0.11.3-20260905.111946-20-linux-x64.tar.gz](https://central.sonatype.com/repository/maven-snapshots/org/gephi/gephi/0.11.3-SNAPSHOT/gephi-0.11.3-20260905.111946-20-linux-x64.tar.gz) (Linux)
 
 ## Developer Introduction
 


### PR DESCRIPTION
## Description

Refreshes the README's "Development builds" links to the artifacts produced by the latest fully-successful `release` workflow run: https://github.com/gephi/gephi/actions/runs/33961325009.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [x] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren't needed