### PR TITLE
Fix edge weight checkbox state bugs in Overview edge settings

### DIFF
--- a/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractEdgeData.java
+++ b/modules/VisualizationEngine/src/main/java/org/gephi/viz/engine/jogl/pipeline/common/AbstractEdgeData.java
@@ -469,16 +469,15 @@ public abstract class AbstractEdgeData extends AbstractSelectionData {
     }
 
     public EdgeWorldData createWorldData(VizEngineModel model, VizEngine<JOGLRenderingTarget, NEWTEvent> engine) {
+        final boolean rescaleWeight = edgeWeightEnabled && model.getRenderingOptions().isEdgeRescaleWeightEnabled();
         return new EdgeWorldData(
             model.getRenderingOptions().getBackgroundColor(),
             someSelection,
             edgeSelectionColor,
             edgeWeightEnabled ? edgesCallback.getMinWeight() : 0f,
             edgeWeightEnabled ? edgesCallback.getMaxWeight() : 1f,
-            model.getRenderingOptions().isEdgeRescaleWeightEnabled() ? model.getRenderingOptions().getEdgeRescaleMin() :
-                1f,
-            model.getRenderingOptions().isEdgeRescaleWeightEnabled() ? model.getRenderingOptions().getEdgeRescaleMax() :
-                1f,
+            rescaleWeight ? model.getRenderingOptions().getEdgeRescaleMin() : 1f,
+            rescaleWeight ? model.getRenderingOptions().getEdgeRescaleMax() : 1f,
             model.getRenderingOptions().getNodeScale(),
             model.getRenderingOptions().getEdgeScale(),
             model.getRenderingOptions().isLightenNonSelected() ?

--- a/modules/VisualizationImpl/src/main/java/org/gephi/desktop/visualization/collapse/EdgeSettingsPanel.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/desktop/visualization/collapse/EdgeSettingsPanel.java
@@ -94,6 +94,8 @@ public class EdgeSettingsPanel extends javax.swing.JPanel implements Visualizati
     private javax.swing.JCheckBox useEdgeWeightCheckbox;
     // End of variables declaration//GEN-END:variables
 
+    private VisualizationModel currentModel;
+
     /**
      * Creates new form EdgeSettingsPanel
      */
@@ -148,12 +150,12 @@ public class EdgeSettingsPanel extends javax.swing.JPanel implements Visualizati
 
         showEdgesCheckbox.addItemListener(e -> {
             vizController.setShowEdges(showEdgesCheckbox.isSelected());
-            setEnable(true, null);
+            setEnable(true, currentModel);
         });
         selectionColorCheckbox.addItemListener(
             e -> {
                 vizController.setEdgeSelectionColor(selectionColorCheckbox.isSelected());
-                setEnable(true, null);
+                setEnable(true, currentModel);
             });
         edgeInSelectionColorChooser.addActionListener(
             ae -> vizController.setEdgeInSelectionColor(edgeInSelectionColorChooser.getColor()));
@@ -172,7 +174,7 @@ public class EdgeSettingsPanel extends javax.swing.JPanel implements Visualizati
         });
         useEdgeWeightCheckbox.addItemListener(e -> {
             vizController.setUseEdgeWeight(useEdgeWeightCheckbox.isSelected());
-            setEnable(true, null);
+            setEnable(true, currentModel);
         });
         rescaleEdgeWeightCheckbox.addItemListener(
             e -> vizController.setRescaleEdgeWeight(rescaleEdgeWeightCheckbox.isSelected()));
@@ -210,6 +212,7 @@ public class EdgeSettingsPanel extends javax.swing.JPanel implements Visualizati
     }
 
     public void setup(VisualizationModel model) {
+        currentModel = model;
         if (model == null) {
             setEnable(false, null);
             return;
@@ -220,6 +223,7 @@ public class EdgeSettingsPanel extends javax.swing.JPanel implements Visualizati
     }
 
     public void unsetup(VisualizationModel model) {
+        currentModel = null;
         vizController.removePropertyChangeListener(this);
     }
 

--- a/modules/VisualizationImpl/src/main/java/org/gephi/visualization/VizModel.java
+++ b/modules/VisualizationImpl/src/main/java/org/gephi/visualization/VizModel.java
@@ -539,7 +539,7 @@ public class VizModel implements VisualizationModel {
         if (oldValue != edgeRescaleWeightEnabled) {
             this.edgeRescaleWeightEnabled = edgeRescaleWeightEnabled;
             getRenderingOptions().ifPresent(options -> options.setEdgeRescaleWeightEnabled(edgeRescaleWeightEnabled));
-            firePropertyChange("edgeRescaleWeightEnabled", oldValue, edgeRescaleWeightEnabled);
+            firePropertyChange("rescaleEdgeWeight", oldValue, edgeRescaleWeightEnabled);
         }
     }
 


### PR DESCRIPTION
## Description

Fixes bugs around "Use edge weight" / "Rescale edge weight" in the Overview edge settings (`EdgeSettingsPanel`) — both a UI state bug and, more importantly, an actual rendering bug found while double-checking the UI fix.

1. **Edge weight estimator combo gets permanently disabled.** The `Show edges`, `Selection color`, and `Use edge weight` checkbox item listeners called `setEnable(true, null)`. `setEnable`'s logic for the estimator combo/label requires `model != null`, so after the very first click on any of those checkboxes the "Edge weight estimator" dropdown became disabled and never re-enabled itself, regardless of further clicks. Fixed by caching the active `VisualizationModel` in a field and passing it through instead of `null`.

2. **Dead property-change listener for "Rescale edge weight".** `VizModel.setEdgeRescaleWeightEnabled` fired the change event as `"edgeRescaleWeightEnabled"`, but `EdgeSettingsPanel.propertyChange` (its only listener) checked for `"rescaleEdgeWeight"`. The names never matched, so the event was silently dropped. Renamed the fired event to `"rescaleEdgeWeight"` to match the listener and the naming convention used by the other boolean toggles (`"useEdgeWeight"`, `"showEdges"`, etc.).

3. **Rescaling was still applied under the hood after disabling "Use edge weight".** Unchecking "Use edge weight" only greys out "Rescale edge weight" in the UI - it doesn't reset its stored value. `AbstractEdgeData.createWorldData()` gated the rescale min/max range on `isEdgeRescaleWeightEnabled()` alone, not on `edgeWeightEnabled`. With edge weight disabled, every edge's per-vertex weight collapses to a constant `1f` while `minWeight`/`maxWeight` become `0`/`1`, which normalizes to `1.0` and pins the shader's `mix(edgeRescaleMin, edgeRescaleMax, ...)` at `edgeRescaleMax` - so every edge rendered at the *maximum* rescale thickness (e.g. `8.0 × edgeScale` with defaults) instead of a uniform `edgeScale`, as long as rescale had ever been left on. Fixed by collapsing the rescale range to a no-op whenever edge weight itself is disabled, independent of the rescale flag's own stored value.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed