### PR TITLE
Fix file descriptor leak when un-embedding statistics report images

### DIFF
--- a/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsModelImpl.java
+++ b/modules/StatisticsAPI/src/main/java/org/gephi/statistics/StatisticsModelImpl.java
@@ -163,8 +163,9 @@ public class StatisticsModelImpl implements StatisticsModel {
                     String fileName = "image" + i + ".png";
                     File file = tempDir.createFile(fileName);
 
-                    FileOutputStream fos = new FileOutputStream(file);
-                    fos.write(imageBytes);
+                    try (FileOutputStream fos = new FileOutputStream(file)) {
+                        fos.write(imageBytes);
+                    }
 
                     String path = "file:" + file.getAbsolutePath();
                     builder.append(path);


### PR DESCRIPTION
## Summary
- `StatisticsModelImpl.unembedImages()` opened a `FileOutputStream` for each embedded chart image (created when loading a project with statistics reports) but never closed it, leaking a file descriptor per image.
- Wrap it in try-with-resources so it's always closed.

Fixes GEPHI-5GC

## Test plan
- [x] `mvn -pl modules/StatisticsAPI -am compile` succeeds