### PR TITLE
Fix statistics report showing wrong workspace's values after switching workspace

### DIFF
--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsFrontEnd.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsFrontEnd.java
@@ -203,11 +203,14 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
                 return;
             }
 
+            //Capture the model, the execution outcome is reported from a background
+            //thread and the current workspace may have changed in the meantime
+            final StatisticsModelUI runModel = currentModel;
             LongTaskListener listener = new LongTaskListener() {
 
                 @Override
                 public void taskFinished(LongTask task) {
-                    showReport();
+                    showReport(runModel);
                 }
             };
             JPanel settingsPanel = statisticsUI.getSettingsPanel();
@@ -249,7 +252,14 @@ public class StatisticsFrontEnd extends javax.swing.JPanel {
     }
 
     private void showReport() {
-        final String report = currentModel.getReport(statisticsUI.getStatisticsClass());
+        showReport(currentModel);
+    }
+
+    private void showReport(StatisticsModelUI model) {
+        if (model == null) {
+            return;
+        }
+        final String report = model.getReport(statisticsUI.getStatisticsClass());
         if (report != null) {
             SwingUtilities.invokeLater(new Runnable() {
 


### PR DESCRIPTION
## Description

Running a long statistic (e.g. Statistical Inference) on a large graph and switching workspace before it finishes could cause the auto-shown report dialog to display the wrong workspace's report (or none / stale zero values) instead of the results just computed.

Root cause: `StatisticsFrontEnd` is a single panel instance shared across all workspaces; its `currentModel` field is reassigned on every workspace switch. The `LongTaskListener` registered when a run starts called `showReport()`, which read the report through that live, mutable field instead of the model bound to the workspace the run actually started in. `StatisticsControllerUIImpl.execute()` already works around this exact race for `setRunning`/`addResult` (see its "Capture the model..." comment), but the same fix was missing from `StatisticsFrontEnd`.

Fix: capture the workspace's `StatisticsModelUI` at the moment the run is launched, and use that captured reference (instead of the live field) when showing the report on task completion. The "view report" button keeps using the live field, since a manual click should reflect whatever workspace is currently displayed.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [ ] 👍 README.md
- [ ] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [x] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)