### PR TITLE
Fix NPE and cross-workspace corruption when running the same statistic concurrently

### DIFF
--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
@@ -43,9 +43,6 @@ Portions Copyrighted 2011 Gephi Consortium.
 package org.gephi.desktop.statistics;
 
 import java.util.ArrayList;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Semaphore;
 import org.gephi.desktop.statistics.api.StatisticsControllerUI;
 import org.gephi.statistics.api.StatisticsController;
 import org.gephi.statistics.spi.Statistics;
@@ -67,11 +64,6 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
 
     //    private final DynamicModelListener dynamicModelListener;
     private StatisticsModelUIImpl model;
-    //StatisticsUI implementations are singletons shared by all workspaces and stash the
-    //running Statistics instance in a field between setup() and unsetup(), so two
-    //workspaces running the same statistics class concurrently would corrupt each
-    //other's state. Serialize per statistics class instead of allowing that overlap.
-    private final Map<Class<? extends Statistics>, Semaphore> executionLocks = new ConcurrentHashMap<>();
 
     public StatisticsControllerUIImpl() {
 //        dynamicModelListener = new DynamicModelListener() {
@@ -129,77 +121,45 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
         final StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
         final StatisticsUI[] uis = getUI(statistics);
 
+        for (StatisticsUI s : uis) {
+            s.setup(statistics);
+        }
         //Capture the model, the execution outcome is reported from a background
         //thread and the current workspace may have changed in the meantime
         final StatisticsModelUIImpl uiModel = model;
         if (uiModel == null) {
             return;
         }
+        uiModel.setRunning(statistics, true);
 
-        //Only one workspace at a time may drive a given statistics class through the
-        //shared StatisticsUI singletons (see executionLocks javadoc above)
-        final Semaphore lock = executionLocks.computeIfAbsent(statistics.getClass(), c -> new Semaphore(1));
-        if (!lock.tryAcquire()) {
-            notifyAlreadyRunning(controller, statistics);
-            return;
-        }
+        controller.execute(statistics, new LongTaskListener() {
 
-        try {
-            for (StatisticsUI s : uis) {
-                s.setup(statistics);
+            @Override
+            public void taskFinished(LongTask task) {
+                uiModel.setRunning(statistics, false);
+                for (StatisticsUI s : uis) {
+                    uiModel.addResult(s, statistics);
+                    s.unsetup();
+                }
+                if (listener != null) {
+                    listener.taskFinished(statistics instanceof LongTask ? (LongTask) statistics : null);
+                }
             }
-            uiModel.setRunning(statistics, true);
 
-            controller.execute(statistics, new LongTaskListener() {
-
-                @Override
-                public void taskFinished(LongTask task) {
-                    try {
-                        uiModel.setRunning(statistics, false);
-                        for (StatisticsUI s : uis) {
-                            uiModel.addResult(s);
-                            s.unsetup();
-                        }
-                    } finally {
-                        lock.release();
-                    }
-                    if (listener != null) {
-                        listener.taskFinished(statistics instanceof LongTask ? (LongTask) statistics : null);
-                    }
+            @Override
+            public void fatalError(Throwable t) {
+                //No result to collect from a failed execution, but the running state
+                //has to be cleared or the front-end stays stuck on 'Cancel'
+                uiModel.setRunning(statistics, false);
+                for (StatisticsUI s : uis) {
+                    s.unsetup();
                 }
-
-                @Override
-                public void fatalError(Throwable t) {
-                    //No result to collect from a failed execution, but the running state
-                    //has to be cleared or the front-end stays stuck on 'Cancel'
-                    try {
-                        uiModel.setRunning(statistics, false);
-                        for (StatisticsUI s : uis) {
-                            s.unsetup();
-                        }
-                    } finally {
-                        lock.release();
-                    }
-                    notifyExecutionError(controller, statistics, t);
-                    if (listener != null) {
-                        listener.fatalError(t);
-                    }
+                notifyExecutionError(controller, statistics, t);
+                if (listener != null) {
+                    listener.fatalError(t);
                 }
-            });
-        } catch (RuntimeException e) {
-            //The background listener above is only reachable once controller.execute()
-            //has scheduled the task; any failure before that would otherwise leak the lock
-            lock.release();
-            throw e;
-        }
-    }
-
-    private static void notifyAlreadyRunning(StatisticsController controller, Statistics statistics) {
-        StatisticsBuilder builder = controller.getBuilder(statistics.getClass());
-        String name = builder != null ? builder.getName() : statistics.getClass().getSimpleName();
-        DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(
-            NbBundle.getMessage(StatisticsControllerUIImpl.class, "StatisticsControllerUIImpl.alreadyRunning", name),
-            NotifyDescriptor.WARNING_MESSAGE));
+            }
+        });
     }
 
     private static void notifyExecutionError(StatisticsController controller, Statistics statistics, Throwable t) {

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsControllerUIImpl.java
@@ -43,6 +43,9 @@ Portions Copyrighted 2011 Gephi Consortium.
 package org.gephi.desktop.statistics;
 
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import org.gephi.desktop.statistics.api.StatisticsControllerUI;
 import org.gephi.statistics.api.StatisticsController;
 import org.gephi.statistics.spi.Statistics;
@@ -64,6 +67,11 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
 
     //    private final DynamicModelListener dynamicModelListener;
     private StatisticsModelUIImpl model;
+    //StatisticsUI implementations are singletons shared by all workspaces and stash the
+    //running Statistics instance in a field between setup() and unsetup(), so two
+    //workspaces running the same statistics class concurrently would corrupt each
+    //other's state. Serialize per statistics class instead of allowing that overlap.
+    private final Map<Class<? extends Statistics>, Semaphore> executionLocks = new ConcurrentHashMap<>();
 
     public StatisticsControllerUIImpl() {
 //        dynamicModelListener = new DynamicModelListener() {
@@ -121,45 +129,77 @@ public class StatisticsControllerUIImpl implements StatisticsControllerUI {
         final StatisticsController controller = Lookup.getDefault().lookup(StatisticsController.class);
         final StatisticsUI[] uis = getUI(statistics);
 
-        for (StatisticsUI s : uis) {
-            s.setup(statistics);
-        }
         //Capture the model, the execution outcome is reported from a background
         //thread and the current workspace may have changed in the meantime
         final StatisticsModelUIImpl uiModel = model;
         if (uiModel == null) {
             return;
         }
-        uiModel.setRunning(statistics, true);
 
-        controller.execute(statistics, new LongTaskListener() {
+        //Only one workspace at a time may drive a given statistics class through the
+        //shared StatisticsUI singletons (see executionLocks javadoc above)
+        final Semaphore lock = executionLocks.computeIfAbsent(statistics.getClass(), c -> new Semaphore(1));
+        if (!lock.tryAcquire()) {
+            notifyAlreadyRunning(controller, statistics);
+            return;
+        }
 
-            @Override
-            public void taskFinished(LongTask task) {
-                uiModel.setRunning(statistics, false);
-                for (StatisticsUI s : uis) {
-                    uiModel.addResult(s);
-                    s.unsetup();
-                }
-                if (listener != null) {
-                    listener.taskFinished(statistics instanceof LongTask ? (LongTask) statistics : null);
-                }
+        try {
+            for (StatisticsUI s : uis) {
+                s.setup(statistics);
             }
+            uiModel.setRunning(statistics, true);
 
-            @Override
-            public void fatalError(Throwable t) {
-                //No result to collect from a failed execution, but the running state
-                //has to be cleared or the front-end stays stuck on 'Cancel'
-                uiModel.setRunning(statistics, false);
-                for (StatisticsUI s : uis) {
-                    s.unsetup();
+            controller.execute(statistics, new LongTaskListener() {
+
+                @Override
+                public void taskFinished(LongTask task) {
+                    try {
+                        uiModel.setRunning(statistics, false);
+                        for (StatisticsUI s : uis) {
+                            uiModel.addResult(s);
+                            s.unsetup();
+                        }
+                    } finally {
+                        lock.release();
+                    }
+                    if (listener != null) {
+                        listener.taskFinished(statistics instanceof LongTask ? (LongTask) statistics : null);
+                    }
                 }
-                notifyExecutionError(controller, statistics, t);
-                if (listener != null) {
-                    listener.fatalError(t);
+
+                @Override
+                public void fatalError(Throwable t) {
+                    //No result to collect from a failed execution, but the running state
+                    //has to be cleared or the front-end stays stuck on 'Cancel'
+                    try {
+                        uiModel.setRunning(statistics, false);
+                        for (StatisticsUI s : uis) {
+                            s.unsetup();
+                        }
+                    } finally {
+                        lock.release();
+                    }
+                    notifyExecutionError(controller, statistics, t);
+                    if (listener != null) {
+                        listener.fatalError(t);
+                    }
                 }
-            }
-        });
+            });
+        } catch (RuntimeException e) {
+            //The background listener above is only reachable once controller.execute()
+            //has scheduled the task; any failure before that would otherwise leak the lock
+            lock.release();
+            throw e;
+        }
+    }
+
+    private static void notifyAlreadyRunning(StatisticsController controller, Statistics statistics) {
+        StatisticsBuilder builder = controller.getBuilder(statistics.getClass());
+        String name = builder != null ? builder.getName() : statistics.getClass().getSimpleName();
+        DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(
+            NbBundle.getMessage(StatisticsControllerUIImpl.class, "StatisticsControllerUIImpl.alreadyRunning", name),
+            NotifyDescriptor.WARNING_MESSAGE));
     }
 
     private static void notifyExecutionError(StatisticsController controller, Statistics statistics, Throwable t) {

--- a/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
+++ b/modules/DesktopStatistics/src/main/java/org/gephi/desktop/statistics/StatisticsModelUIImpl.java
@@ -80,11 +80,12 @@ public class StatisticsModelUIImpl implements StatisticsModelUI {
         listeners = new ArrayList<>();
     }
 
-    public void addResult(StatisticsUI ui) {
-        if (resultMap.containsKey(ui) && ui.getValue() == null) {
+    public void addResult(StatisticsUI ui, Statistics statistics) {
+        String value = ui.getValue(statistics);
+        if (resultMap.containsKey(ui) && value == null) {
             resultMap.remove(ui);
         } else {
-            resultMap.put(ui, ui.getValue());
+            resultMap.put(ui, value);
         }
         fireChangeEvent();
     }

--- a/modules/DesktopStatistics/src/main/resources/org/gephi/desktop/statistics/Bundle.properties
+++ b/modules/DesktopStatistics/src/main/resources/org/gephi/desktop/statistics/Bundle.properties
@@ -22,6 +22,7 @@ StatisticsFrontEnd.runButton.text=Run
 StatisticsFrontEnd.notDynamicGraph=Can't run a dynamic statistic if the graph isn't dynamic
 
 StatisticsControllerUIImpl.executionError=Execution of {0} failed with the following error: {1}
+StatisticsControllerUIImpl.alreadyRunning={0} is already running in another workspace. Please wait for it to finish before running it again.
 
 DynamicSettingsPanel.TimeUnit.DAYS=DAYS
 DynamicSettingsPanel.TimeUnit.HOURS=HOURS

--- a/modules/DesktopStatistics/src/main/resources/org/gephi/desktop/statistics/Bundle.properties
+++ b/modules/DesktopStatistics/src/main/resources/org/gephi/desktop/statistics/Bundle.properties
@@ -22,7 +22,6 @@ StatisticsFrontEnd.runButton.text=Run
 StatisticsFrontEnd.notDynamicGraph=Can't run a dynamic statistic if the graph isn't dynamic
 
 StatisticsControllerUIImpl.executionError=Execution of {0} failed with the following error: {1}
-StatisticsControllerUIImpl.alreadyRunning={0} is already running in another workspace. Please wait for it to finish before running it again.
 
 DynamicSettingsPanel.TimeUnit.DAYS=DAYS
 DynamicSettingsPanel.TimeUnit.HOURS=HOURS

--- a/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsControllerUIImplTest.java
+++ b/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsControllerUIImplTest.java
@@ -110,6 +110,32 @@ public class StatisticsControllerUIImplTest {
         Assert.assertTrue("The statistics UI wasn't unsetup", TestStatisticsUI.isUnsetup());
     }
 
+    @Test
+    public void testConcurrentRunOfSameStatisticsIsRejected() throws InterruptedException {
+        CountDownLatch releaseFirstRun = new CountDownLatch(1);
+        RecordingListener firstListener = new RecordingListener();
+        RecordingListener secondListener = new RecordingListener();
+
+        controllerUI.execute(new TestStatistics(false, releaseFirstRun), firstListener);
+        controllerUI.execute(new TestStatistics(false), secondListener);
+
+        NotifyDescriptor descriptor = CapturingDialogDisplayer.awaitMessage();
+        Assert.assertNotNull("No dialog was shown for the rejected concurrent execution", descriptor);
+        Assert.assertEquals(NotifyDescriptor.WARNING_MESSAGE, descriptor.getMessageType());
+        String message = String.valueOf(descriptor.getMessage());
+        Assert.assertTrue("Message doesn't name the busy algorithm: " + message, message.contains(BUILDER_NAME));
+
+        Assert.assertTrue("The rejected run's listener should not have been notified",
+            secondListener.getCalls().isEmpty());
+        Assert.assertTrue("The first run should still be reported as running", model.isRunning(statisticsUI()));
+
+        releaseFirstRun.countDown();
+        Assert.assertTrue("The first listener was never notified", firstListener.await());
+        Assert.assertEquals(List.of("taskFinished"), firstListener.getCalls());
+        Assert.assertFalse("The statistics is still reported as running after completion",
+            model.isRunning(statisticsUI()));
+    }
+
     private StatisticsUI statisticsUI() {
         StatisticsUI[] uis = controllerUI.getUI(new TestStatistics(false));
         Assert.assertEquals("The test StatisticsUI isn't registered in Lookup", 1, uis.length);
@@ -145,13 +171,27 @@ public class StatisticsControllerUIImplTest {
     public static class TestStatistics implements Statistics {
 
         private final boolean fail;
+        private final CountDownLatch blockUntil;
 
         public TestStatistics(boolean fail) {
+            this(fail, null);
+        }
+
+        public TestStatistics(boolean fail, CountDownLatch blockUntil) {
             this.fail = fail;
+            this.blockUntil = blockUntil;
         }
 
         @Override
         public void execute(GraphModel graphModel) {
+            if (blockUntil != null) {
+                try {
+                    Assert.assertTrue("Test setup issue: blockUntil was never released",
+                        blockUntil.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
             if (fail) {
                 throw new IllegalStateException(FAILURE_MESSAGE);
             }

--- a/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsControllerUIImplTest.java
+++ b/modules/DesktopStatistics/src/test/java/org/gephi/desktop/statistics/StatisticsControllerUIImplTest.java
@@ -27,7 +27,9 @@ import org.openide.util.Lookup;
 
 /**
  * Checks that a statistics algorithm which throws is reported to the user with the name of the
- * failing algorithm and doesn't leave the front-end stuck in the running state.
+ * failing algorithm and doesn't leave the front-end stuck in the running state, and that running
+ * the same statistics class concurrently in more than one workspace doesn't cross-contaminate or
+ * crash (StatisticsUI implementations are singletons shared by all workspaces).
  */
 public class StatisticsControllerUIImplTest {
 
@@ -111,29 +113,34 @@ public class StatisticsControllerUIImplTest {
     }
 
     @Test
-    public void testConcurrentRunOfSameStatisticsIsRejected() throws InterruptedException {
+    public void testConcurrentRunsDoNotCrossContaminateResults() throws InterruptedException {
         CountDownLatch releaseFirstRun = new CountDownLatch(1);
         RecordingListener firstListener = new RecordingListener();
         RecordingListener secondListener = new RecordingListener();
 
-        controllerUI.execute(new TestStatistics(false, releaseFirstRun), firstListener);
-        controllerUI.execute(new TestStatistics(false), secondListener);
+        TestStatistics first = new TestStatistics(false, "10", releaseFirstRun);
+        TestStatistics second = new TestStatistics(false, "20", null);
 
-        NotifyDescriptor descriptor = CapturingDialogDisplayer.awaitMessage();
-        Assert.assertNotNull("No dialog was shown for the rejected concurrent execution", descriptor);
-        Assert.assertEquals(NotifyDescriptor.WARNING_MESSAGE, descriptor.getMessageType());
-        String message = String.valueOf(descriptor.getMessage());
-        Assert.assertTrue("Message doesn't name the busy algorithm: " + message, message.contains(BUILDER_NAME));
+        // Simulates a second workspace starting the same statistics class while the first is
+        // still running: setup() is called again on the shared StatisticsUI singleton before
+        // the first run's taskFinished (and its addResult/getValue call) has happened.
+        controllerUI.execute(first, firstListener);
+        controllerUI.execute(second, secondListener);
 
-        Assert.assertTrue("The rejected run's listener should not have been notified",
-            secondListener.getCalls().isEmpty());
-        Assert.assertTrue("The first run should still be reported as running", model.isRunning(statisticsUI()));
+        Assert.assertTrue("The second run's listener was never notified", secondListener.await());
+        Assert.assertEquals(List.of("taskFinished"), secondListener.getCalls());
+        Assert.assertEquals("20", model.getResult(statisticsUI()));
 
         releaseFirstRun.countDown();
-        Assert.assertTrue("The first listener was never notified", firstListener.await());
+
+        Assert.assertTrue(
+            "The first run's listener was never notified (a getValue() reading state left over "
+                + "by the second run's setup()/unsetup() would NPE or hang here instead)",
+            firstListener.await());
         Assert.assertEquals(List.of("taskFinished"), firstListener.getCalls());
-        Assert.assertFalse("The statistics is still reported as running after completion",
-            model.isRunning(statisticsUI()));
+        Assert.assertEquals("The result must come from the just-finished Statistics instance, "
+                + "not from whatever another workspace's run last passed to setup()",
+            "10", model.getResult(statisticsUI()));
     }
 
     private StatisticsUI statisticsUI() {
@@ -171,14 +178,16 @@ public class StatisticsControllerUIImplTest {
     public static class TestStatistics implements Statistics {
 
         private final boolean fail;
+        private final String resultValue;
         private final CountDownLatch blockUntil;
 
         public TestStatistics(boolean fail) {
-            this(fail, null);
+            this(fail, RESULT_VALUE, null);
         }
 
-        public TestStatistics(boolean fail, CountDownLatch blockUntil) {
+        public TestStatistics(boolean fail, String resultValue, CountDownLatch blockUntil) {
             this.fail = fail;
+            this.resultValue = resultValue;
             this.blockUntil = blockUntil;
         }
 
@@ -200,6 +209,10 @@ public class StatisticsControllerUIImplTest {
         @Override
         public String getReport() {
             return REPORT;
+        }
+
+        String getResultValue() {
+            return resultValue;
         }
     }
 
@@ -255,7 +268,14 @@ public class StatisticsControllerUIImplTest {
 
         @Override
         public String getValue() {
-            return RESULT_VALUE;
+            //Deprecated overload: intentionally unimplemented so this test fails loudly if
+            //production code ever falls back to it instead of getValue(Statistics)
+            throw new UnsupportedOperationException("getValue(Statistics) should be used instead");
+        }
+
+        @Override
+        public String getValue(Statistics statistics) {
+            return ((TestStatistics) statistics).getResultValue();
         }
 
         @Override

--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/StatisticsUI.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/spi/StatisticsUI.java
@@ -106,8 +106,27 @@ public interface StatisticsUI {
      * Returns this statistics result as a String, if exists
      *
      * @return this statistics' result string
+     * @deprecated Relies on whatever <code>Statistics</code> instance the last {@link #setup(Statistics)}
+     * call stashed, which is unsafe if the same statistics class is executed concurrently in more than
+     * one workspace, since implementations of this interface are singletons shared by the whole
+     * application. Implement {@link #getValue(Statistics)} instead.
      */
+    @Deprecated
     String getValue();
+
+    /**
+     * Returns this statistics result as a String for the given, just-executed statistics
+     * instance, if it exists.
+     * <p>
+     * The default implementation falls back to the deprecated {@link #getValue()} for
+     * implementations that predate this method.
+     *
+     * @param statistics the statistics instance that was just executed
+     * @return this statistics' result string
+     */
+    default String getValue(Statistics statistics) {
+        return getValue();
+    }
 
     /**
      * Returns this statistics display name

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ClusteringCoefficientUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ClusteringCoefficientUI.java
@@ -94,6 +94,12 @@ public class ClusteringCoefficientUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((ClusteringCoefficient) statistics).getAverageClusteringCoefficient());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "ClusteringCoefficientUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ConnectedComponentUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ConnectedComponentUI.java
@@ -94,6 +94,12 @@ public class ConnectedComponentUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((ConnectedComponents) statistics).getConnectedComponentsCount());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "ConnectedComponentUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DegreeUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DegreeUI.java
@@ -85,6 +85,12 @@ public class DegreeUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((Degree) statistics).getAverageDegree());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "InOutDegreeUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DiameterUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/DiameterUI.java
@@ -93,6 +93,12 @@ public class DiameterUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((GraphDistance) statistics).getDiameter());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DiameterUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/EigenvectorCentralityUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/EigenvectorCentralityUI.java
@@ -97,6 +97,11 @@ public class EigenvectorCentralityUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        return null;
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "EigenvectorCentralityUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/GraphDensityUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/GraphDensityUI.java
@@ -91,6 +91,12 @@ public class GraphDensityUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((GraphDensity) statistics).getDensity());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "GraphDensityUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/HitsUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/HitsUI.java
@@ -97,6 +97,11 @@ public class HitsUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        return null;
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "HitsUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ModularityUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/ModularityUI.java
@@ -100,6 +100,12 @@ public class ModularityUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((Modularity) statistics).getModularity());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "ModularityUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PageRankUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PageRankUI.java
@@ -98,6 +98,11 @@ public class PageRankUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        return null;
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "PageRankUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PathLengthUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/PathLengthUI.java
@@ -93,6 +93,12 @@ public class PathLengthUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((GraphDistance) statistics).getPathLength());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "PathLengthUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/StatisticalInferenceClusteringUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/StatisticalInferenceClusteringUI.java
@@ -82,6 +82,12 @@ public class StatisticalInferenceClusteringUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((StatisticalInferenceClustering) statistics).getDescriptionLength());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "StatisticalInferenceClusteringUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/WeightedDegreeUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/WeightedDegreeUI.java
@@ -85,6 +85,12 @@ public class WeightedDegreeUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        DecimalFormat df = new DecimalFormat("###.###");
+        return "" + df.format(((WeightedDegree) statistics).getAverageDegree());
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "WeightedDegreeUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicClusteringCoefficientUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicClusteringCoefficientUI.java
@@ -96,6 +96,11 @@ public class DynamicClusteringCoefficientUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        return "";
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicClusteringCoefficientUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicDegreeUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicDegreeUI.java
@@ -97,6 +97,11 @@ public class DynamicDegreeUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        return "";
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicDegreeUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbEdgesUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbEdgesUI.java
@@ -92,6 +92,11 @@ public class DynamicNbEdgesUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        return "";
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicNbEdgesUI.name");
     }

--- a/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbNodesUI.java
+++ b/modules/StatisticsPluginUI/src/main/java/org/gephi/ui/statistics/plugin/dynamic/DynamicNbNodesUI.java
@@ -92,6 +92,11 @@ public class DynamicNbNodesUI implements StatisticsUI {
     }
 
     @Override
+    public String getValue(Statistics statistics) {
+        return "";
+    }
+
+    @Override
     public String getDisplayName() {
         return NbBundle.getMessage(getClass(), "DynamicNbNodesUI.name");
     }

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -72,6 +72,10 @@
             <li>Added a <code>fatalError(Throwable)</code> default method to <code>LongTaskListener</code>. It is called when a task terminates with an uncaught exception, instead of <code>taskFinished()</code>, so that a single listener receives both outcomes. The default implementation does nothing, therefore existing listeners are unaffected.</li>
             <li><code>LongTaskErrorHandler</code> and <code>LongTaskExecutor.setDefaultErrorHandler()</code> are deprecated in favor of <code>LongTaskListener.fatalError(Throwable)</code>. They remain fully functional and are still invoked, in addition to the listener.</li>
         </ul>
+        <h4>Statistics API</h4>
+        <ul>
+            <li>Added a <code>getValue(Statistics)</code> default method to <code>StatisticsUI</code>, superseding the no-argument <code>getValue()</code> which is now deprecated. Implementations of <code>StatisticsUI</code> are singletons shared by every workspace, so a result computed from state stashed by <code>setup(Statistics)</code> is unsafe when the same statistics class runs concurrently in more than one workspace. The default implementation of <code>getValue(Statistics)</code> falls back to the deprecated <code>getValue()</code>, so existing implementations keep compiling and working unchanged until migrated.</li>
+        </ul>
         <h3>0.10.0</h3>
         <h4>Project API</h4>
         <ul>


### PR DESCRIPTION
## Description

Running the same statistic (e.g. Statistical Inference) in two workspaces at the same time throws:

```
java.lang.NullPointerException: Cannot invoke "org.gephi.statistics.plugin.StatisticalInferenceClustering.getDescriptionLength()" because "this.descriptionLength" is null
	at org.gephi.ui.statistics.plugin.StatisticalInferenceClusteringUI.getValue(StatisticalInferenceClusteringUI.java:81)
	at org.gephi.desktop.statistics.StatisticsModelUIImpl.addResult(StatisticsModelUIImpl.java:84)
	at org.gephi.desktop.statistics.StatisticsControllerUIImpl$1.taskFinished(StatisticsControllerUIImpl.java:141)
```

Root cause: every `StatisticsUI` implementation is registered as a `@ServiceProvider` singleton shared by all workspaces. `setup(statistics)` stashes the running `Statistics` instance in an instance field, `getValue()` reads it, `unsetup()` nulls it. Two workspaces running the same statistics class concurrently race on that shared field: whichever finishes first calls `unsetup()` and nulls it out from under the other, which crashes on `getValue()` (or, without the crash, could silently read/report the wrong workspace's value). Most of the ~16 `StatisticsUI` implementations follow this same pattern, so the bug isn't specific to Statistical Inference.

An earlier version of this PR serialized runs per statistics class with a `Semaphore`. A review caught that this didn't actually close the bug: `StatisticsFrontEnd`'s pre-execution `setup()`/`unsetup()` calls around a statistic's settings panel (e.g. Modularity) happen outside that lock, so the same race — and for statistics with no settings panel, a redundant `setup()` call ahead of the lock check turned the crash into guaranteed silent data corruption instead of fixing it.

This version fixes the actual root cause instead: `StatisticsUI.getValue()` is deprecated and a new `getValue(Statistics)` is added as a **default method** (falling back to the deprecated `getValue()` for any implementation that hasn't migrated, so third-party `StatisticsUI` plugins keep compiling and working unchanged, just without the fix). Every first-party implementation (16 classes) and their one caller (`StatisticsModelUIImpl.addResult`) are migrated to read the result from the passed-in `Statistics` instance directly instead of a shared field. With no more shared mutable state involved, concurrent runs of the same statistic across workspaces just work — no locking, no rejection dialog, no behavior change for the happy path.

## Checklist

- [x] Merged with master beforehand

## Added tests?

- [x] 👍 yes

## Added to documentation?
- [ ] 👍 README.md
- [x] 👍 [API Changes](https://github.com/gephi/gephi/blob/master/src/main/javadoc/overview.html)
- [ ] 👍 Additional documentation in [docs](https://github.com/gephi/gephi-documentation)
- [ ] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren't needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)